### PR TITLE
Add reasoning config plumbing and web UI rendering

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,10 @@ export interface KernConfig {
   maxToolResultChars: number;
   heartbeatInterval: number;
   autoRecall?: boolean;
+  reasoning?: {
+    enabled?: boolean;
+    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  };
   telegram?: {
     allowedUsers?: number[];
     showTools?: boolean;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,13 +13,14 @@ export type { SessionStats } from "./context.js";
 
 
 export interface StreamEvent {
-  type: "text-delta" | "tool-call" | "tool-result" | "finish" | "error" | "recall";
+  type: "text-delta" | "tool-call" | "tool-result" | "finish" | "error" | "recall" | "reasoning";
   text?: string;
   toolName?: string;
   toolDetail?: string;
   toolInput?: Record<string, unknown>;
   toolResult?: string;
   error?: string;
+  reasoningText?: string;
   recall?: { query: string; chunks: number; tokens: number; results: Array<{ timestamp: string; text: string; distance: number }> };
 }
 
@@ -213,6 +214,9 @@ export class Runtime {
           const output = (part as any).output;
           const resultText = typeof output === "string" ? output : JSON.stringify(output);
           onEvent({ type: "tool-result", toolName: part.toolName, toolResult: resultText });
+        } else if ((part as any).type === "reasoning-delta" || (part as any).type === "reasoning" || (part as any).type === "response.reasoning_summary_text.delta") {
+          const reasoningText = (((part as any).text || (part as any).delta || "") as string).toString();
+          if (reasoningText) onEvent({ type: "reasoning", reasoningText });
         }
       }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -130,11 +130,20 @@ export class Runtime {
       const pendingInjections = this.pendingInjections;
       let persistedCount = 0;
 
+      const providerOptions: Record<string, any> = {};
+      const reasoning = this.config.reasoning;
+      if (reasoning?.enabled !== false && reasoning?.effort && reasoning.effort !== "none") {
+        providerOptions.openai = {
+          reasoningEffort: reasoning.effort,
+        };
+      }
+
       const result = streamText({
         model,
         system: this.systemPrompt,
         messages: contextMessages,
         tools,
+        providerOptions,
         stopWhen: stepCountIs(this.config.maxSteps),
         onError: ({ error }) => {
           streamError = error;

--- a/templates/web/index.html
+++ b/templates/web/index.html
@@ -450,6 +450,21 @@
     border-radius: 8px 8px 8px 2px;
     color: #d4d4d4;
   }
+  .message.reasoning {
+    align-self: flex-start;
+    background: rgba(188, 140, 255, 0.08);
+    border: 1px solid rgba(188, 140, 255, 0.25);
+    border-radius: 8px 8px 8px 2px;
+    color: var(--text-dim);
+    font-size: 12px;
+  }
+  .message.reasoning .label {
+    display: block;
+    font-size: 11px;
+    color: var(--magenta);
+    margin-bottom: 4px;
+    font-weight: 600;
+  }
   .timestamp {
     font-size: 10px;
     color: var(--text-muted);
@@ -1668,6 +1683,8 @@ function setupSwitcher() {
 let busy = false;
 let streamingText = '';
 let streamingEl = null;
+let reasoningText = '';
+let reasoningEl = null;
 let _streamRaf = 0;
 let connection = null;
 let authFailed = false;
@@ -1966,6 +1983,14 @@ function addMessage(type, content, meta, toolInput, timestamp, iface) {
     el.textContent = content;
   } else if (type === 'system') {
     el.textContent = content;
+  } else if (type === 'reasoning') {
+    const label = document.createElement('span');
+    label.className = 'label';
+    label.textContent = 'thinking';
+    el.appendChild(label);
+    const text = document.createElement('div');
+    text.innerHTML = renderMarkdown(content);
+    el.appendChild(text);
   } else {
     const isMuted = type === 'assistant' && (content.trim() === 'NO_REPLY' || content.trim() === '(no text response)');
     if (isMuted) el.classList.add('muted');
@@ -1994,8 +2019,14 @@ function flushStreaming() {
     if (isMuted) streamingEl.classList.add('muted');
     streamingEl.innerHTML = renderMarkdown(streamingText);
   }
+  if (reasoningEl && reasoningText) {
+    const textEl = reasoningEl.querySelector('div');
+    if (textEl) textEl.innerHTML = renderMarkdown(reasoningText);
+  }
   streamingText = '';
   streamingEl = null;
+  reasoningText = '';
+  reasoningEl = null;
   if (_streamRaf) { cancelAnimationFrame(_streamRaf); _streamRaf = 0; }
 }
 
@@ -2088,6 +2119,19 @@ function handleEvent(event) {
       scrollToBottom();
       // Agent is thinking about what to do next — show dots
       showThinking();
+      break;
+    }
+
+    case 'reasoning': {
+      hideThinking();
+      if (!reasoningEl) {
+        reasoningEl = addMessage('reasoning', '');
+      }
+      reasoningText += event.reasoningText || '';
+      const textEl = reasoningEl.querySelector('div');
+      if (textEl) textEl.innerHTML = renderMarkdown(reasoningText);
+      scrollToBottom();
+      setBusy(true);
       break;
     }
 


### PR DESCRIPTION
## Summary
- add reasoning config plumbing to model setup
- render reasoning summaries in the web UI

## Notes
- branch exists already and was pushed earlier
- this is separate from semantic segmentation / history injection work