### PR TITLE
Fix: strip inherited env vars when spawning child agents

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -33,11 +33,17 @@ async function startOne(name: string, path: string): Promise<void> {
   // Find the kern entry point
   const kernBin = join(import.meta.dirname, "index.js");
 
+  // Clean up env vars that shouldn't be inherited by other agents
+  const env = { ...process.env };
+  delete env.KERN_AUTH_TOKEN;
+  delete env.PORT;
+
   // Fork detached process using kern run
   const child = spawn("node", ["--no-deprecation", kernBin, "run", path], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
     cwd: path,
+    env,
   });
 
   child.unref();


### PR DESCRIPTION
When `kern start` spawns a child agent process, it was inheriting the parent's `KERN_AUTH_TOKEN` and `PORT` env vars. This caused child agents to use the wrong auth token or port.

Strips `KERN_AUTH_TOKEN` and `PORT` from the env before forking, so each agent picks up its own values from its `.kern/.env` file.