### PR TITLE
Add X-Accel-Buffering header for SSE through reverse proxies

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -165,6 +165,7 @@ export class AgentServer {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
         "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
       });
       // Assign a connection ID and send it as the first event
       const connectionId = crypto.randomUUID().slice(0, 8);


### PR DESCRIPTION
Adds `X-Accel-Buffering: no` header to the SSE `/events` endpoint.

Nginx and similar reverse proxies buffer responses by default, which breaks SSE streaming. This header tells the proxy to pass events through immediately.

One-line change. No behavioral impact for direct connections.