### PR TITLE
Rendered HTML blocks in chat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - **Hide tool calls in Telegram** ([#76](https://github.com/oguzbilgic/kern-ai/issues/76)) — new `telegramTools` config (default `false`) controls whether tool call progress lines (`⚙ bash`, etc.) appear in Telegram messages
 - **Infinite scroll** ([#53](https://github.com/oguzbilgic/kern-ai/issues/53)) — scroll up in chat to load older messages; uses existing paginated `/history` API with scroll-position preservation
+- **Rendered HTML blocks** ([#103](https://github.com/oguzbilgic/kern-ai/issues/103)) — agents can output rich visual content using ` ```render ` fenced blocks; web UI renders as sandboxed iframes with auto-height and fullscreen toggle
 
 ### Improvements
 - **Markdown rendering** ([#95](https://github.com/oguzbilgic/kern-ai/issues/95)) — replaced hand-rolled regex parser with `marked`; fixes loose lists, nested bullets, multi-paragraph list items, adds GFM strikethrough and task lists

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -81,6 +81,20 @@ Images are automatically described by a vision model on arrival. You see the des
 
 Treat `.kern/media/` as an inbox. If a file matters long-term, copy it into your repo with a meaningful name and note it in your knowledge files.
 
+### Rendered HTML blocks
+You can output rich visual content (tables, charts, status cards, interactive widgets) in the web UI by using a `render` fenced code block:
+
+~~~
+```render
+<div style="padding: 16px; font-family: sans-serif;">
+  <h3>Status</h3>
+  <p style="color: green;">All systems operational</p>
+</div>
+```
+~~~
+
+The web UI renders this as a sandboxed iframe instead of a code block. The content runs in isolation — no access to the page, tokens, or agent APIs. Include all styles inline. You can use CDN scripts (Chart.js, D3, etc.) for charts and visualizations. Use this when visual presentation adds value over plain text — data tables, dashboards, formatted reports.
+
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -132,7 +132,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
-.render-block-fullscreen {
+.render-block-fullscreen, .render-block-toggle {
   background: none;
   border: none;
   color: var(--text-muted);
@@ -141,9 +141,12 @@ body {
   padding: 2px 4px;
   border-radius: 4px;
 }
-.render-block-fullscreen:hover {
+.render-block-fullscreen:hover, .render-block-toggle:hover {
   color: var(--text);
   background: rgba(255,255,255,0.06);
+}
+.render-block-toggle.active {
+  color: var(--text);
 }
 .render-block.fullscreen {
   position: fixed;

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -110,4 +110,57 @@ body {
   50% { background-color: color-mix(in srgb, var(--accent) 50%, var(--bg-sidebar)); }
 }
 
+/* Render blocks — agent-created HTML content */
+.render-block {
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  margin: 4px 0;
+}
+.render-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 10px;
+  background: var(--bg-sidebar);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+}
+.render-block-label {
+  color: var(--text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.render-block-fullscreen {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+.render-block-fullscreen:hover {
+  color: var(--text);
+  background: rgba(255,255,255,0.06);
+}
+.render-block.fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  border-radius: 0;
+  border: none;
+  display: flex;
+  flex-direction: column;
+}
+.render-block.fullscreen .render-block-header {
+  border-radius: 0;
+}
+.render-block.fullscreen iframe {
+  flex: 1;
+  height: 100% !important;
+  border-radius: 0 !important;
+}
+
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -26,11 +26,13 @@ const renderBlockScript = `
       document.addEventListener('keydown', handler);
     }
   };
-  // Auto-resize iframes based on content height
+  // Auto-resize iframes based on content height (debounced, skip no-ops)
   window.addEventListener('message', function(e) {
     if (e.data && e.data.type === 'render-block-resize' && e.data.id) {
       var iframe = document.getElementById(e.data.id);
-      if (iframe) iframe.style.height = Math.min(e.data.height + 2, 800) + 'px';
+      if (!iframe) return;
+      var newHeight = Math.min(e.data.height + 2, 800) + 'px';
+      if (iframe.style.height !== newHeight) iframe.style.height = newHeight;
     }
   });
 `;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,10 +6,42 @@ export const metadata: Metadata = {
   description: "Agent runtime",
 };
 
+// Global script for render block iframe features
+const renderBlockScript = `
+  // Fullscreen toggle for render blocks
+  window.toggleRenderFullscreen = function(btn) {
+    var block = btn.closest('.render-block');
+    if (!block) return;
+    block.classList.toggle('fullscreen');
+    btn.textContent = block.classList.contains('fullscreen') ? '✕' : '⛶';
+    // ESC to exit fullscreen
+    if (block.classList.contains('fullscreen')) {
+      var handler = function(e) {
+        if (e.key === 'Escape') {
+          block.classList.remove('fullscreen');
+          btn.textContent = '⛶';
+          document.removeEventListener('keydown', handler);
+        }
+      };
+      document.addEventListener('keydown', handler);
+    }
+  };
+  // Auto-resize iframes based on content height
+  window.addEventListener('message', function(e) {
+    if (e.data && e.data.type === 'render-block-resize' && e.data.id) {
+      var iframe = document.getElementById(e.data.id);
+      if (iframe) iframe.style.height = Math.min(e.data.height + 2, 800) + 'px';
+    }
+  });
+`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="h-dvh overflow-hidden flex">{children}</body>
+      <body className="h-dvh overflow-hidden flex">
+        {children}
+        <script dangerouslySetInnerHTML={{ __html: renderBlockScript }} />
+      </body>
     </html>
   );
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -26,6 +26,18 @@ const renderBlockScript = `
       document.addEventListener('keydown', handler);
     }
   };
+  // Toggle between rendered iframe and raw source code
+  window.toggleRenderSource = function(btn) {
+    var block = btn.closest('.render-block');
+    if (!block) return;
+    var iframe = block.querySelector('iframe');
+    var source = block.querySelector('.render-block-source');
+    if (!iframe || !source) return;
+    var showingSource = source.style.display !== 'none';
+    iframe.style.display = showingSource ? '' : 'none';
+    source.style.display = showingSource ? 'none' : 'block';
+    btn.classList.toggle('active', !showingSource);
+  };
   // Auto-resize iframes based on content height (debounced, skip no-ops)
   window.addEventListener('message', function(e) {
     if (e.data && e.data.type === 'render-block-resize' && e.data.id) {

--- a/web/components/MessageContent.tsx
+++ b/web/components/MessageContent.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo, useMemo } from "react";
 import type { ChatMessage, MediaItem } from "../lib/types";
 import type { MessageProps } from "../lib/messages";
 import { renderMarkdown } from "../lib/markdown";
@@ -29,15 +30,25 @@ export function MediaAttachments({ media, agentName, token, serverUrl }: { media
 }
 
 // Renders the text body of a message — markdown for assistant, plain for others
-export function MessageBody({ msg }: { msg: ChatMessage }) {
+// Memoized: only re-renders when msg.text or msg.isStreaming changes
+export const MessageBody = memo(function MessageBody({ msg }: { msg: ChatMessage }) {
+  const html = useMemo(() => {
+    if (msg.role !== "assistant") return "";
+    if (msg.streaming) {
+      // During streaming, render markdown but skip render blocks (show placeholder)
+      return renderMarkdown(msg.text, { skipRenderBlocks: true });
+    }
+    return renderMarkdown(msg.text);
+  }, [msg.text, msg.role, msg.streaming]);
+
   if (msg.role === "assistant") {
     return (
       <div className="markdown-body"
-        dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.text) }} />
+        dangerouslySetInnerHTML={{ __html: html }} />
     );
   }
   return <span className="whitespace-pre-wrap">{msg.text}</span>;
-}
+});
 
 // Renders special message types: heartbeat, error, command, NO_REPLY, emoji
 // Returns null if message is a normal text message

--- a/web/hooks/useChat.ts
+++ b/web/hooks/useChat.ts
@@ -22,14 +22,16 @@ export function useChat({ messages, streamParts, thinking, showTools, peekLastTo
   const [showScrollBtn, setShowScrollBtn] = useState(false);
 
   // Track user scroll + infinite scroll up
+  const ignoreScrollUntil = useRef(0);
+
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    let programmaticScroll = false;
 
     function onScroll() {
-      if (programmaticScroll) return;
-      const atBottom = el!.scrollHeight - el!.scrollTop - el!.clientHeight < 40;
+      // Ignore scroll events triggered by programmatic scrollIntoView
+      if (Date.now() < ignoreScrollUntil.current) return;
+      const atBottom = el!.scrollHeight - el!.scrollTop - el!.clientHeight < 100;
       userScrolledUp.current = !atBottom;
       setShowScrollBtn(!atBottom);
 
@@ -37,7 +39,6 @@ export function useChat({ messages, streamParts, thinking, showTools, peekLastTo
       if (el!.scrollTop < 200 && hasMore && !loadingMore && loadMore) {
         const prevHeight = el!.scrollHeight;
         loadMore().then(() => {
-          // Preserve scroll position after prepending
           requestAnimationFrame(() => {
             const newHeight = el!.scrollHeight;
             el!.scrollTop += newHeight - prevHeight;
@@ -45,30 +46,25 @@ export function useChat({ messages, streamParts, thinking, showTools, peekLastTo
         });
       }
     }
-    el.addEventListener("scroll", onScroll);
-    (el as any)._setProgrammatic = (v: boolean) => { programmaticScroll = v; };
+    el.addEventListener("scroll", onScroll, { passive: true });
     return () => el.removeEventListener("scroll", onScroll);
   }, [hasMore, loadingMore, loadMore]);
 
   // Auto-scroll on new content
   useEffect(() => {
     if (userScrolledUp.current) return;
-    const el = containerRef.current;
-    if (!el) return;
-    const setter = (el as any)._setProgrammatic;
-    setter?.(true);
+    // Suppress scroll events for 150ms to prevent programmatic scroll from toggling userScrolledUp
+    ignoreScrollUntil.current = Date.now() + 150;
     requestAnimationFrame(() => {
       bottomRef.current?.scrollIntoView({ behavior: "instant" });
-      requestAnimationFrame(() => {
-        setter?.(false);
-        setShowScrollBtn(false);
-      });
+      setShowScrollBtn(false);
     });
   }, [messages, streamParts, thinking]);
 
   const scrollToBottom = () => {
     userScrolledUp.current = false;
     setShowScrollBtn(false);
+    ignoreScrollUntil.current = Date.now() + 300;
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   };
 

--- a/web/lib/events.ts
+++ b/web/lib/events.ts
@@ -32,13 +32,14 @@ export function processStreamEvent(
 
     case "text-delta": {
       const last = result.parts[result.parts.length - 1];
-      if (last?.role === "assistant") {
+      if (last?.role === "assistant" && last.streaming) {
         last.text += ev.text;
       } else {
         result.parts.push({
           id: `stream-text-${Date.now()}-${Math.random()}`,
           role: "assistant",
           text: ev.text,
+          streaming: true,
         });
       }
       break;
@@ -80,9 +81,9 @@ export function processStreamEvent(
       break;
 
     case "finish": {
-      result.append = result.parts.filter(
-        (p) => p.role === "tool" || (p.role === "assistant" && p.text.trim())
-      );
+      result.append = result.parts
+        .filter((p) => p.role === "tool" || (p.role === "assistant" && p.text.trim()))
+        .map((p) => ({ ...p, streaming: false }));
       result.parts = [];
       result.flush = true;
       break;

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -110,8 +110,11 @@ const marked = new Marked(
 export function renderMarkdown(text: string, opts?: { skipRenderBlocks?: boolean }): string {
   if (!text) return "";
   if (opts?.skipRenderBlocks) {
-    // Replace ```render blocks with a loading placeholder before parsing
+    // Replace complete ```render...``` blocks with placeholder
     text = text.replace(/```render\n[\s\S]*?```/g,
+      '```\n⏳ Render block loading…\n```');
+    // Also catch unclosed render blocks still streaming (no closing ```)
+    text = text.replace(/```render\n[\s\S]*$/,
       '```\n⏳ Render block loading…\n```');
   }
   return marked.parse(text) as string;

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -40,10 +40,15 @@ hljs.registerLanguage("go", go);
 hljs.registerLanguage("sql", sql);
 hljs.registerLanguage("shell", shell);
 
+// Unique ID counter for render block iframes
+let renderBlockId = 0;
+
 const marked = new Marked(
   markedHighlight({
     langPrefix: "hljs language-",
     highlight(code: string, lang: string) {
+      // Skip highlighting for render blocks — handled by code renderer
+      if (lang === "render") return code;
       if (lang && hljs.getLanguage(lang)) {
         try { return hljs.highlight(code, { language: lang }).value; } catch { /* fall through */ }
       }
@@ -55,6 +60,37 @@ const marked = new Marked(
     gfm: true,
     breaks: true,
     renderer: {
+      code({ text, lang }) {
+        if (lang === "render") {
+          const id = `render-block-${++renderBlockId}`;
+          // Parse optional height hint from <!-- height: N --> comment
+          const heightMatch = text.match(/<!--\s*height:\s*(\d+)\s*-->/);
+          const height = heightMatch ? `${heightMatch[1]}px` : "300px";
+          // Escape HTML for srcdoc attribute
+          const escaped = text
+            .replace(/&/g, "&amp;")
+            .replace(/"/g, "&quot;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+          // Auto-height script: content measures itself, posts height to parent
+          const autoHeightScript = `&lt;script&gt;new ResizeObserver(()=&gt;parent.postMessage({type:&quot;render-block-resize&quot;,id:&quot;${id}&quot;,height:document.body.scrollHeight},&quot;*&quot;)).observe(document.body)&lt;/script&gt;`;
+          return `<div class="render-block" data-id="${id}">
+            <div class="render-block-header">
+              <span class="render-block-label">rendered</span>
+              <button class="render-block-fullscreen" onclick="toggleRenderFullscreen(this)" title="Fullscreen">⛶</button>
+            </div>
+            <iframe
+              id="${id}"
+              sandbox="allow-scripts"
+              srcdoc="${escaped}${autoHeightScript}"
+              style="width:100%;height:${height};border:none;border-radius:0 0 6px 6px;background:#1a1a1a;"
+            ></iframe>
+          </div>`;
+        }
+        // Default code block rendering (highlight.js already applied by markedHighlight)
+        const langClass = lang ? ` class="hljs language-${lang}"` : "";
+        return `<pre><code${langClass}>${text}</code></pre>`;
+      },
       link({ href, text }) {
         // Block javascript: URLs
         if (/^javascript:/i.test(href)) return text;

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -107,7 +107,12 @@ const marked = new Marked(
   }
 );
 
-export function renderMarkdown(text: string): string {
+export function renderMarkdown(text: string, opts?: { skipRenderBlocks?: boolean }): string {
   if (!text) return "";
+  if (opts?.skipRenderBlocks) {
+    // Replace ```render blocks with a loading placeholder before parsing
+    text = text.replace(/```render\n[\s\S]*?```/g,
+      '```\n⏳ Render block loading…\n```');
+  }
   return marked.parse(text) as string;
 }

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -72,11 +72,17 @@ const marked = new Marked(
             .replace(/"/g, "&quot;")
             .replace(/</g, "&lt;")
             .replace(/>/g, "&gt;");
+          // Code-escaped version for raw view
+          const codeEscaped = text
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
           // Auto-height script: content measures itself, posts height to parent
           const autoHeightScript = `&lt;script&gt;new ResizeObserver(()=&gt;parent.postMessage({type:&quot;render-block-resize&quot;,id:&quot;${id}&quot;,height:document.body.scrollHeight},&quot;*&quot;)).observe(document.body)&lt;/script&gt;`;
           return `<div class="render-block" data-id="${id}">
             <div class="render-block-header">
               <span class="render-block-label">rendered</span>
+              <button class="render-block-toggle" onclick="toggleRenderSource(this)" title="Toggle source">{ }</button>
               <button class="render-block-fullscreen" onclick="toggleRenderFullscreen(this)" title="Fullscreen">⛶</button>
             </div>
             <iframe
@@ -85,6 +91,7 @@ const marked = new Marked(
               srcdoc="${escaped}${autoHeightScript}"
               style="width:100%;height:${height};border:none;border-radius:0 0 6px 6px;background:#1a1a1a;"
             ></iframe>
+            <pre class="render-block-source" style="display:none;margin:0;padding:12px;background:#161616;border-radius:0 0 6px 6px;overflow-x:auto;font-size:13px;"><code class="hljs language-html">${codeEscaped}</code></pre>
           </div>`;
         }
         // Default code block rendering (highlight.js already applied by markedHighlight)


### PR DESCRIPTION
Closes #103

Agents can output rich visual content using ```render``` fenced code blocks. The web UI renders them as sandboxed iframes instead of syntax-highlighted code.

## How it works

Agent writes:
```
```render
<div style="padding: 16px">
  <h3>Container Status</h3>
  <table>...</table>
</div>
```
```

Web UI detects the `render` language tag and outputs a sandboxed iframe with `srcdoc`.

## Features
- **Sandboxed**: `sandbox="allow-scripts"` — JS runs but no access to parent page, tokens, localStorage
- **Auto-height**: iframe content uses ResizeObserver + postMessage to resize to fit content (max 800px)
- **Height hint**: agent can specify `<!-- height: 400 -->` comment for explicit sizing
- **Fullscreen**: expand button opens content fullscreen, ESC to exit
- **KERN.md**: documents the capability so agents know how to use it

## Changes
- `web/lib/markdown.ts` — custom `code` renderer for `render` blocks → iframe with srcdoc
- `web/app/globals.css` — render block styling (header, fullscreen mode)
- `web/app/layout.tsx` — global JS for fullscreen toggle and iframe auto-resize listener
- `templates/KERN.md` — teaches agents about render blocks
- `CHANGELOG.md` — feature entry

137 additions, purely client-side. No backend changes.