### PR TITLE
Write messages to DB on append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Features
+- **Session DB writes** ([#31](https://github.com/oguzbilgic/kern-ai/pull/31)) — messages written to SQLite synchronously on append. Recall indexing skips messages already in DB. First step toward DB as source of truth for sessions.
+
 ## v0.17.0
 
 ### Features
@@ -27,6 +30,7 @@
   - Segment overlay shows `All` / `Context` filters, clearer modal styling, and confirmation prompts for `Clean` / `Rebuild`
 - **Cross-platform shell** ([#25](https://github.com/oguzbilgic/kern-ai/pull/25)) — `bash` tool on Unix, `pwsh` tool on Windows. One shell tool per platform, selected automatically. No config needed.
   - `grep` works on Unix only; on Windows suggests `Select-String` via pwsh
+- **Session DB writes** ([#31](https://github.com/oguzbilgic/kern-ai/pull/31)) — messages written to SQLite synchronously on append. Recall indexing skips messages already in DB. First step toward DB as source of truth for sessions.
 
 ### Changes
 - **Logging** ([#24](https://github.com/oguzbilgic/kern-ai/pull/24)) — structured, leveled, colored log output. All levels written to file, filtering only at read time.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,47 @@
+# Sessions
+
+Each agent has one continuous session — a single conversation history shared across all interfaces.
+
+## Storage
+
+Messages are stored in two places:
+
+- **SQLite database** (`.kern/recall.db`, `messages` table) — written synchronously on every message. ACID transactions, crash-safe, no corruption risk from partial writes.
+- **JSONL file** (`.kern/sessions/<id>.jsonl`) — also written on every message. Human-readable, one JSON object per line. First line is session metadata, rest are messages.
+
+Both are always written. The database is the durable copy. JSONL is the current read path (loaded on startup) and serves as a portable backup.
+
+## Session lifecycle
+
+- On first start, a new session is created with a random UUID.
+- On subsequent starts, the most recent session is loaded from JSONL.
+- Messages accumulate indefinitely — there's no session rotation or expiry.
+- The full history is always preserved even when the [context window](context.md) trims old messages.
+
+## Crash recovery
+
+If the process dies mid-turn:
+- Messages already appended to the DB and JSONL are safe.
+- An incomplete assistant turn (tool call without result) is detected on load and a synthetic "[interrupted]" message is appended so the model doesn't re-execute lost tool calls.
+
+If JSONL is corrupted, the session can be rebuilt from the database. Recovery scripts are available for this.
+
+## What's stored per message
+
+| Field | Description |
+|-------|-------------|
+| `session_id` | UUID of the session |
+| `msg_index` | Sequential position (0-based) |
+| `role` | `user`, `assistant`, or `tool` |
+| `content` | Message text or JSON array (tool calls/results) |
+| `timestamp` | ISO 8601, extracted from message metadata when present |
+
+## Local files
+
+| Path | Description | In git |
+|------|-------------|:------:|
+| `.kern/sessions/*.jsonl` | Session JSONL files | ✗ |
+| `.kern/recall.db` | Memory database (messages + indexes) | ✗ |
+| `.kern/usage.json` | Cumulative API token usage | ✗ |
+| `.kern/logs/kern.log` | Daemon logs | ✗ |
+| `.kern/pairing.json` | User pairing state | ✗ |

--- a/src/recall.ts
+++ b/src/recall.ts
@@ -81,25 +81,29 @@ export class RecallIndex {
     const sessionCreated = new Date(meta.createdAt).getTime();
     const sessionUpdated = new Date(meta.updatedAt).getTime();
 
-    // Store raw messages in sqlite
-    const insertMsg = this.db.prepare(
-      "INSERT OR IGNORE INTO messages (session_id, msg_index, role, content, timestamp) VALUES (?, ?, ?, ?, ?)"
-    );
-    const msgTx = this.db.transaction(() => {
-      for (let i = 0; i < newMessages.length; i++) {
-        const msg = newMessages[i];
-        const msgIndex = lastIndexed + i;
-        const msgContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+    // Messages are now written to DB by SessionManager.append().
+    // Backfill any that might be missing (e.g. from older sessions before this change).
+    const existingCount = (this.db.prepare(
+      "SELECT COUNT(*) as count FROM messages WHERE session_id = ? AND msg_index >= ? AND msg_index < ?"
+    ).get(sessionId, lastIndexed, totalMessages) as { count: number }).count;
 
-        // Extract timestamp from message metadata
-        let timestamp: string | null = null;
-        const timeMatch = msgContent.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+Z)/);
-        if (timeMatch) timestamp = timeMatch[1];
-
-        insertMsg.run(sessionId, msgIndex, msg.role, msgContent, timestamp);
-      }
-    });
-    msgTx();
+    if (existingCount < newMessages.length) {
+      const insertMsg = this.db.prepare(
+        "INSERT OR IGNORE INTO messages (session_id, msg_index, role, content, timestamp) VALUES (?, ?, ?, ?, ?)"
+      );
+      const msgTx = this.db.transaction(() => {
+        for (let i = 0; i < newMessages.length; i++) {
+          const msg = newMessages[i];
+          const msgIndex = lastIndexed + i;
+          const msgContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+          let timestamp: string | null = null;
+          const timeMatch = msgContent.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+Z)/);
+          if (timeMatch) timestamp = timeMatch[1];
+          insertMsg.run(sessionId, msgIndex, msg.role, msgContent, timestamp);
+        }
+      });
+      msgTx();
+    }
 
     // Chunk new messages into turns
     // We need context: if lastIndexed lands mid-turn (after a user msg, before next user msg),

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -65,7 +65,7 @@ export class Runtime {
   async init(): Promise<void> {
     this.config = await loadConfig(this.agentDir);
     this.systemPrompt = await loadSystemPrompt(this.agentDir, this.config, this.memoryDB);
-    this.session = new SessionManager(this.agentDir);
+    this.session = new SessionManager(this.agentDir, this.memoryDB ?? undefined);
     await this.session.init();
     await this.session.load();
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,6 +2,8 @@ import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 import type { ModelMessage } from "ai";
+import type { MemoryDB } from "./memory.js";
+import { log } from "./log.js";
 
 export interface Session {
   id: string;
@@ -13,9 +15,11 @@ export interface Session {
 export class SessionManager {
   private dir: string;
   private session: Session | null = null;
+  private db: MemoryDB["db"] | null = null;
 
-  constructor(agentDir: string) {
+  constructor(agentDir: string, memoryDB?: MemoryDB) {
     this.dir = join(agentDir, ".kern", "sessions");
+    this.db = memoryDB?.db ?? null;
   }
 
   async init(): Promise<void> {
@@ -86,8 +90,35 @@ export class SessionManager {
 
   async append(messages: ModelMessage[]): Promise<void> {
     if (!this.session) throw new Error("No active session");
+    const startIndex = this.session.messages.length;
     this.session.messages.push(...messages);
     this.session.updatedAt = new Date().toISOString();
+
+    // Write to DB first (atomic, crash-safe)
+    if (this.db) {
+      try {
+        const insert = this.db.prepare(
+          "INSERT OR IGNORE INTO messages (session_id, msg_index, role, content, timestamp) VALUES (?, ?, ?, ?, ?)"
+        );
+        const tx = this.db.transaction(() => {
+          for (let i = 0; i < messages.length; i++) {
+            const msg = messages[i];
+            const msgIndex = startIndex + i;
+            const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+            // Extract timestamp from message metadata
+            let timestamp: string | null = null;
+            const timeMatch = content.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+Z)/);
+            if (timeMatch) timestamp = timeMatch[1];
+            insert.run(this.session!.id, msgIndex, msg.role, content, timestamp);
+          }
+        });
+        tx();
+      } catch (err: any) {
+        log.error("session", `DB write failed: ${err.message}`);
+      }
+    }
+
+    // Write JSONL (still primary for reads)
     await this.save();
   }
 


### PR DESCRIPTION
Session messages are now written to the SQLite DB synchronously on append, not just during async recall indexing.

- `SessionManager.append()` writes messages to DB immediately after JSONL write
- Recall indexing skips messages already present in DB
- DB becomes a reliable secondary store for session data (crash recovery, recall search)
- JSONL remains primary read path for now

This is the first step toward making the DB the source of truth for sessions, eventually replacing full JSONL rewrites.