### PR TITLE
Prevent duplicate SSE streams on reconnect

### DIFF
--- a/templates/web/index.html
+++ b/templates/web/index.html
@@ -978,9 +978,15 @@ const AgentClient = {
    * @returns {{ close: function }} - Call close() to disconnect
    */
   connect(baseUrl, token, { onEvent, onConnect, onDisconnect }) {
+    // Close any existing EventSource to prevent duplicates
+    if (activeEventSource) {
+      activeEventSource.close();
+      activeEventSource = null;
+    }
     // EventSource can't set headers — pass token as query param
     const url = token ? `${baseUrl}/events?token=${encodeURIComponent(token)}` : `${baseUrl}/events`;
     const es = new EventSource(url);
+    activeEventSource = es;
     let connected = false;
     es.onopen = () => { connected = true; onConnect?.(); };
     let connectionId = null;
@@ -1546,6 +1552,7 @@ let _streamRaf = 0;
 let connection = null;
 let authFailed = false;
 let intentionalClose = false;
+let activeEventSource = null;
 let currentTurnContext = null; // tracks which interface/type triggered the current turn
 let lastToolEl = null; // last tool call element — kept expanded during streaming
 let isLoadingHistory = false; // suppress auto-expand during history load
@@ -1989,6 +1996,11 @@ async function init() {
   // Close existing connection
   intentionalClose = true;
   if (connection) { connection.close(); connection = null; }
+  // Safety close for orphaned EventSource
+  if (activeEventSource) {
+    activeEventSource.close();
+    activeEventSource = null;
+  }
   intentionalClose = false;
   // Clear previous messages to avoid duplicates on reconnect
   messagesEl.innerHTML = '';


### PR DESCRIPTION
## Bug

When the SSE connection drops (network timeout, idle, OS sleep), `onerror` fires and `init()` reconnects with a new EventSource. But if the old EventSource isn't fully closed (reference lost, async race in `close()`), both the old and new streams deliver events to `handleEvent`, causing duplicate text rendering.

Easy to reproduce in the browser console:
```js
connection.close = function(){}; connection = null; init();
```
Every message now renders twice.

In practice this happens when a user is idle for a while (connection drops and reconnects), which is common with reverse proxies, mobile browsers, or laptop sleep/wake.

## Fix

Track the raw EventSource in a module-scoped `activeEventSource` variable. Before creating a new one, always close the existing one — both in `AgentClient.connect()` and as a safety net in `init()`.

Three changes, all in `templates/web/index.html`:
1. `let activeEventSource = null;` — alongside other module-scoped vars
2. In `connect()` — close existing ES before creating new one, assign new one
3. In `init()` — safety close for any orphaned ES before reconnecting

Ensures only one EventSource exists at a time regardless of how the previous one was lost.
