### PR TITLE
Render tool: dashboards, inline HTML, and side panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
   - New `render` tool lets agents produce charts, tables, and status cards as sandboxed HTML — displayed inline in chat or in a resizable side panel
   - Agents write `dashboards/<name>/` folders with HTML + JSON data, served with live data injection via `window.__KERN_DATA__`
   - Dashboards auto-discovered across all running agents and listed in the sidebar with ownership labels
-  - Side panel resizes from 280–800px with drag handle; persists active dashboard across page reloads
-  - Header dropdown and sidebar entries for quick dashboard switching
+  - Resizable side panel with dashboard switching from header and sidebar
 - **Hide tool calls in Telegram** ([#76](https://github.com/oguzbilgic/kern-ai/issues/76)) — new `telegramTools` config (default `false`) hides tool call progress from Telegram messages
 - **Infinite scroll** ([#53](https://github.com/oguzbilgic/kern-ai/issues/53)) — scroll up in chat to load older messages with scroll-position preservation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 ## next
 
 ### Features
-- **Render tool** ([#103](https://github.com/oguzbilgic/kern-ai/issues/103), [#105](https://github.com/oguzbilgic/kern-ai/pull/105)) — agents can create rich visual content (charts, tables, status cards) rendered as sandboxed HTML in chat or a persistent side panel
-- **Dashboards** ([#101](https://github.com/oguzbilgic/kern-ai/issues/101), [#105](https://github.com/oguzbilgic/kern-ai/pull/105)) — agents write `dashboards/<name>/` folders with HTML + data; auto-discovered in sidebar across all running agents, open in resizable side panel with live data injection
+- **Dashboards and rendered HTML** ([#101](https://github.com/oguzbilgic/kern-ai/issues/101), [#103](https://github.com/oguzbilgic/kern-ai/issues/103), [#105](https://github.com/oguzbilgic/kern-ai/pull/105)) — agents can create rich visual content and persistent dashboards
+  - New `render` tool lets agents produce charts, tables, and status cards as sandboxed HTML — displayed inline in chat or in a resizable side panel
+  - Agents write `dashboards/<name>/` folders with HTML + JSON data, served with live data injection via `window.__KERN_DATA__`
+  - Dashboards auto-discovered across all running agents and listed in the sidebar with ownership labels
+  - Side panel resizes from 280–800px with drag handle; persists active dashboard across page reloads
+  - Header dropdown and sidebar entries for quick dashboard switching
 - **Hide tool calls in Telegram** ([#76](https://github.com/oguzbilgic/kern-ai/issues/76)) — new `telegramTools` config (default `false`) hides tool call progress from Telegram messages
 - **Infinite scroll** ([#53](https://github.com/oguzbilgic/kern-ai/issues/53)) — scroll up in chat to load older messages with scroll-position preservation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,17 @@
 ## next
 
 ### Features
-- **Hide tool calls in Telegram** ([#76](https://github.com/oguzbilgic/kern-ai/issues/76)) — new `telegramTools` config (default `false`) controls whether tool call progress lines (`⚙ bash`, etc.) appear in Telegram messages
-- **Infinite scroll** ([#53](https://github.com/oguzbilgic/kern-ai/issues/53)) — scroll up in chat to load older messages; uses existing paginated `/history` API with scroll-position preservation
+- **Render tool** ([#103](https://github.com/oguzbilgic/kern-ai/issues/103), [#105](https://github.com/oguzbilgic/kern-ai/pull/105)) — agents can create rich visual content (charts, tables, status cards) rendered as sandboxed HTML in chat or a persistent side panel
+- **Dashboards** ([#101](https://github.com/oguzbilgic/kern-ai/issues/101), [#105](https://github.com/oguzbilgic/kern-ai/pull/105)) — agents write `dashboards/<name>/` folders with HTML + data; auto-discovered in sidebar across all running agents, open in resizable side panel with live data injection
+- **Hide tool calls in Telegram** ([#76](https://github.com/oguzbilgic/kern-ai/issues/76)) — new `telegramTools` config (default `false`) hides tool call progress from Telegram messages
+- **Infinite scroll** ([#53](https://github.com/oguzbilgic/kern-ai/issues/53)) — scroll up in chat to load older messages with scroll-position preservation
 
 ### Improvements
-- **Markdown rendering** ([#95](https://github.com/oguzbilgic/kern-ai/issues/95)) — replaced hand-rolled regex parser with `marked`; fixes loose lists, nested bullets, multi-paragraph list items, adds GFM strikethrough and task lists
+- **Markdown rendering** ([#95](https://github.com/oguzbilgic/kern-ai/issues/95)) — replaced hand-rolled regex parser with `marked`; fixes loose lists, nested bullets, multi-paragraph list items
 
 ### Fixes
 - **Mid-turn steering** ([#94](https://github.com/oguzbilgic/kern-ai/pull/94)) — operator messages sent during an agent's turn now persist across all steps instead of being lost after one step
-- **web/out packaging** ([#97](https://github.com/oguzbilgic/kern-ai/issues/97)) — `web/out/` build artifacts no longer tracked in git; npm package still includes them via `web/.npmignore`
+- **web/out packaging** ([#97](https://github.com/oguzbilgic/kern-ai/issues/97)) — build artifacts no longer tracked in git; npm package still includes them
 
 ## v0.23.2
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,8 +37,8 @@ export interface KernConfig {
 const shell = process.platform === "win32" ? "pwsh" : "bash";
 
 const TOOL_SCOPES: Record<ToolScope, string[]> = {
-  full: [shell, "read", "write", "edit", "glob", "grep", "webfetch", "websearch", "kern", "message", "recall", "pdf", "image"],
-  write: ["read", "write", "edit", "glob", "grep", "webfetch", "websearch", "kern", "message", "recall", "pdf", "image"],
+  full: [shell, "read", "write", "edit", "glob", "grep", "webfetch", "websearch", "kern", "message", "recall", "pdf", "image", "render"],
+  write: ["read", "write", "edit", "glob", "grep", "webfetch", "websearch", "kern", "message", "recall", "pdf", "image", "render"],
   read: ["read", "glob", "grep", "webfetch", "websearch", "kern", "recall", "pdf", "image"],
 };
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -18,7 +18,7 @@ export type { SessionStats } from "./context.js";
 
 
 export interface StreamEvent {
-  type: "text-delta" | "tool-call" | "tool-result" | "finish" | "error" | "recall" | "thinking";
+  type: "text-delta" | "tool-call" | "tool-result" | "finish" | "error" | "recall" | "thinking" | "render";
   text?: string;
   toolName?: string;
   toolDetail?: string;
@@ -26,6 +26,7 @@ export interface StreamEvent {
   toolResult?: string;
   error?: string;
   recall?: { query: string; chunks: number; tokens: number; results: Array<{ timestamp: string; text: string; distance: number }> };
+  render?: { html: string; dashboard?: string | null; target: string; title: string };
 }
 
 export type StreamHandler = (event: StreamEvent) => void;
@@ -307,6 +308,26 @@ export class Runtime {
           const output = (part as any).output;
           const resultText = typeof output === "string" ? output : JSON.stringify(output);
           onEvent({ type: "tool-result", toolName: part.toolName, toolResult: resultText });
+
+          // Detect render tool output and emit render event for UI
+          if (part.toolName === "render" && typeof resultText === "string") {
+            try {
+              const parsed = JSON.parse(resultText);
+              if (parsed.__kern_render) {
+                onEvent({
+                  type: "render",
+                  render: {
+                    html: parsed.html,
+                    dashboard: parsed.dashboard,
+                    target: parsed.target || "inline",
+                    title: parsed.title || "Render",
+                  },
+                });
+              }
+            } catch {
+              // Not JSON or not a render result — ignore
+            }
+          }
         }
       }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { join } from "path";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import type { StreamEvent } from "./runtime.js";
 import type { Attachment } from "./interfaces/types.js";
 import { log } from "./log.js";
@@ -606,7 +606,6 @@ export class AgentServer {
       const dashDir = join(this.agentDir, "dashboards");
       let dashboards: string[] = [];
       if (existsSync(dashDir)) {
-        const { readdirSync } = require("fs");
         dashboards = readdirSync(dashDir, { withFileTypes: true })
           .filter((d: any) => d.isDirectory() && existsSync(join(dashDir, d.name, "index.html")))
           .map((d: any) => d.name);

--- a/src/server.ts
+++ b/src/server.ts
@@ -591,9 +591,20 @@ export class AgentServer {
       }
 
       if (existsSync(filePath)) {
-        const data = readFileSync(filePath);
+        let content: string | Buffer = readFileSync(filePath);
+        // Inject data.json into index.html if available
+        if ((subPath === "/" || subPath === "/index.html") && contentType.startsWith("text/html")) {
+          const dataPath = join(dashDir, "data.json");
+          if (existsSync(dataPath)) {
+            const jsonData = readFileSync(dataPath, "utf-8");
+            const dataScript = `<script>window.__KERN_DATA__ = ${jsonData};</script>`;
+            let html = content.toString("utf-8");
+            html = html.includes("</head>") ? html.replace("</head>", `${dataScript}</head>`) : dataScript + html;
+            content = html;
+          }
+        }
         res.writeHead(200, { "Content-Type": contentType });
-        res.end(data);
+        res.end(content);
       } else {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "file not found" }));

--- a/src/server.ts
+++ b/src/server.ts
@@ -551,6 +551,71 @@ export class AgentServer {
       return;
     }
 
+    // Serve dashboard files: GET /d/<name>/ or /d/<name>/data.json
+    const dashMatch = url.match(/^\/d\/([a-zA-Z0-9_-]+)(\/.*)?$/);
+    if (dashMatch && req.method === "GET") {
+      const dashName = dashMatch[1];
+      const subPath = dashMatch[2] || "/";
+      const dashDir = join(this.agentDir, "dashboards", dashName);
+
+      if (!existsSync(dashDir)) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: `dashboard '${dashName}' not found` }));
+        return;
+      }
+
+      let filePath: string;
+      let contentType: string;
+      if (subPath === "/" || subPath === "/index.html") {
+        filePath = join(dashDir, "index.html");
+        contentType = "text/html; charset=utf-8";
+      } else if (subPath === "/data.json") {
+        filePath = join(dashDir, "data.json");
+        contentType = "application/json; charset=utf-8";
+      } else {
+        // Serve any file in the dashboard directory
+        filePath = join(dashDir, subPath.slice(1));
+        const ext = filePath.split(".").pop() || "";
+        const mimeMap: Record<string, string> = {
+          html: "text/html", css: "text/css", js: "application/javascript",
+          json: "application/json", svg: "image/svg+xml", png: "image/png",
+        };
+        contentType = mimeMap[ext] || "application/octet-stream";
+      }
+
+      // Prevent path traversal
+      if (!filePath.startsWith(dashDir)) {
+        res.writeHead(403);
+        res.end(JSON.stringify({ error: "forbidden" }));
+        return;
+      }
+
+      if (existsSync(filePath)) {
+        const data = readFileSync(filePath);
+        res.writeHead(200, { "Content-Type": contentType });
+        res.end(data);
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "file not found" }));
+      }
+      return;
+    }
+
+    // List available dashboards: GET /dashboards
+    if (url === "/dashboards" && req.method === "GET") {
+      const dashDir = join(this.agentDir, "dashboards");
+      let dashboards: string[] = [];
+      if (existsSync(dashDir)) {
+        const { readdirSync } = require("fs");
+        dashboards = readdirSync(dashDir, { withFileTypes: true })
+          .filter((d: any) => d.isDirectory() && existsSync(join(dashDir, d.name, "index.html")))
+          .map((d: any) => d.name);
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ dashboards }));
+      return;
+    }
+
     res.writeHead(404);
     res.end(JSON.stringify({ error: "not found" }));
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ import { messageTool } from "./message.js";
 import { recallTool } from "./recall.js";
 import { pdfTool } from "./pdf.js";
 import { imageTool } from "./image.js";
+import { renderTool } from "./render.js";
 
 const isWindows = process.platform === "win32";
 
@@ -30,6 +31,7 @@ export const allTools = {
   recall: recallTool,
   pdf: pdfTool,
   image: imageTool,
+  render: renderTool,
 };
 
 export type ToolName = keyof typeof allTools;

--- a/src/tools/render.ts
+++ b/src/tools/render.ts
@@ -30,7 +30,6 @@ export const renderTool = tool({
       .describe("Optional title for the render block"),
   }),
   execute: async ({ html, dashboard, target, title }) => {
-    // Validate: must provide html or dashboard
     if (!html && !dashboard) {
       return "Error: provide either `html` or `dashboard` parameter";
     }
@@ -41,14 +40,12 @@ export const renderTool = tool({
       if (!existsSync(indexPath)) {
         return `Error: dashboard not found at dashboards/${dashboard}/index.html — create it with the write tool first`;
       }
-      // Read the dashboard HTML
       html = readFileSync(indexPath, "utf-8");
 
       // Inject data.json if it exists
       const dataPath = join(dashDir, "data.json");
       if (existsSync(dataPath)) {
         const data = readFileSync(dataPath, "utf-8");
-        // Inject as a script tag before closing </head> or at start
         const dataScript = `<script>window.__KERN_DATA__ = ${data};</script>`;
         if (html.includes("</head>")) {
           html = html.replace("</head>", `${dataScript}</head>`);
@@ -56,10 +53,11 @@ export const renderTool = tool({
           html = dataScript + html;
         }
       }
+
+      // Dashboard always opens in panel
+      target = "panel";
     }
 
-    // The actual rendering is handled by the UI via SSE event
-    // Tool result contains metadata for the UI to process
     return JSON.stringify({
       __kern_render: true,
       html,

--- a/src/tools/render.ts
+++ b/src/tools/render.ts
@@ -1,0 +1,71 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { join } from "path";
+import { existsSync, readFileSync } from "fs";
+
+export const renderTool = tool({
+  description:
+    "Render rich visual content (HTML) in the web UI. Two modes:\n" +
+    "1. Inline: provide `html` for one-off visuals in the chat (status cards, tables, charts).\n" +
+    "2. Dashboard: provide `dashboard` name to display a persistent dashboard from dashboards/<name>/index.html.\n" +
+    "   Dashboards are created with the write tool first, then displayed with render.\n" +
+    "Use `target` to control where it appears: 'inline' shows in chat, 'panel' opens/refreshes a side panel.",
+  inputSchema: z.object({
+    html: z
+      .string()
+      .optional()
+      .describe("Raw HTML to render inline. Self-contained with inline styles."),
+    dashboard: z
+      .string()
+      .optional()
+      .describe("Dashboard name — loads dashboards/<name>/index.html"),
+    target: z
+      .enum(["inline", "panel"])
+      .optional()
+      .default("inline")
+      .describe('Where to render: "inline" in chat or "panel" as persistent side panel'),
+    title: z
+      .string()
+      .optional()
+      .describe("Optional title for the render block"),
+  }),
+  execute: async ({ html, dashboard, target, title }) => {
+    // Validate: must provide html or dashboard
+    if (!html && !dashboard) {
+      return "Error: provide either `html` or `dashboard` parameter";
+    }
+
+    if (dashboard) {
+      const dashDir = join(process.cwd(), "dashboards", dashboard);
+      const indexPath = join(dashDir, "index.html");
+      if (!existsSync(indexPath)) {
+        return `Error: dashboard not found at dashboards/${dashboard}/index.html — create it with the write tool first`;
+      }
+      // Read the dashboard HTML
+      html = readFileSync(indexPath, "utf-8");
+
+      // Inject data.json if it exists
+      const dataPath = join(dashDir, "data.json");
+      if (existsSync(dataPath)) {
+        const data = readFileSync(dataPath, "utf-8");
+        // Inject as a script tag before closing </head> or at start
+        const dataScript = `<script>window.__KERN_DATA__ = ${data};</script>`;
+        if (html.includes("</head>")) {
+          html = html.replace("</head>", `${dataScript}</head>`);
+        } else {
+          html = dataScript + html;
+        }
+      }
+    }
+
+    // The actual rendering is handled by the UI via SSE event
+    // Tool result contains metadata for the UI to process
+    return JSON.stringify({
+      __kern_render: true,
+      html,
+      dashboard: dashboard || null,
+      target: target || "inline",
+      title: title || dashboard || "Render",
+    });
+  },
+});

--- a/src/tools/render.ts
+++ b/src/tools/render.ts
@@ -8,8 +8,7 @@ export const renderTool = tool({
     "Render rich visual content (HTML) in the web UI. Two modes:\n" +
     "1. Inline: provide `html` for one-off visuals in the chat (status cards, tables, charts).\n" +
     "2. Dashboard: provide `dashboard` name to display a persistent dashboard from dashboards/<name>/index.html.\n" +
-    "   Dashboards are created with the write tool first, then displayed with render.\n" +
-    "Use `target` to control where it appears: 'inline' shows in chat, 'panel' opens/refreshes a side panel.",
+    "   Dashboards are created with the write tool first, then displayed with render.",
   inputSchema: z.object({
     html: z
       .string()
@@ -19,20 +18,17 @@ export const renderTool = tool({
       .string()
       .optional()
       .describe("Dashboard name — loads dashboards/<name>/index.html"),
-    target: z
-      .enum(["inline", "panel"])
-      .optional()
-      .default("panel")
-      .describe('Where to render: "inline" shows in chat, "panel" opens/refreshes a side panel'),
     title: z
       .string()
       .optional()
       .describe("Optional title for the render block"),
   }),
-  execute: async ({ html, dashboard, target, title }) => {
+  execute: async ({ html, dashboard, title }) => {
     if (!html && !dashboard) {
       return "Error: provide either `html` or `dashboard` parameter";
     }
+
+    let target: "inline" | "panel" = "inline";
 
     if (dashboard) {
       const dashDir = join(process.cwd(), "dashboards", dashboard);
@@ -47,14 +43,13 @@ export const renderTool = tool({
       if (existsSync(dataPath)) {
         const data = readFileSync(dataPath, "utf-8");
         const dataScript = `<script>window.__KERN_DATA__ = ${data};</script>`;
-        if (html.includes("</head>")) {
-          html = html.replace("</head>", `${dataScript}</head>`);
+        if (html!.includes("</head>")) {
+          html = html!.replace("</head>", `${dataScript}</head>`);
         } else {
           html = dataScript + html;
         }
       }
 
-      // Dashboard always opens in panel
       target = "panel";
     }
 
@@ -62,7 +57,7 @@ export const renderTool = tool({
       __kern_render: true,
       html,
       dashboard: dashboard || null,
-      target: target || "inline",
+      target,
       title: title || dashboard || "Render",
     });
   },

--- a/src/tools/render.ts
+++ b/src/tools/render.ts
@@ -22,8 +22,8 @@ export const renderTool = tool({
     target: z
       .enum(["inline", "panel"])
       .optional()
-      .default("inline")
-      .describe('Where to render: "inline" in chat or "panel" as persistent side panel'),
+      .default("panel")
+      .describe('Where to render: "inline" shows in chat, "panel" opens/refreshes a side panel'),
     title: z
       .string()
       .optional()

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -87,7 +87,7 @@ You have a `render` tool that displays HTML visually in the web UI. Two modes:
 2. **Dashboard**: provide `dashboard` name to display a persistent dashboard from `dashboards/<name>/index.html`.
    Dashboards are created with the write tool first, then displayed with render.
 
-Inline HTML renders in the chat by default. Use `target: "panel"` to open it in a side panel instead. Dashboards always open in the side panel.
+Inline HTML shows in the chat. Dashboards always open in a side panel.
 
 For dashboards, write structured data to `dashboards/<name>/data.json` and read it in your HTML via `window.__KERN_DATA__`. Update the data file and re-render to refresh.
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -81,6 +81,16 @@ Images are automatically described by a vision model on arrival. You see the des
 
 Treat `.kern/media/` as an inbox. If a file matters long-term, copy it into your repo with a meaningful name and note it in your knowledge files.
 
+### Rendering rich content
+You have a `render` tool that displays HTML visually in the web UI. Two modes:
+1. **Inline**: provide `html` for one-off visuals in the chat (status cards, tables, charts).
+2. **Dashboard**: provide `dashboard` name to display a persistent dashboard from `dashboards/<name>/index.html`.
+   Dashboards are created with the write tool first, then displayed with render.
+
+Use `target` to control where it appears: `"inline"` shows in chat, `"panel"` opens/refreshes a side panel.
+
+For dashboards, write structured data to `dashboards/<name>/data.json` and read it in your HTML via `window.__KERN_DATA__`. Update the data file and re-render to refresh.
+
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -87,7 +87,7 @@ You have a `render` tool that displays HTML visually in the web UI. Two modes:
 2. **Dashboard**: provide `dashboard` name to display a persistent dashboard from `dashboards/<name>/index.html`.
    Dashboards are created with the write tool first, then displayed with render.
 
-Use `target` to control where it appears: `"inline"` shows in chat, `"panel"` opens/refreshes a side panel.
+Inline HTML renders in the chat by default. Use `target: "panel"` to open it in a side panel instead. Dashboards always open in the side panel.
 
 For dashboards, write structured data to `dashboards/<name>/data.json` and read it in your HTML via `window.__KERN_DATA__`. Update the data file and re-render to refresh.
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -89,6 +89,8 @@ You have a `render` tool that displays HTML visually in the web UI. Two modes:
 
 Inline HTML shows in the chat. Dashboards always open in a side panel.
 
+HTML is rendered in a sandboxed iframe with scripts enabled. Include CDN libraries (Chart.js, D3, etc.) via `<script>` and `<link>` tags directly in your HTML for rich visuals.
+
 For dashboards, write structured data to `dashboards/<name>/data.json` and read it in your HTML via `window.__KERN_DATA__`. Update the data file and re-render to refresh.
 
 ### Heartbeat

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -148,7 +148,8 @@ export default function Home() {
       />
 
       <div
-        className="flex-1 flex flex-col min-w-0 relative"
+        className="flex-1 flex flex-col relative"
+        style={{ minWidth: panelHtml ? 360 : 0 }}
         onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
         onDragLeave={(e) => {
           // Only leave if exiting the container

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,7 +12,7 @@ import { Inspector } from "../components/Inspector";
 import { InfoPanel, PinnedStats } from "../components/InfoPanel";
 import { ThemePicker, usePreferences } from "../components/ThemePicker";
 import { ThinkingDots } from "../components/ThinkingDots";
-import { RenderPanel } from "../components/RenderBlock";
+import { RenderPanel, DashboardButton } from "../components/RenderBlock";
 import type { Attachment } from "../lib/types";
 
 export default function Home() {
@@ -24,10 +24,32 @@ export default function Home() {
   const { prefs, setPrefs } = usePreferences();
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
-  const [panelHtml, setPanelHtml] = useState<{ html: string; title: string } | null>(null);
-  const handleOpenPanel = useCallback((html: string, title: string) => {
-    setPanelHtml({ html, title });
+  const [panelHtml, setPanelHtml] = useState<{ html: string; title: string; dashboard?: string } | null>(null);
+  const [dashboardList, setDashboardList] = useState<string[]>([]);
+  const handleOpenPanel = useCallback((html: string, title: string, dashboard?: string) => {
+    setPanelHtml({ html, title, dashboard });
   }, []);
+  const openDashboard = useCallback((name: string) => {
+    if (!activeAgent) return;
+    const base = activeAgent.serverUrl || "";
+    const headers: Record<string, string> = {};
+    if (activeAgent.token) headers["Authorization"] = `Bearer ${activeAgent.token}`;
+    fetch(`${base}/api/agents/${activeAgent.name}/d/${name}/`, { headers })
+      .then(r => r.ok ? r.text() : Promise.reject())
+      .then(html => setPanelHtml({ html, title: name, dashboard: name }))
+      .catch(() => {});
+  }, [activeAgent]);
+  // Fetch dashboard list when agent changes
+  useEffect(() => {
+    if (!activeAgent) { setDashboardList([]); return; }
+    const base = activeAgent.serverUrl || "";
+    const headers: Record<string, string> = {};
+    if (activeAgent.token) headers["Authorization"] = `Bearer ${activeAgent.token}`;
+    fetch(`${base}/api/agents/${activeAgent.name}/dashboards`, { headers })
+      .then(r => r.json())
+      .then(d => setDashboardList(d.dashboards || []))
+      .catch(() => setDashboardList([]));
+  }, [activeAgent]);
   const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true, onOpenPanel: handleOpenPanel });
   const [pinned, setPinned] = useState<Set<string>>(() => {
     if (typeof window === "undefined") return new Set();
@@ -158,6 +180,12 @@ export default function Home() {
           </div>
           <div className="ml-auto flex items-center gap-1">
             <ThemePicker prefs={prefs} onPrefsChange={setPrefs} />
+            <DashboardButton
+              agentName={activeAgent?.name}
+              token={activeAgent?.token ?? undefined}
+              serverUrl={activeAgent?.serverUrl}
+              onOpenDashboard={openDashboard}
+            />
             <button
               onClick={() => setInspectorOpen(true)}
               className="px-1.5 py-1 text-sm rounded text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)] transition-colors leading-none cursor-pointer"
@@ -217,7 +245,14 @@ export default function Home() {
 
       {/* Render panel */}
       {panelHtml && (
-        <RenderPanel html={panelHtml.html} title={panelHtml.title} onClose={() => setPanelHtml(null)} />
+        <RenderPanel
+          html={panelHtml.html}
+          title={panelHtml.title}
+          dashboards={dashboardList}
+          activeDashboard={panelHtml.dashboard}
+          onSwitchDashboard={openDashboard}
+          onClose={() => setPanelHtml(null)}
+        />
       )}
     </div>
   );

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -50,6 +50,11 @@ export default function Home() {
     setPanelHtml({ html, title, dashboard });
     if (dashboard) { setActiveDashboard(dashboard); localStorage.setItem("kern-active-dashboard", dashboard); }
   }, []);
+  const closePanel = useCallback(() => {
+    setPanelHtml(null);
+    setActiveDashboard(null);
+    localStorage.removeItem("kern-active-dashboard");
+  }, []);
   const openDashboard = useCallback((name: string, fromAgent?: DashboardInfo) => {
     const agent = fromAgent
       ? agents.find(a => a.name === fromAgent.agentName && a.serverUrl === fromAgent.serverUrl) || activeAgent
@@ -65,14 +70,20 @@ export default function Home() {
         setActiveDashboard(name);
         localStorage.setItem("kern-active-dashboard", name);
       })
-      .catch(() => {});
-  }, [activeAgent, agents]);
+      .catch(() => closePanel());
+  }, [activeAgent, agents, closePanel]);
   // Restore active dashboard on load
   useEffect(() => {
     if (!activeAgent) return;
     const saved = localStorage.getItem("kern-active-dashboard");
     if (saved) openDashboard(saved);
   }, [activeAgent]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Close panel if active dashboard no longer exists in fetched list
+  useEffect(() => {
+    if (activeDashboard && allDashboards.length > 0 && !allDashboards.some(d => d.name === activeDashboard)) {
+      closePanel();
+    }
+  }, [allDashboards, activeDashboard, closePanel]);
   const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true, onOpenPanel: handleOpenPanel });
   const [pinned, setPinned] = useState<Set<string>>(() => {
     if (typeof window === "undefined") return new Set();
@@ -161,7 +172,7 @@ export default function Home() {
         dashboards={allDashboards}
         activeDashboard={activeDashboard}
         onOpenDashboard={(d) => openDashboard(d.name, d)}
-        onCloseDashboard={() => { setPanelHtml(null); setActiveDashboard(null); localStorage.removeItem("kern-active-dashboard"); }}
+        onCloseDashboard={closePanel}
       />
 
       <div
@@ -279,7 +290,7 @@ export default function Home() {
           dashboards={dashboardList}
           activeDashboard={panelHtml.dashboard}
           onSwitchDashboard={openDashboard}
-          onClose={() => { setPanelHtml(null); setActiveDashboard(null); localStorage.removeItem("kern-active-dashboard"); }}
+          onClose={closePanel}
         />
       )}
     </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -13,7 +13,7 @@ import { InfoPanel, PinnedStats } from "../components/InfoPanel";
 import { ThemePicker, usePreferences } from "../components/ThemePicker";
 import { ThinkingDots } from "../components/ThinkingDots";
 import { RenderPanel, DashboardButton } from "../components/RenderBlock";
-import type { Attachment } from "../lib/types";
+import type { Attachment, DashboardInfo } from "../lib/types";
 
 export default function Home() {
   const { token, setToken } = useAuth();
@@ -25,41 +25,54 @@ export default function Home() {
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
   const [panelHtml, setPanelHtml] = useState<{ html: string; title: string; dashboard?: string } | null>(null);
-  const [dashboardList, setDashboardList] = useState<string[]>([]);
+  const [allDashboards, setAllDashboards] = useState<DashboardInfo[]>([]);
+  const [activeDashboard, setActiveDashboard] = useState<string | null>(null);
+  // Fetch dashboards from all running agents
+  useEffect(() => {
+    if (!agents.length) { setAllDashboards([]); return; }
+    const running = agents.filter(a => a.running);
+    Promise.all(running.map(async (agent) => {
+      try {
+        const base = agent.serverUrl || "";
+        const headers: Record<string, string> = {};
+        if (agent.token) headers["Authorization"] = `Bearer ${agent.token}`;
+        const r = await fetch(`${base}/api/agents/${agent.name}/dashboards`, { headers });
+        const d = await r.json();
+        return (d.dashboards || []).map((name: string) => ({
+          name, agentName: agent.name, serverUrl: agent.serverUrl, token: agent.token,
+        }));
+      } catch { return []; }
+    })).then(results => setAllDashboards(results.flat()));
+  }, [agents]);
+  const dashboardList = allDashboards.filter(d => d.agentName === activeAgent?.name).map(d => d.name);
+
   const handleOpenPanel = useCallback((html: string, title: string, dashboard?: string) => {
     setPanelHtml({ html, title, dashboard });
-    if (dashboard) localStorage.setItem("kern-active-dashboard", dashboard);
+    if (dashboard) { setActiveDashboard(dashboard); localStorage.setItem("kern-active-dashboard", dashboard); }
   }, []);
-  const openDashboard = useCallback((name: string) => {
-    if (!activeAgent) return;
-    const base = activeAgent.serverUrl || "";
+  const openDashboard = useCallback((name: string, fromAgent?: DashboardInfo) => {
+    const agent = fromAgent
+      ? agents.find(a => a.name === fromAgent.agentName && a.serverUrl === fromAgent.serverUrl) || activeAgent
+      : activeAgent;
+    if (!agent) return;
+    const base = agent.serverUrl || "";
     const headers: Record<string, string> = {};
-    if (activeAgent.token) headers["Authorization"] = `Bearer ${activeAgent.token}`;
-    fetch(`${base}/api/agents/${activeAgent.name}/d/${name}/`, { headers })
+    if (agent.token) headers["Authorization"] = `Bearer ${agent.token}`;
+    fetch(`${base}/api/agents/${agent.name}/d/${name}/`, { headers })
       .then(r => r.ok ? r.text() : Promise.reject())
       .then(html => {
         setPanelHtml({ html, title: name, dashboard: name });
+        setActiveDashboard(name);
         localStorage.setItem("kern-active-dashboard", name);
       })
       .catch(() => {});
-  }, [activeAgent]);
+  }, [activeAgent, agents]);
   // Restore active dashboard on load
   useEffect(() => {
     if (!activeAgent) return;
     const saved = localStorage.getItem("kern-active-dashboard");
     if (saved) openDashboard(saved);
   }, [activeAgent]); // eslint-disable-line react-hooks/exhaustive-deps
-  // Fetch dashboard list when agent changes
-  useEffect(() => {
-    if (!activeAgent) { setDashboardList([]); return; }
-    const base = activeAgent.serverUrl || "";
-    const headers: Record<string, string> = {};
-    if (activeAgent.token) headers["Authorization"] = `Bearer ${activeAgent.token}`;
-    fetch(`${base}/api/agents/${activeAgent.name}/dashboards`, { headers })
-      .then(r => r.json())
-      .then(d => setDashboardList(d.dashboards || []))
-      .catch(() => setDashboardList([]));
-  }, [activeAgent]);
   const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true, onOpenPanel: handleOpenPanel });
   const [pinned, setPinned] = useState<Set<string>>(() => {
     if (typeof window === "undefined") return new Set();
@@ -145,6 +158,10 @@ export default function Home() {
         onLogout={handleLogout}
         onAddServer={addServer}
         onRemoveServer={removeServer}
+        dashboards={allDashboards}
+        activeDashboard={activeDashboard}
+        onOpenDashboard={(d) => openDashboard(d.name, d)}
+        onCloseDashboard={() => { setPanelHtml(null); setActiveDashboard(null); localStorage.removeItem("kern-active-dashboard"); }}
       />
 
       <div
@@ -262,7 +279,7 @@ export default function Home() {
           dashboards={dashboardList}
           activeDashboard={panelHtml.dashboard}
           onSwitchDashboard={openDashboard}
-          onClose={() => { setPanelHtml(null); localStorage.removeItem("kern-active-dashboard"); }}
+          onClose={() => { setPanelHtml(null); setActiveDashboard(null); localStorage.removeItem("kern-active-dashboard"); }}
         />
       )}
     </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -24,6 +24,7 @@ export default function Home() {
   const { prefs, setPrefs } = usePreferences();
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
+  const [panelHtml, setPanelHtml] = useState<{ html: string; title: string } | null>(null);
   const [pinned, setPinned] = useState<Set<string>>(() => {
     if (typeof window === "undefined") return new Set();
     try {
@@ -182,6 +183,7 @@ export default function Home() {
           loadMore={loadMore}
           hasMore={hasMore}
           loadingMore={loadingMore}
+          onOpenPanel={(html, title) => setPanelHtml({ html, title })}
         />
 
         {thinking && (
@@ -207,6 +209,25 @@ export default function Home() {
           token={activeAgent.token}
           serverUrl={activeAgent.serverUrl}
         />
+      )}
+
+      {/* Render panel */}
+      {panelHtml && (
+        <div className="flex flex-col border-l border-[var(--border)]" style={{ width: 480, minWidth: 320, flexShrink: 0 }}>
+          <div className="h-12 border-b border-[var(--border)] flex items-center justify-between px-4 flex-shrink-0">
+            <span className="text-sm font-semibold">{panelHtml.title}</span>
+            <button
+              onClick={() => setPanelHtml(null)}
+              className="text-[var(--text-muted)] hover:text-[var(--text)] transition-colors cursor-pointer text-base leading-none"
+            >✕</button>
+          </div>
+          <iframe
+            srcDoc={`<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{box-sizing:border-box}body{margin:0;padding:0;background:transparent;color:#e0e0e0;font-family:-apple-system,sans-serif}</style></head><body>${panelHtml.html}</body></html>`}
+            sandbox="allow-scripts"
+            className="flex-1 w-full border-0"
+            style={{ background: "transparent" }}
+          />
+        </div>
       )}
     </div>
   );

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -12,19 +12,23 @@ import { Inspector } from "../components/Inspector";
 import { InfoPanel, PinnedStats } from "../components/InfoPanel";
 import { ThemePicker, usePreferences } from "../components/ThemePicker";
 import { ThinkingDots } from "../components/ThinkingDots";
+import { RenderPanel } from "../components/RenderBlock";
 import type { Attachment } from "../lib/types";
 
 export default function Home() {
   const { token, setToken } = useAuth();
   const validToken = token ?? null;
   const { agents, activeAgent, active, setActive, addServer, removeServer } = useServers(validToken);
-  const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true });
   const [dragOver, setDragOver] = useState(false);
   const [externalAttachments, setExternalAttachments] = useState<Attachment[]>([]);
   const { prefs, setPrefs } = usePreferences();
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
   const [panelHtml, setPanelHtml] = useState<{ html: string; title: string } | null>(null);
+  const handleOpenPanel = useCallback((html: string, title: string) => {
+    setPanelHtml({ html, title });
+  }, []);
+  const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true, onOpenPanel: handleOpenPanel });
   const [pinned, setPinned] = useState<Set<string>>(() => {
     if (typeof window === "undefined") return new Set();
     try {
@@ -183,7 +187,7 @@ export default function Home() {
           loadMore={loadMore}
           hasMore={hasMore}
           loadingMore={loadingMore}
-          onOpenPanel={(html, title) => setPanelHtml({ html, title })}
+          onOpenPanel={handleOpenPanel}
         />
 
         {thinking && (
@@ -213,21 +217,7 @@ export default function Home() {
 
       {/* Render panel */}
       {panelHtml && (
-        <div className="flex flex-col border-l border-[var(--border)]" style={{ width: 480, minWidth: 320, flexShrink: 0 }}>
-          <div className="h-12 border-b border-[var(--border)] flex items-center justify-between px-4 flex-shrink-0">
-            <span className="text-sm font-semibold">{panelHtml.title}</span>
-            <button
-              onClick={() => setPanelHtml(null)}
-              className="text-[var(--text-muted)] hover:text-[var(--text)] transition-colors cursor-pointer text-base leading-none"
-            >✕</button>
-          </div>
-          <iframe
-            srcDoc={`<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>*{box-sizing:border-box}body{margin:0;padding:0;background:transparent;color:#e0e0e0;font-family:-apple-system,sans-serif}</style></head><body>${panelHtml.html}</body></html>`}
-            sandbox="allow-scripts"
-            className="flex-1 w-full border-0"
-            style={{ background: "transparent" }}
-          />
-        </div>
+        <RenderPanel html={panelHtml.html} title={panelHtml.title} onClose={() => setPanelHtml(null)} />
       )}
     </div>
   );

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -28,6 +28,7 @@ export default function Home() {
   const [dashboardList, setDashboardList] = useState<string[]>([]);
   const handleOpenPanel = useCallback((html: string, title: string, dashboard?: string) => {
     setPanelHtml({ html, title, dashboard });
+    if (dashboard) localStorage.setItem("kern-active-dashboard", dashboard);
   }, []);
   const openDashboard = useCallback((name: string) => {
     if (!activeAgent) return;
@@ -36,9 +37,18 @@ export default function Home() {
     if (activeAgent.token) headers["Authorization"] = `Bearer ${activeAgent.token}`;
     fetch(`${base}/api/agents/${activeAgent.name}/d/${name}/`, { headers })
       .then(r => r.ok ? r.text() : Promise.reject())
-      .then(html => setPanelHtml({ html, title: name, dashboard: name }))
+      .then(html => {
+        setPanelHtml({ html, title: name, dashboard: name });
+        localStorage.setItem("kern-active-dashboard", name);
+      })
       .catch(() => {});
   }, [activeAgent]);
+  // Restore active dashboard on load
+  useEffect(() => {
+    if (!activeAgent) return;
+    const saved = localStorage.getItem("kern-active-dashboard");
+    if (saved) openDashboard(saved);
+  }, [activeAgent]); // eslint-disable-line react-hooks/exhaustive-deps
   // Fetch dashboard list when agent changes
   useEffect(() => {
     if (!activeAgent) { setDashboardList([]); return; }
@@ -251,7 +261,7 @@ export default function Home() {
           dashboards={dashboardList}
           activeDashboard={panelHtml.dashboard}
           onSwitchDashboard={openDashboard}
-          onClose={() => setPanelHtml(null)}
+          onClose={() => { setPanelHtml(null); localStorage.removeItem("kern-active-dashboard"); }}
         />
       )}
     </div>

--- a/web/components/Chat.tsx
+++ b/web/components/Chat.tsx
@@ -4,7 +4,7 @@ import type { ChatMessage } from "../lib/types";
 import { BubbleLayout } from "./layouts/BubbleLayout";
 import { FlatLayout } from "./layouts/FlatLayout";
 
-interface ChatProps {
+export interface ChatProps {
   messages: ChatMessage[];
   streamParts: ChatMessage[];
   thinking: boolean;
@@ -18,10 +18,11 @@ interface ChatProps {
   loadMore?: () => Promise<void>;
   hasMore?: boolean;
   loadingMore?: boolean;
+  onOpenPanel?: (html: string, title: string) => void;
 }
 
-export function Chat({ messages, streamParts, thinking, agentName, token, serverUrl, layout, showTools = true, coloredTools = true, peekLastTool = true, loadMore, hasMore, loadingMore }: ChatProps) {
-  const shared = { messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore };
+export function Chat({ messages, streamParts, thinking, agentName, token, serverUrl, layout, showTools = true, coloredTools = true, peekLastTool = true, loadMore, hasMore, loadingMore, onOpenPanel }: ChatProps) {
+  const shared = { messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore, onOpenPanel };
 
   if (layout === "flat") {
     return <FlatLayout {...shared} />;

--- a/web/components/RenderBlock.tsx
+++ b/web/components/RenderBlock.tsx
@@ -3,9 +3,8 @@
 import { useState, useRef, useEffect } from "react";
 import type { ChatMessage } from "../lib/types";
 
-export function RenderBlock({ msg }: { msg: ChatMessage }) {
+export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPanel?: (html: string, title: string) => void }) {
   const [showSource, setShowSource] = useState(false);
-  const [fullscreen, setFullscreen] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [height, setHeight] = useState(200);
 
@@ -47,16 +46,18 @@ export function RenderBlock({ msg }: { msg: ChatMessage }) {
         <div className="flex gap-2">
           <button
             onClick={() => setShowSource(!showSource)}
-            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors"
+            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
             title={showSource ? "Show render" : "Show source"}>
             {showSource ? "▶" : "{ }"}
           </button>
-          <button
-            onClick={() => setFullscreen(!fullscreen)}
-            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors"
-            title={fullscreen ? "Exit fullscreen" : "Fullscreen"}>
-            {fullscreen ? "✕" : "⛶"}
-          </button>
+          {onOpenPanel && (
+            <button
+              onClick={() => onOpenPanel(html, title)}
+              className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
+              title="Open in panel">
+              ⧉
+            </button>
+          )}
         </div>
       </div>
 
@@ -71,17 +72,12 @@ export function RenderBlock({ msg }: { msg: ChatMessage }) {
           ref={iframeRef}
           srcDoc={wrappedHtml}
           sandbox="allow-scripts"
-          className={`w-full border-0 rounded-b-lg ${fullscreen ? "fixed inset-0 z-50 rounded-none" : ""}`}
+          className="w-full border-0 rounded-b-lg"
           style={{
-            height: fullscreen ? "100vh" : height,
+            height,
             background: "transparent",
           }}
         />
-      )}
-
-      {/* Fullscreen backdrop */}
-      {fullscreen && (
-        <div className="fixed inset-0 z-40 bg-black/80" onClick={() => setFullscreen(false)} />
       )}
     </div>
   );

--- a/web/components/RenderBlock.tsx
+++ b/web/components/RenderBlock.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import type { ChatMessage } from "../lib/types";
+
+export function RenderBlock({ msg }: { msg: ChatMessage }) {
+  const [showSource, setShowSource] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(200);
+
+  const html = msg.renderHtml || "";
+  const title = msg.renderTitle || "Render";
+
+  // Auto-resize iframe based on content
+  useEffect(() => {
+    const handler = (e: MessageEvent) => {
+      if (e.data?.type === "kern-render-height" && iframeRef.current) {
+        const h = Math.min(Math.max(e.data.height || 200, 60), 800);
+        if (Math.abs(h - height) > 2) setHeight(h);
+      }
+    };
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [height]);
+
+  // Wrap HTML with auto-height reporting script
+  const wrappedHtml = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<style>*{box-sizing:border-box}body{margin:0;padding:0;background:transparent;color:#e0e0e0;font-family:-apple-system,sans-serif}</style>
+</head><body>${html}
+<script>
+  const ro = new ResizeObserver(() => {
+    parent.postMessage({ type: 'kern-render-height', height: document.body.scrollHeight }, '*');
+  });
+  ro.observe(document.body);
+</script></body></html>`;
+
+  return (
+    <div className="my-2 max-w-[90%]">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-1.5 rounded-t-lg text-xs"
+        style={{ background: "var(--bg-surface)", borderBottom: "1px solid var(--border)" }}>
+        <span className="text-[var(--text-muted)]">
+          {msg.renderDashboard ? `📊 ${title}` : `✦ ${title}`}
+        </span>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setShowSource(!showSource)}
+            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors"
+            title={showSource ? "Show render" : "Show source"}>
+            {showSource ? "▶" : "{ }"}
+          </button>
+          <button
+            onClick={() => setFullscreen(!fullscreen)}
+            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors"
+            title={fullscreen ? "Exit fullscreen" : "Fullscreen"}>
+            {fullscreen ? "✕" : "⛶"}
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {showSource ? (
+        <pre className="px-3 py-2 text-xs overflow-auto rounded-b-lg font-mono"
+          style={{ background: "#161616", color: "var(--text-dim)", maxHeight: 400 }}>
+          {html}
+        </pre>
+      ) : (
+        <iframe
+          ref={iframeRef}
+          srcDoc={wrappedHtml}
+          sandbox="allow-scripts"
+          className={`w-full border-0 rounded-b-lg ${fullscreen ? "fixed inset-0 z-50 rounded-none" : ""}`}
+          style={{
+            height: fullscreen ? "100vh" : height,
+            background: "transparent",
+          }}
+        />
+      )}
+
+      {/* Fullscreen backdrop */}
+      {fullscreen && (
+        <div className="fixed inset-0 z-40 bg-black/80" onClick={() => setFullscreen(false)} />
+      )}
+    </div>
+  );
+}

--- a/web/components/RenderBlock.tsx
+++ b/web/components/RenderBlock.tsx
@@ -167,7 +167,14 @@ export function RenderPanel({ html, title, dashboards, activeDashboard, onSwitch
   onSwitchDashboard?: (name: string) => void;
   onClose: () => void;
 }) {
-  const [width, setWidth] = useState(480);
+  const [width, setWidth] = useState(() => {
+    // Try to give panel ~50% of available space, min 480, max 800
+    if (typeof window !== "undefined") {
+      const available = window.innerWidth - 400; // reserve ~400px for sidebar + chat
+      return Math.max(480, Math.min(Math.floor(available * 0.55), 800));
+    }
+    return 480;
+  });
   const dragging = useRef(false);
   const startX = useRef(0);
   const startW = useRef(0);

--- a/web/components/RenderBlock.tsx
+++ b/web/components/RenderBlock.tsx
@@ -3,6 +3,22 @@
 import { useState, useRef, useEffect } from "react";
 import type { ChatMessage } from "../lib/types";
 
+const DashIcon = ({ size = 14, className = "" }: { size?: number; className?: string }) => (
+  <svg width={size} height={size} viewBox="0 0 16 16" fill="none" className={className}>
+    <rect x="1" y="1" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+    <rect x="9" y="1" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+    <rect x="1" y="9" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+    <rect x="9" y="9" width="6" height="6" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+  </svg>
+);
+
+const PanelIcon = () => (
+  <svg width={12} height={12} viewBox="0 0 16 16" fill="none">
+    <rect x="1" y="1" width="14" height="14" rx="2" stroke="currentColor" strokeWidth="1.5" />
+    <line x1="10" y1="1" x2="10" y2="15" stroke="currentColor" strokeWidth="1.5" />
+  </svg>
+);
+
 /** Inline render block — full iframe in chat */
 export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPanel?: (html: string, title: string) => void }) {
   const [showSource, setShowSource] = useState(false);
@@ -29,8 +45,9 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
     <div className="my-2 max-w-[90%]">
       <div className="flex items-center justify-between px-3 py-1.5 rounded-t-lg text-xs"
         style={{ background: "var(--bg-surface)", borderBottom: "1px solid var(--border)" }}>
-        <span className="text-[var(--text-muted)]">
-          {msg.renderDashboard ? `📊 ${title}` : `✦ ${title}`}
+        <span className="flex items-center gap-1.5 text-[var(--text-muted)]">
+          <DashIcon size={12} />
+          {title}
         </span>
         <div className="flex gap-2">
           <button onClick={() => setShowSource(!showSource)}
@@ -41,7 +58,9 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
           {onOpenPanel && (
             <button onClick={() => onOpenPanel(html, title)}
               className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
-              title="Open in panel">⧉</button>
+              title="Open in panel">
+              <PanelIcon />
+            </button>
           )}
         </div>
       </div>
@@ -59,7 +78,6 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
 /** Panel-target card — small clickable button in chat that opens panel */
 export function RenderCard({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPanel?: (html: string, title: string) => void }) {
   const title = msg.renderTitle || "Render";
-  const icon = msg.renderDashboard ? "📊" : "✦";
 
   return (
     <button
@@ -68,15 +86,87 @@ export function RenderCard({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPanel
       style={{ background: "var(--bg-surface)", border: "1px solid var(--border)" }}
       title="Open in panel"
     >
-      <span className="text-base">{icon}</span>
+      <DashIcon size={14} className="text-[var(--text-muted)]" />
       <span className="text-[var(--text-dim)] font-medium">{title}</span>
-      <span className="text-[var(--text-muted)] ml-1">⧉</span>
+      <PanelIcon />
     </button>
   );
 }
 
+/** Dashboard header button with dropdown */
+export function DashboardButton({ agentName, token, serverUrl, onOpenDashboard }: {
+  agentName?: string;
+  token?: string;
+  serverUrl?: string;
+  onOpenDashboard: (name: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [dashboards, setDashboards] = useState<string[]>([]);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open || !agentName) return;
+    const base = serverUrl || "";
+    const headers: Record<string, string> = {};
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    fetch(`${base}/api/agents/${agentName}/dashboards`, { headers })
+      .then(r => r.json())
+      .then(d => setDashboards(d.dashboards || []))
+      .catch(() => setDashboards([]));
+  }, [open, agentName, token, serverUrl]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="px-1.5 py-1 text-sm rounded text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-surface)] transition-colors leading-none cursor-pointer"
+        title="Dashboards"
+      >
+        <DashIcon size={14} />
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 rounded-lg shadow-lg overflow-hidden z-50 min-w-[180px]"
+          style={{ background: "var(--bg-surface)", border: "1px solid var(--border)" }}
+        >
+          {dashboards.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-[var(--text-muted)]">No dashboards</div>
+          ) : (
+            dashboards.map(d => (
+              <button
+                key={d}
+                onClick={() => { onOpenDashboard(d); setOpen(false); }}
+                className="w-full text-left px-3 py-2 text-xs hover:bg-[var(--bg-hover)] transition-colors cursor-pointer flex items-center gap-2"
+              >
+                <DashIcon size={12} className="text-[var(--text-muted)]" />
+                <span className="text-[var(--text-dim)]">{d}</span>
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /** Resizable side panel for rendered content */
-export function RenderPanel({ html, title, onClose }: { html: string; title: string; onClose: () => void }) {
+export function RenderPanel({ html, title, dashboards, activeDashboard, onSwitchDashboard, onClose }: {
+  html: string;
+  title: string;
+  dashboards?: string[];
+  activeDashboard?: string;
+  onSwitchDashboard?: (name: string) => void;
+  onClose: () => void;
+}) {
   const [width, setWidth] = useState(480);
   const dragging = useRef(false);
   const startX = useRef(0);
@@ -114,7 +204,23 @@ export function RenderPanel({ html, title, onClose }: { html: string; title: str
       />
       {/* Header */}
       <div className="h-12 border-b border-[var(--border)] flex items-center justify-between px-4 flex-shrink-0 ml-1">
-        <span className="text-sm font-semibold truncate">{title}</span>
+        <div className="flex items-center gap-2 min-w-0">
+          <DashIcon size={13} className="text-[var(--text-muted)] flex-shrink-0" />
+          {dashboards && dashboards.length > 1 && onSwitchDashboard ? (
+            <select
+              value={activeDashboard || ""}
+              onChange={e => onSwitchDashboard(e.target.value)}
+              className="text-sm font-semibold bg-transparent border-none outline-none cursor-pointer truncate text-[var(--text)]"
+              style={{ appearance: "auto" }}
+            >
+              {dashboards.map(d => (
+                <option key={d} value={d}>{d}</option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-sm font-semibold truncate">{title}</span>
+          )}
+        </div>
         <button onClick={onClose}
           className="text-[var(--text-muted)] hover:text-[var(--text)] transition-colors cursor-pointer text-base leading-none ml-2">✕</button>
       </div>

--- a/web/components/RenderBlock.tsx
+++ b/web/components/RenderBlock.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import type { ChatMessage } from "../lib/types";
 
+/** Inline render block — full iframe in chat */
 export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPanel?: (html: string, title: string) => void }) {
   const [showSource, setShowSource] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -11,7 +12,6 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
   const html = msg.renderHtml || "";
   const title = msg.renderTitle || "Render";
 
-  // Auto-resize iframe based on content
   useEffect(() => {
     const handler = (e: MessageEvent) => {
       if (e.data?.type === "kern-render-height" && iframeRef.current) {
@@ -23,8 +23,114 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
     return () => window.removeEventListener("message", handler);
   }, [height]);
 
-  // Wrap HTML with auto-height reporting script
-  const wrappedHtml = `<!DOCTYPE html>
+  const wrappedHtml = wrapHtml(html);
+
+  return (
+    <div className="my-2 max-w-[90%]">
+      <div className="flex items-center justify-between px-3 py-1.5 rounded-t-lg text-xs"
+        style={{ background: "var(--bg-surface)", borderBottom: "1px solid var(--border)" }}>
+        <span className="text-[var(--text-muted)]">
+          {msg.renderDashboard ? `📊 ${title}` : `✦ ${title}`}
+        </span>
+        <div className="flex gap-2">
+          <button onClick={() => setShowSource(!showSource)}
+            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
+            title={showSource ? "Show render" : "Show source"}>
+            {showSource ? "▶" : "{ }"}
+          </button>
+          {onOpenPanel && (
+            <button onClick={() => onOpenPanel(html, title)}
+              className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
+              title="Open in panel">⧉</button>
+          )}
+        </div>
+      </div>
+      {showSource ? (
+        <pre className="px-3 py-2 text-xs overflow-auto rounded-b-lg font-mono"
+          style={{ background: "#161616", color: "var(--text-dim)", maxHeight: 400 }}>{html}</pre>
+      ) : (
+        <iframe ref={iframeRef} srcDoc={wrappedHtml} sandbox="allow-scripts"
+          className="w-full border-0 rounded-b-lg" style={{ height, background: "transparent" }} />
+      )}
+    </div>
+  );
+}
+
+/** Panel-target card — small clickable button in chat that opens panel */
+export function RenderCard({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPanel?: (html: string, title: string) => void }) {
+  const title = msg.renderTitle || "Render";
+  const icon = msg.renderDashboard ? "📊" : "✦";
+
+  return (
+    <button
+      onClick={() => onOpenPanel?.(msg.renderHtml || "", title)}
+      className="my-2 flex items-center gap-2.5 px-4 py-2.5 rounded-lg text-xs cursor-pointer transition-all hover:brightness-110 active:scale-[0.98]"
+      style={{ background: "var(--bg-surface)", border: "1px solid var(--border)" }}
+      title="Open in panel"
+    >
+      <span className="text-base">{icon}</span>
+      <span className="text-[var(--text-dim)] font-medium">{title}</span>
+      <span className="text-[var(--text-muted)] ml-1">⧉</span>
+    </button>
+  );
+}
+
+/** Resizable side panel for rendered content */
+export function RenderPanel({ html, title, onClose }: { html: string; title: string; onClose: () => void }) {
+  const [width, setWidth] = useState(480);
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const startW = useRef(0);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!dragging.current) return;
+      const delta = startX.current - e.clientX;
+      setWidth(Math.max(280, Math.min(startW.current + delta, 800)));
+    };
+    const onUp = () => { dragging.current = false; document.body.style.cursor = ""; document.body.style.userSelect = ""; };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => { window.removeEventListener("mousemove", onMove); window.removeEventListener("mouseup", onUp); };
+  }, []);
+
+  const onDragStart = (e: React.MouseEvent) => {
+    dragging.current = true;
+    startX.current = e.clientX;
+    startW.current = width;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  const wrappedHtml = wrapHtml(html);
+
+  return (
+    <div className="flex flex-col flex-shrink-0 relative" style={{ width }}>
+      {/* Resize handle */}
+      <div
+        onMouseDown={onDragStart}
+        className="absolute left-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-[var(--accent)] transition-colors z-10"
+        style={{ background: "var(--border)" }}
+      />
+      {/* Header */}
+      <div className="h-12 border-b border-[var(--border)] flex items-center justify-between px-4 flex-shrink-0 ml-1">
+        <span className="text-sm font-semibold truncate">{title}</span>
+        <button onClick={onClose}
+          className="text-[var(--text-muted)] hover:text-[var(--text)] transition-colors cursor-pointer text-base leading-none ml-2">✕</button>
+      </div>
+      {/* Content */}
+      <iframe
+        srcDoc={wrappedHtml}
+        sandbox="allow-scripts"
+        className="flex-1 w-full border-0 ml-1"
+        style={{ background: "transparent" }}
+      />
+    </div>
+  );
+}
+
+function wrapHtml(html: string): string {
+  return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <style>*{box-sizing:border-box}body{margin:0;padding:0;background:transparent;color:#e0e0e0;font-family:-apple-system,sans-serif}</style>
 </head><body>${html}
@@ -34,51 +140,4 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
   });
   ro.observe(document.body);
 </script></body></html>`;
-
-  return (
-    <div className="my-2 max-w-[90%]">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-1.5 rounded-t-lg text-xs"
-        style={{ background: "var(--bg-surface)", borderBottom: "1px solid var(--border)" }}>
-        <span className="text-[var(--text-muted)]">
-          {msg.renderDashboard ? `📊 ${title}` : `✦ ${title}`}
-        </span>
-        <div className="flex gap-2">
-          <button
-            onClick={() => setShowSource(!showSource)}
-            className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
-            title={showSource ? "Show render" : "Show source"}>
-            {showSource ? "▶" : "{ }"}
-          </button>
-          {onOpenPanel && (
-            <button
-              onClick={() => onOpenPanel(html, title)}
-              className="text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors cursor-pointer"
-              title="Open in panel">
-              ⧉
-            </button>
-          )}
-        </div>
-      </div>
-
-      {/* Content */}
-      {showSource ? (
-        <pre className="px-3 py-2 text-xs overflow-auto rounded-b-lg font-mono"
-          style={{ background: "#161616", color: "var(--text-dim)", maxHeight: 400 }}>
-          {html}
-        </pre>
-      ) : (
-        <iframe
-          ref={iframeRef}
-          srcDoc={wrappedHtml}
-          sandbox="allow-scripts"
-          className="w-full border-0 rounded-b-lg"
-          style={{
-            height,
-            background: "transparent",
-          }}
-        />
-      )}
-    </div>
-  );
 }

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import type { AgentInfo } from "../lib/types";
+import type { AgentInfo, DashboardInfo } from "../lib/types";
 import { useAgent } from "../hooks/useAgent";
 import { agentKey } from "../hooks/useServers";
 
@@ -75,9 +75,13 @@ interface SidebarProps {
   onLogout?: () => void;
   onAddServer?: (url: string, token: string) => void;
   onRemoveServer?: (url: string) => void;
+  dashboards?: DashboardInfo[];
+  activeDashboard?: string | null;
+  onOpenDashboard?: (d: DashboardInfo) => void;
+  onCloseDashboard?: () => void;
 }
 
-export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, onAddServer, onRemoveServer }: SidebarProps) {
+export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, onAddServer, onRemoveServer, dashboards, activeDashboard, onOpenDashboard, onCloseDashboard }: SidebarProps) {
   const [showAddModal, setShowAddModal] = useState(false);
   const [newUrl, setNewUrl] = useState("");
   const [newToken, setNewToken] = useState("");
@@ -194,6 +198,51 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
           <div className="text-xs text-[var(--text-muted)] px-2 py-4">
             No agents found.
           </div>
+        )}
+
+        {/* Dashboards section */}
+        {dashboards && dashboards.length > 0 && (
+          <>
+            <div className="mx-4 my-2 border-t border-[var(--border)]" />
+            {!mini && (
+              <div className="px-4 mb-1">
+                <span className="text-[10px] text-[var(--text-muted)] uppercase tracking-wider font-semibold">Dashboards</span>
+              </div>
+            )}
+            {dashboards.map((d) => {
+              const isActive = activeDashboard === d.name;
+              return (
+                <button
+                  key={`${d.agentName}-${d.name}`}
+                  onClick={() => isActive ? onCloseDashboard?.() : onOpenDashboard?.(d)}
+                  className={`flex items-center gap-2 w-full text-left transition-colors cursor-pointer rounded-md mx-1.5 overflow-hidden ${
+                    mini ? "px-0 py-1.5 justify-center" : "px-3 py-1.5"
+                  } ${isActive ? "bg-white/[0.08]" : "hover:bg-white/[0.05]"}`}
+                  style={{ width: mini ? undefined : "calc(100% - 12px)" }}
+                  title={mini ? `${d.name} (${d.agentName})` : d.name}
+                >
+                  <span
+                    className="flex-shrink-0 w-2 h-2"
+                    style={{
+                      transform: "rotate(45deg)",
+                      background: isActive ? "var(--accent)" : "var(--text-muted)",
+                      opacity: isActive ? 1 : 0.5,
+                    }}
+                  />
+                  {!mini && (
+                    <>
+                      <span className={`text-xs truncate ${isActive ? "text-[var(--text)]" : "text-[var(--text-muted)]"}`}>
+                        {d.name}
+                      </span>
+                      <span className="text-[10px] text-[var(--text-muted)] ml-auto opacity-50 flex-shrink-0">
+                        {d.agentName}
+                      </span>
+                    </>
+                  )}
+                </button>
+              );
+            })}
+          </>
         )}
 
         {/* Add server row — matches agent row style */}

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -233,10 +233,9 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
                 <button
                   key={`${d.agentName}-${d.name}`}
                   onClick={() => isActive ? onCloseDashboard?.() : onOpenDashboard?.(d)}
-                  className={`flex items-center gap-2 w-full text-left transition-colors cursor-pointer rounded-md mx-1.5 overflow-hidden ${
-                    mini ? "px-0 py-1.5 justify-center" : "px-3 py-1.5"
+                  className={`flex items-center w-full text-left transition-colors cursor-pointer rounded-lg overflow-hidden p-2.5 ${
+                    mini ? "justify-center" : "gap-2"
                   } ${isActive ? "bg-white/[0.08]" : "hover:bg-white/[0.05]"}`}
-                  style={{ width: mini ? undefined : "calc(100% - 12px)" }}
                   title={mini ? `${d.name} (${d.agentName})` : d.name}
                 >
                   <span

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -200,6 +200,24 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
           </div>
         )}
 
+        {/* Add server row — after agents */}
+        <button
+          onClick={() => setShowAddModal(true)}
+          className="flex items-center gap-2.5 w-full rounded-lg text-sm text-left transition-colors cursor-pointer p-2.5 mb-0.5 overflow-hidden hover:bg-white/[0.05]"
+          title="Add server"
+        >
+          <div className="relative flex-shrink-0">
+            <div className="w-10 h-10 flex items-center justify-center border border-dashed border-[var(--text-muted)]"
+              style={{ borderRadius: "22%" }}>
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round">
+                <line x1="8" y1="4" x2="8" y2="12" />
+                <line x1="4" y1="8" x2="12" y2="8" />
+              </svg>
+            </div>
+          </div>
+          <span className="text-[var(--text-muted)] text-xs whitespace-nowrap">Add server</span>
+        </button>
+
         {/* Dashboards section */}
         {dashboards && dashboards.length > 0 && (
           <>
@@ -244,24 +262,6 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
             })}
           </>
         )}
-
-        {/* Add server row — matches agent row style */}
-        <button
-          onClick={() => setShowAddModal(true)}
-          className="flex items-center gap-2.5 w-full rounded-lg text-sm text-left transition-colors cursor-pointer p-2.5 mb-0.5 overflow-hidden hover:bg-white/[0.05]"
-          title="Add server"
-        >
-          <div className="relative flex-shrink-0">
-            <div className="w-10 h-10 flex items-center justify-center border border-dashed border-[var(--text-muted)]"
-              style={{ borderRadius: "22%" }}>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round">
-                <line x1="8" y1="4" x2="8" y2="12" />
-                <line x1="4" y1="8" x2="12" y2="8" />
-              </svg>
-            </div>
-          </div>
-          <span className="text-[var(--text-muted)] text-xs whitespace-nowrap">Add server</span>
-        </button>
       </div>
 
       {/* Footer: logout */}

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -203,7 +203,7 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
         {/* Dashboards section */}
         {dashboards && dashboards.length > 0 && (
           <>
-            <div className="mx-4 my-2 border-t border-[var(--border)]" />
+            <div className="mt-2" />
             {!mini && (
               <div className="px-4 mb-1">
                 <span className="text-[10px] text-[var(--text-muted)] uppercase tracking-wider font-semibold">Dashboards</span>

--- a/web/components/layouts/BubbleLayout.tsx
+++ b/web/components/layouts/BubbleLayout.tsx
@@ -5,7 +5,7 @@ import type { MessageGroupInfo } from "../../lib/messages";
 import { analyzeMessage, formatTime } from "../../lib/messages";
 import { SpecialMessage, MediaAttachments, MessageBody } from "../MessageContent";
 import { ToolCall } from "../ToolCall";
-import { RenderBlock } from "../RenderBlock";
+import { RenderBlock, RenderCard } from "../RenderBlock";
 import { ScrollToBottom } from "../ScrollToBottom";
 import { useChat } from "../../hooks/useChat";
 
@@ -42,9 +42,10 @@ export function BubbleLayout({ messages, streamParts, thinking, agentName, token
     }
 
     if (msg.role === "render") {
+      const isPanel = msg.renderTarget === "panel";
       return (
         <div key={msg.id} className="flex justify-start">
-          <RenderBlock msg={msg} onOpenPanel={onOpenPanel} />
+          {isPanel ? <RenderCard msg={msg} onOpenPanel={onOpenPanel} /> : <RenderBlock msg={msg} onOpenPanel={onOpenPanel} />}
         </div>
       );
     }

--- a/web/components/layouts/BubbleLayout.tsx
+++ b/web/components/layouts/BubbleLayout.tsx
@@ -22,9 +22,10 @@ interface BubbleLayoutProps {
   loadMore?: () => Promise<void>;
   hasMore?: boolean;
   loadingMore?: boolean;
+  onOpenPanel?: (html: string, title: string) => void;
 }
 
-export function BubbleLayout({ messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore }: BubbleLayoutProps) {
+export function BubbleLayout({ messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore, onOpenPanel }: BubbleLayoutProps) {
   const { containerRef, bottomRef, showScrollBtn, scrollToBottom, allMsgs, lastToolId, groups, showDots, loadingMore: isLoadingMore } = useChat({
     messages, streamParts, thinking, showTools, peekLastTool, loadMore, hasMore, loadingMore,
   });
@@ -43,7 +44,7 @@ export function BubbleLayout({ messages, streamParts, thinking, agentName, token
     if (msg.role === "render") {
       return (
         <div key={msg.id} className="flex justify-start">
-          <RenderBlock msg={msg} />
+          <RenderBlock msg={msg} onOpenPanel={onOpenPanel} />
         </div>
       );
     }

--- a/web/components/layouts/BubbleLayout.tsx
+++ b/web/components/layouts/BubbleLayout.tsx
@@ -5,6 +5,7 @@ import type { MessageGroupInfo } from "../../lib/messages";
 import { analyzeMessage, formatTime } from "../../lib/messages";
 import { SpecialMessage, MediaAttachments, MessageBody } from "../MessageContent";
 import { ToolCall } from "../ToolCall";
+import { RenderBlock } from "../RenderBlock";
 import { ScrollToBottom } from "../ScrollToBottom";
 import { useChat } from "../../hooks/useChat";
 
@@ -35,6 +36,14 @@ export function BubbleLayout({ messages, streamParts, thinking, agentName, token
       return (
         <div key={msg.id}>
           <ToolCall msg={msg} colored={coloredTools} peek={msg.id === lastToolId} />
+        </div>
+      );
+    }
+
+    if (msg.role === "render") {
+      return (
+        <div key={msg.id} className="flex justify-start">
+          <RenderBlock msg={msg} />
         </div>
       );
     }

--- a/web/components/layouts/BubbleLayout.tsx
+++ b/web/components/layouts/BubbleLayout.tsx
@@ -30,7 +30,7 @@ export function BubbleLayout({ messages, streamParts, thinking, agentName, token
   });
 
   const renderMsg = (msg: ChatMessage) => {
-    if (msg.role === "tool" && !showTools) return null;
+    if (msg.role === "tool" && (!showTools || msg.hidden)) return null;
 
     if (msg.role === "tool") {
       return (

--- a/web/components/layouts/FlatLayout.tsx
+++ b/web/components/layouts/FlatLayout.tsx
@@ -5,6 +5,7 @@ import { analyzeMessage, formatTime, getChannelInfo } from "../../lib/messages";
 import { avatarColor } from "../../lib/colors";
 import { SpecialMessage, MediaAttachments, MessageBody } from "../MessageContent";
 import { ToolCall } from "../ToolCall";
+import { RenderBlock } from "../RenderBlock";
 import { ScrollToBottom } from "../ScrollToBottom";
 import { useChat } from "../../hooks/useChat";
 
@@ -55,6 +56,14 @@ export function FlatLayout({ messages, streamParts, thinking, agentName, token, 
           <div style={{ marginLeft: 42 }}>
             <ToolCall msg={msg} colored={coloredTools} peek={msg.id === lastToolId} />
           </div>
+        </div>
+      );
+    }
+
+    if (msg.role === "render") {
+      return (
+        <div key={msg.id} style={{ marginLeft: 42 }}>
+          <RenderBlock msg={msg} />
         </div>
       );
     }

--- a/web/components/layouts/FlatLayout.tsx
+++ b/web/components/layouts/FlatLayout.tsx
@@ -40,7 +40,7 @@ export function FlatLayout({ messages, streamParts, thinking, agentName, token, 
   });
 
   const renderMsg = (msg: ChatMessage) => {
-    if (msg.role === "tool" && !showTools) return null;
+    if (msg.role === "tool" && (!showTools || msg.hidden)) return null;
 
     const group = groups.get(msg.id);
 

--- a/web/components/layouts/FlatLayout.tsx
+++ b/web/components/layouts/FlatLayout.tsx
@@ -5,7 +5,7 @@ import { analyzeMessage, formatTime, getChannelInfo } from "../../lib/messages";
 import { avatarColor } from "../../lib/colors";
 import { SpecialMessage, MediaAttachments, MessageBody } from "../MessageContent";
 import { ToolCall } from "../ToolCall";
-import { RenderBlock } from "../RenderBlock";
+import { RenderBlock, RenderCard } from "../RenderBlock";
 import { ScrollToBottom } from "../ScrollToBottom";
 import { useChat } from "../../hooks/useChat";
 
@@ -62,9 +62,10 @@ export function FlatLayout({ messages, streamParts, thinking, agentName, token, 
     }
 
     if (msg.role === "render") {
+      const isPanel = msg.renderTarget === "panel";
       return (
         <div key={msg.id} style={{ marginLeft: 42 }}>
-          <RenderBlock msg={msg} onOpenPanel={onOpenPanel} />
+          {isPanel ? <RenderCard msg={msg} onOpenPanel={onOpenPanel} /> : <RenderBlock msg={msg} onOpenPanel={onOpenPanel} />}
         </div>
       );
     }

--- a/web/components/layouts/FlatLayout.tsx
+++ b/web/components/layouts/FlatLayout.tsx
@@ -22,6 +22,7 @@ interface FlatLayoutProps {
   loadMore?: () => Promise<void>;
   hasMore?: boolean;
   loadingMore?: boolean;
+  onOpenPanel?: (html: string, title: string) => void;
 }
 
 function Avatar({ name, isUser }: { name: string; isUser: boolean }) {
@@ -34,7 +35,7 @@ function Avatar({ name, isUser }: { name: string; isUser: boolean }) {
   );
 }
 
-export function FlatLayout({ messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore }: FlatLayoutProps) {
+export function FlatLayout({ messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore, onOpenPanel }: FlatLayoutProps) {
   const { containerRef, bottomRef, showScrollBtn, scrollToBottom, allMsgs, lastToolId, groups, showDots, loadingMore: isLoadingMore } = useChat({
     messages, streamParts, thinking, showTools, peekLastTool, loadMore, hasMore, loadingMore,
   });
@@ -63,7 +64,7 @@ export function FlatLayout({ messages, streamParts, thinking, agentName, token, 
     if (msg.role === "render") {
       return (
         <div key={msg.id} style={{ marginLeft: 42 }}>
-          <RenderBlock msg={msg} />
+          <RenderBlock msg={msg} onOpenPanel={onOpenPanel} />
         </div>
       );
     }

--- a/web/hooks/useAgent.ts
+++ b/web/hooks/useAgent.ts
@@ -90,7 +90,7 @@ const EMPTY_STATE: AgentState = {
 
 export function useAgent(
   agent: AgentInfo | null,
-  opts: { withHistory: boolean } = { withHistory: false }
+  opts: { withHistory: boolean; onOpenPanel?: (html: string, title: string) => void } = { withHistory: false }
 ): AgentState {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [streamParts, setStreamParts] = useState<ChatMessage[]>([]);
@@ -113,6 +113,7 @@ export function useAgent(
   const token = agent?.token ?? null;
   const serverUrl = agent?.serverUrl;
   const withHistory = opts.withHistory;
+  const onOpenPanel = opts.onOpenPanel;
 
   // Load history + status on agent change (only when withHistory)
   useEffect(() => {
@@ -175,6 +176,11 @@ export function useAgent(
 
           partsRef.current = result.parts;
           setStreamParts([...result.parts]);
+
+          // Auto-open/refresh panel for panel-target renders
+          if (result.panelRender && onOpenPanel) {
+            onOpenPanel(result.panelRender.html, result.panelRender.title);
+          }
 
           // Thinking + activity tracking
           if (ev.type === "thinking") {

--- a/web/hooks/useAgent.ts
+++ b/web/hooks/useAgent.ts
@@ -23,6 +23,7 @@ function toolActivity(toolName?: string): string {
     case "image": return "analyzing image";
     case "kern": return "checking status";
     case "message": return "sending message";
+    case "render": return "rendering";
     default: return `using ${toolName}`;
   }
 }
@@ -44,6 +45,7 @@ function toolDetail(toolName?: string, input?: Record<string, unknown>): string 
     case "recall": return truncDetail(String(input.query || ""));
     case "kern": return String(input.action || "");
     case "message": return String(input.userId || "");
+    case "render": return String(input.dashboard || input.title || "");
     default: return "";
   }
 }

--- a/web/lib/events.ts
+++ b/web/lib/events.ts
@@ -19,11 +19,13 @@ export function processStreamEvent(
   parts: ChatMessage[];
   append: ChatMessage[];
   flush: boolean;
+  panelRender?: { html: string; title: string };
 } {
   const result = {
     parts: [...parts],
     append: [] as ChatMessage[],
     flush: false,
+    panelRender: undefined as { html: string; title: string } | undefined,
   };
 
   switch (ev.type) {
@@ -148,16 +150,22 @@ export function processStreamEvent(
       break;
 
     case "render": {
+      const rTitle = ev.render.title || "Render";
+      const rTarget = ev.render.target || "inline";
       const target = inTurn ? result.parts : result.append;
       target.push({
         id: `render-${Date.now()}`,
         role: "render",
-        text: ev.render.title || "Render",
+        text: rTitle,
         renderHtml: ev.render.html,
-        renderTarget: ev.render.target,
-        renderTitle: ev.render.title,
+        renderTarget: rTarget,
+        renderTitle: rTitle,
         renderDashboard: ev.render.dashboard,
       });
+      // Auto-open panel for panel-target renders
+      if (rTarget === "panel") {
+        result.panelRender = { html: ev.render.html, title: rTitle };
+      }
       break;
     }
 

--- a/web/lib/events.ts
+++ b/web/lib/events.ts
@@ -63,6 +63,10 @@ export function processStreamEvent(
             toolOutput: ev.toolResult || ev.output || ev.result,
             streaming: false,
           };
+          // Hide render tool calls — the render event creates the visible block
+          if (result.parts[i].toolName === "render") {
+            result.parts[i].hidden = true;
+          }
           break;
         }
       }
@@ -81,7 +85,7 @@ export function processStreamEvent(
 
     case "finish": {
       result.append = result.parts.filter(
-        (p) => p.role === "tool" || (p.role === "assistant" && p.text.trim())
+        (p) => p.role === "render" || (p.role === "tool" && !p.hidden) || (p.role === "assistant" && p.text.trim())
       );
       result.parts = [];
       result.flush = true;

--- a/web/lib/events.ts
+++ b/web/lib/events.ts
@@ -143,6 +143,20 @@ export function processStreamEvent(
       });
       break;
 
+    case "render": {
+      const target = inTurn ? result.parts : result.append;
+      target.push({
+        id: `render-${Date.now()}`,
+        role: "render",
+        text: ev.render.title || "Render",
+        renderHtml: ev.render.html,
+        renderTarget: ev.render.target,
+        renderTitle: ev.render.title,
+        renderDashboard: ev.render.dashboard,
+      });
+      break;
+    }
+
     case "error":
       result.append.push({
         id: `err-${Date.now()}`,

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -165,6 +165,24 @@ export function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
         const lastTool = findLastUnresolvedTool(messages);
         if (lastTool) {
           lastTool.toolOutput = content;
+          // Convert render tool results to render messages
+          if (lastTool.toolName === "render") {
+            try {
+              const parsed = JSON.parse(content);
+              if (parsed.__kern_render) {
+                lastTool.hidden = true;
+                messages.push({
+                  id: `msg-${msgCounter++}`,
+                  role: "render",
+                  text: parsed.title || "Render",
+                  renderHtml: parsed.html,
+                  renderTarget: parsed.target || "inline",
+                  renderTitle: parsed.title || "Render",
+                  renderDashboard: parsed.dashboard,
+                });
+              }
+            } catch { /* not JSON */ }
+          }
         }
         continue;
       }
@@ -180,6 +198,24 @@ export function historyToMessages(history: HistoryMessage[]): ChatMessage[] {
               : findLastUnresolvedTool(messages);
             if (match) {
               match.toolOutput = output;
+              // Convert render tool results to render messages
+              if (match.toolName === "render" && output) {
+                try {
+                  const parsed = JSON.parse(output);
+                  if (parsed.__kern_render) {
+                    match.hidden = true;
+                    messages.push({
+                      id: `msg-${msgCounter++}`,
+                      role: "render",
+                      text: parsed.title || "Render",
+                      renderHtml: parsed.html,
+                      renderTarget: parsed.target || "inline",
+                      renderTitle: parsed.title || "Render",
+                      renderDashboard: parsed.dashboard,
+                    });
+                  }
+                } catch { /* not JSON */ }
+              }
             }
           }
         }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -95,6 +95,13 @@ export interface ParsedUserMessage {
   iface?: string;
 }
 
+export interface DashboardInfo {
+  name: string;
+  agentName: string;
+  serverUrl?: string;
+  token: string;
+}
+
 export interface MediaItem {
   type: "image" | "file";
   url: string;

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -25,7 +25,8 @@ export type StreamEvent =
   | { type: "command-result"; text: string; command?: string }
   | { type: "incoming"; text: string; fromInterface?: string; fromUserId?: string; fromChannel?: string; media?: MediaItem[] }
   | { type: "outgoing"; text: string; fromInterface?: string }
-  | { type: "heartbeat" };
+  | { type: "heartbeat" }
+  | { type: "render"; render: { html: string; dashboard?: string | null; target: string; title: string } };
 
 export interface StatusData {
   version?: string;
@@ -103,7 +104,7 @@ export interface MediaItem {
 // A rendered message block in the chat UI
 export interface ChatMessage {
   id: string;
-  role: "user" | "assistant" | "tool" | "heartbeat" | "incoming" | "error" | "command";
+  role: "user" | "assistant" | "tool" | "heartbeat" | "incoming" | "error" | "command" | "render";
   text: string;
   timestamp?: string | null;
   iface?: string;
@@ -115,6 +116,11 @@ export interface ChatMessage {
   toolInput?: Record<string, unknown>;
   toolOutput?: string;
   toolCallId?: string;
+  // Render fields
+  renderHtml?: string;
+  renderTarget?: string;
+  renderTitle?: string;
+  renderDashboard?: string | null;
   // Streaming
   streaming?: boolean;
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -121,6 +121,7 @@ export interface ChatMessage {
   renderTarget?: string;
   renderTitle?: string;
   renderDashboard?: string | null;
-  // Streaming
+  // UI flags
+  hidden?: boolean;
   streaming?: boolean;
 }


### PR DESCRIPTION
New `render` tool enabling agents to create rich visual content:

**Features:**
- `render` tool with two modes: inline HTML blocks and persistent dashboards
- Dashboard system: `dashboards/<name>/` with `index.html` + `data.json`, served at `/d/<name>/`
- Side panel for persistent dashboard display with resize handle (280–800px)
- Panel auto-opens on `target: 'panel'` renders, inline iframe for `target: 'inline'`
- Dashboard discovery across all running agents via `/dashboards` endpoint
- Sidebar dashboard list with cross-agent ownership labels and active state indicators
- Header dropdown for quick dashboard switching
- `data.json` injection as `window.__KERN_DATA__` for dynamic data-driven dashboards
- localStorage persistence of active dashboard across reloads
- Clickable cards in chat for panel-target renders, full iframe for inline renders
- Source view toggle and fullscreen support on render blocks

**Fixes:**
- Crash on `/dashboards` endpoint (CJS require in ESM module)

Closes #101, closes #103