### PR TITLE
Self-contained agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@
 - **Self-contained agents** ([#126](https://github.com/oguzbilgic/kern-ai/issues/126)) — all agent runtime state (port, token, PID) now lives in the agent's own `.kern/` directory instead of a central registry
   - `~/.kern/agents.json` simplified from complex records to a plain list of agent directory paths
   - New `port` config field: set a fixed port for direct network connections (default `0` = random)
-  - `KERN_AUTH_TOKEN` renamed to `KERN_TOKEN` (legacy name still supported)
   - Server binds `0.0.0.0` by default, enabling direct connections over Tailscale or LAN
-  - Legacy registry format auto-migrates on first load, including token migration to agent `.env` files
 
 ## v0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Self-contained agents** ([#126](https://github.com/oguzbilgic/kern-ai/issues/126)) — all agent runtime state (port, token, PID) now lives in the agent's own `.kern/` directory instead of a central registry
   - Agent list moved from `~/.kern/agents.json` to `agents` field in `~/.kern/config.json` — one global config file for everything
   - Legacy `agents.json` auto-migrates on first load and gets deleted
-  - New `port` config field: set a fixed port for direct network connections (default `0` = random)
+  - Sticky ports: agents get a fixed port (4100-4999) assigned on creation or first start — no more random ports
   - Server binds `0.0.0.0` by default, enabling direct connections over Tailscale or LAN
 
 ## v0.24.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 - **Self-contained agents** ([#126](https://github.com/oguzbilgic/kern-ai/issues/126)) — all agent runtime state (port, token, PID) now lives in the agent's own `.kern/` directory instead of a central registry
-  - `~/.kern/agents.json` simplified from complex records to a plain list of agent directory paths
+  - Agent list moved from `~/.kern/agents.json` to `agents` field in `~/.kern/config.json` — one global config file for everything
+  - Legacy `agents.json` auto-migrates on first load and gets deleted
   - New `port` config field: set a fixed port for direct network connections (default `0` = random)
   - Server binds `0.0.0.0` by default, enabling direct connections over Tailscale or LAN
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## next
+
+### Features
+- **Self-contained agents** ([#126](https://github.com/oguzbilgic/kern-ai/issues/126)) — all agent runtime state (port, token, PID) now lives in the agent's own `.kern/` directory instead of a central registry
+  - `~/.kern/agents.json` simplified from complex records to a plain list of agent directory paths
+  - New `port` config field: set a fixed port for direct network connections (default `0` = random)
+  - `KERN_AUTH_TOKEN` renamed to `KERN_TOKEN` (legacy name still supported)
+  - Server binds `0.0.0.0` by default, enabling direct connections over Tailscale or LAN
+  - Legacy registry format auto-migrates on first load, including token migration to agent `.env` files
+
 ## v0.24.1
 
 ### Fixes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,11 +5,11 @@ How kern's processes fit together.
 ## Overview
 
 ```
-Browser ──→ kern web (:9000) ──→ agent A (:random)
-                               ├─→ agent B (:random)
-                               └─→ agent C (:random)
+Browser ──→ kern web (:9000) ──→ agent A (:4100)
+                               ├─→ agent B (:4101)
+                               └─→ agent C (:4102)
 
-TUI ──────────────────────────→ agent A (:random)
+TUI ──────────────────────────→ agent A (:4100)
 Telegram ←────────────────────→ agent A (long poll)
 Slack ←───────────────────────→ agent A (socket mode)
 ```
@@ -20,7 +20,7 @@ Each agent is a separate process. The web server is a separate process. They com
 
 `kern start` launches an agent as a background daemon. Each agent process:
 
-- Binds an HTTP server to `127.0.0.1` on a **random port** (OS-assigned)
+- Binds an HTTP server to `0.0.0.0` on a **sticky port** (auto-assigned from 4100-4999 on first start, saved to config)
 - Registers its path in `~/.kern/config.json` and writes PID to its own `.kern/agent.pid`
 - Connects to Telegram (long polling) and/or Slack (socket mode) if tokens are configured
 - Runs the message queue, tool executor, and model calls
@@ -63,7 +63,7 @@ It serves two things:
 ```
 Browser → GET /api/agents/vega/status
        → kern web reads ~/.kern/config.json agents list
-       → finds vega: { port: 34521, token: "abc..." }
+       → finds vega: { port: 4100, token: "abc..." }
        → forwards to 127.0.0.1:34521/status with Authorization header
        → streams response back to browser
 ```
@@ -127,14 +127,14 @@ Without `kern install`, agents run as plain daemons managed by PID files.
 ```
 ~/.kern/
   config.json          # global config + agent registry
-  config.json          # global config (web port, host)
   .env                 # KERN_WEB_TOKEN
   web.pid              # web server PID
 
 ~/my-agent/
   .kern/
-    config.json        # agent config (model, provider, toolScope)
-    .env               # API keys, bot tokens, KERN_AGENT_TOKEN
+    config.json        # agent config (model, provider, port, toolScope)
+    .env               # API keys, bot tokens, KERN_AUTH_TOKEN
+    agent.pid          # PID file (written on start, removed on stop)
     sessions/          # conversation JSONL
     recall.db          # memory database (embeddings, segments, summaries)
     logs/              # structured logs
@@ -150,7 +150,7 @@ Without `kern install`, agents run as plain daemons managed by PID files.
 
 | Process | Binds to | Port | Accessible from |
 |---------|----------|------|-----------------|
-| Agent | 127.0.0.1 | random | localhost only |
+| Agent | 0.0.0.0 | 4100-4999 | sticky, auto-assigned |
 | Web server | 0.0.0.0 (configurable) | 9000 (configurable) | LAN / Tailscale |
 | Telegram | outbound only | — | — |
 | Slack | outbound only | — | — |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Each agent is a separate process. The web server is a separate process. They com
 `kern start` launches an agent as a background daemon. Each agent process:
 
 - Binds an HTTP server to `127.0.0.1` on a **random port** (OS-assigned)
-- Registers its PID, port, and auth token in `~/.kern/agents.json`
+- Registers its path in `~/.kern/config.json` and writes PID to its own `.kern/agent.pid`
 - Connects to Telegram (long polling) and/or Slack (socket mode) if tokens are configured
 - Runs the message queue, tool executor, and model calls
 - Serves SSE for real-time streaming to connected clients (TUI, web UI)
@@ -48,7 +48,7 @@ These are internal — the web proxy forwards to them, TUI connects directly.
 
 ### Auth
 
-Each agent generates a random token on first start, stored in `.kern/.env` as `KERN_AGENT_TOKEN`. Every request must include `Authorization: Bearer <token>`. The TUI reads the token from the agent's `.env` file. The web proxy reads it from the registry.
+Each agent generates a random token on first start, stored in `.kern/.env` as `KERN_AUTH_TOKEN`. Every request must include `Authorization: Bearer <token>`. The TUI and web proxy read the token from the agent's `.kern/.env` file.
 
 ## Web server
 
@@ -62,7 +62,7 @@ It serves two things:
 
 ```
 Browser → GET /api/agents/vega/status
-       → kern web reads ~/.kern/agents.json
+       → kern web reads ~/.kern/config.json agents list
        → finds vega: { port: 34521, token: "abc..." }
        → forwards to 127.0.0.1:34521/status with Authorization header
        → streams response back to browser
@@ -82,26 +82,20 @@ The browser stores this token and sends it with every request. No per-agent auth
 
 ## Registry
 
-`~/.kern/agents.json` is the coordination point. Every agent registers itself on start:
+`~/.kern/config.json` is the coordination point. Every agent registers its path on start:
 
 ```json
-[
-  {
-    "name": "vega",
-    "path": "/root/vega",
-    "pid": 12345,
-    "port": 34521,
-    "token": "kern_...",
-    "addedAt": "2026-03-26T10:00:00Z"
-  }
-]
+{
+  "web_port": 9000,
+  "agents": ["/root/vega", "/home/kern/atlas"]
+}
 ```
 
-The web server and TUI read this file to discover agents. `kern list` reads it to show status. PIDs are checked with `kill -0` to detect stale entries.
+The web server and TUI read this file to discover agents, then read each agent's `.kern/` directory for port, token, and PID. `kern list` reads it to show status. PIDs are checked with `kill -0` to detect stale entries.
 
 ## TUI
 
-`kern tui [name]` connects directly to an agent's HTTP server — no web proxy involved. It reads the agent's port and token from the registry, opens an SSE connection for streaming, and sends messages via POST. It's a direct localhost connection.
+`kern tui [name]` connects directly to an agent's HTTP server — no web proxy involved. It reads the agent's port and token from the agent's `.kern/` directory, opens an SSE connection for streaming, and sends messages via POST. It's a direct localhost connection.
 
 ## Telegram & Slack
 
@@ -132,7 +126,7 @@ Without `kern install`, agents run as plain daemons managed by PID files.
 
 ```
 ~/.kern/
-  agents.json          # agent registry (discovery, PIDs, ports, tokens)
+  config.json          # global config + agent registry
   config.json          # global config (web port, host)
   .env                 # KERN_WEB_TOKEN
   web.pid              # web server PID

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,7 @@ It serves two things:
 Browser → GET /api/agents/vega/status
        → kern web reads ~/.kern/config.json agents list
        → finds vega: { port: 4100, token: "abc..." }
-       → forwards to 127.0.0.1:34521/status with Authorization header
+       → forwards to 127.0.0.1:4100/status with Authorization header
        → streams response back to browser
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,9 +8,9 @@ Show help and available commands.
 
 Create a new agent or reconfigure an existing one.
 
-**New agent**: interactive wizard asks for provider, API key, model, Telegram/Slack tokens. Scaffolds agent-kernel files (AGENTS.md, IDENTITY.md, KNOWLEDGE.md, USERS.md), creates `.kern/` config, initializes git, registers in `~/.kern/agents.json`, and starts the agent.
+**New agent**: interactive wizard asks for provider, API key, model, Telegram/Slack tokens. Scaffolds agent-kernel files (AGENTS.md, IDENTITY.md, KNOWLEDGE.md, USERS.md), creates `.kern/` config, initializes git, registers in `~/.kern/config.json`, and starts the agent.
 
-**Existing agent**: detects by name (from registry) or path. Shows current config with masked secrets. Update any field — press enter to keep current value. Restarts automatically after changes.
+**Existing agent**: detects by name or path. Shows current config with masked secrets. Update any field — press enter to keep current value. Restarts automatically after changes.
 
 **Adopting an existing repo**: if the directory exists but has no `.kern/`, creates only `.kern/` config without overwriting existing AGENTS.md, IDENTITY.md, etc.
 
@@ -66,11 +66,11 @@ kern uninstall atlas  # single agent
 Start agents as background daemons.
 
 - No argument: starts all registered agents
-- With name: starts that agent (looks up in registry)
+- With name: starts that agent (looks up in `~/.kern/config.json`)
 - With path: auto-registers and starts (e.g. `kern start ./cloned-repo`)
 - Waits 2 seconds after fork, verifies process is alive
 - Shows error log if startup fails
-- Writes PID and port to `~/.kern/agents.json`
+- Writes PID to agent's `.kern/agent.pid`
 - If a systemd service is installed for the agent, delegates to `systemctl --user start`
 
 ## kern stop [name]
@@ -79,7 +79,7 @@ Stop agents.
 
 - No argument: stops all running agents
 - With name: stops that agent
-- Sends SIGTERM, clears PID from registry
+- Sends SIGTERM, removes agent's `.kern/agent.pid`
 - If a systemd service is installed, delegates to `systemctl --user stop`
 
 ## kern restart [name]
@@ -148,7 +148,7 @@ Backup an agent to a `.tar.gz` file.
 Restore an agent from a backup archive.
 
 - Extracts to `./{agent-name}/` in the current directory
-- Registers the agent in `~/.kern/agents.json`
+- Registers the agent in `~/.kern/config.json`
 - If agent already exists: warns and asks to confirm overwrite
 - If agent is running: stops it before overwriting
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -64,8 +64,7 @@ Only set the API keys for providers/interfaces you use.
 **`KERN_AUTH_TOKEN`** — per-agent Bearer token required on all agent API endpoints (except `/health`).
 
 - Auto-generated on first agent start — written to `.kern/.env` automatically
-- Registered in `~/.kern/agents.json` so the TUI and web proxy can read it
-- TUI reads it from the registry automatically
+- TUI and web proxy read it from the agent's `.kern/.env` automatically
 - Web proxy injects it into proxied requests — the browser never sees agent tokens
 
 **`KERN_WEB_TOKEN`** — web proxy auth token stored in `~/.kern/.env`.
@@ -79,12 +78,13 @@ You never need to set either token manually unless you want specific values.
 
 ## Global: ~/.kern/config.json
 
-Global settings for the `kern web` server. Optional — defaults apply if the file doesn't exist.
+Global settings and agent registry. Optional — defaults apply if the file doesn't exist.
 
 ```json
 {
   "web_port": 9000,
-  "web_host": "0.0.0.0"
+  "web_host": "0.0.0.0",
+  "agents": ["/home/user/my-agent"]
 }
 ```
 
@@ -92,12 +92,7 @@ Global settings for the `kern web` server. Optional — defaults apply if the fi
 |-------|---------|-------------|
 | `web_port` | `9000` | Port for the `kern web` UI server. |
 | `web_host` | `0.0.0.0` | Bind address for the web UI server. |
-
-## Global: ~/.kern/agents.json
-
-Agent registry. Managed automatically — do not edit by hand.
-
-Tracks all registered agents with their name, path, PID, port, and auth token. Updated when agents start/stop.
+| `agents` | `[]` | List of registered agent directory paths. Managed automatically by `kern init` and `kern start`. |
 
 ## .kern/ local files
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,6 +20,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 | `provider` | `openrouter` | API provider: `openrouter`, `anthropic`, `openai`, `ollama` |
 | `toolScope` | `full` | Tool access level: `full`, `write`, `read` |
 | `maxSteps` | `30` | Max tool-use steps per message |
+| `port` | auto | Fixed port for the agent HTTP server. Assigned automatically from 4100-4999 on creation or first start. |
 | `maxContextTokens` | `100000` | Token budget for context window. Messages beyond this are trimmed oldest-first. Full history stays in session JSONL files. |
 | `maxToolResultChars` | `20000` | Max characters per tool result in context. Oversized results are truncated in context only. Full results stay in session storage. Set to `0` to disable. |
 | `telegramTools` | `false` | Show tool call progress lines (⚙ bash, etc.) in Telegram messages. |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -72,7 +72,7 @@ Two layers:
 
 ### Agent discovery
 
-- **Local agents** are auto-discovered from `~/.kern/agents.json`
+- **Local agents** are auto-discovered from `~/.kern/config.json`
 - **Remote servers** can be added in the sidebar ("Add server" with URL + token)
 
 ### Global config

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,7 +8,7 @@ import { readFile, appendFile } from "fs/promises";
 import { join, basename } from "path";
 import { randomBytes } from "crypto";
 import type { Interface, MessageHandler } from "./interfaces/types.js";
-import { registerAgent, setPortAndToken, setPid } from "./registry.js";
+import { registerAgent, writePidFile, removePidFile } from "./registry.js";
 import { AgentServer } from "./server.js";
 import { PairingManager } from "./pairing.js";
 import { setMessageSender } from "./tools/message.js";
@@ -66,22 +66,25 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   const config = await loadConfig(agentDir);
 
   // Auto-generate auth token if missing
-  if (!process.env.KERN_AUTH_TOKEN) {
+  // Support both KERN_TOKEN (new) and KERN_AUTH_TOKEN (legacy)
+  if (!process.env.KERN_TOKEN && process.env.KERN_AUTH_TOKEN) {
+    process.env.KERN_TOKEN = process.env.KERN_AUTH_TOKEN;
+  }
+  if (!process.env.KERN_TOKEN) {
     const envPath = join(agentDir, ".kern", ".env");
-    // Check if token already exists in file (env might not have loaded it)
     let existingToken: string | null = null;
     try {
       const envContent = await readFile(envPath, "utf-8");
-      const match = envContent.match(/^KERN_AUTH_TOKEN=(.+)$/m);
+      const match = envContent.match(/^KERN_TOKEN=(.+)$/m) || envContent.match(/^KERN_AUTH_TOKEN=(.+)$/m);
       if (match) existingToken = match[1].trim();
     } catch {}
 
     if (existingToken) {
-      process.env.KERN_AUTH_TOKEN = existingToken;
+      process.env.KERN_TOKEN = existingToken;
     } else {
       const token = randomBytes(16).toString("hex");
-      await appendFile(envPath, `\nKERN_AUTH_TOKEN=${token}\n`);
-      process.env.KERN_AUTH_TOKEN = token;
+      await appendFile(envPath, `\nKERN_TOKEN=${token}\n`);
+      process.env.KERN_TOKEN = token;
       log("kern", `generated auth token: ${token.slice(0, 8)}...`);
     }
   }
@@ -111,7 +114,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   }
 
   const agentName = basename(agentDir);
-  await registerAgent(agentName, agentDir);
+  await registerAgent(agentDir);
   process.chdir(agentDir);
 
   // Initialize pairing
@@ -353,9 +356,9 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     };
   });
 
-  const port = await server.start("127.0.0.1");
-  await setPortAndToken(agentName, port, process.env.KERN_AUTH_TOKEN || null);
-  await setPid(agentName, process.pid);
+  const port = await server.start("0.0.0.0", config.port);
+  await registerAgent(agentDir);
+  await writePidFile(agentDir, process.pid);
 
   // Start Telegram if configured
   const telegramToken = process.env.TELEGRAM_BOT_TOKEN;
@@ -472,6 +475,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     await plugins.shutdown(pluginCtx);
     server.stop();
     memoryDB.close();
+    await removePidFile(agentDir);
     log("kern", `stopped ${agentName}`);
     process.exit(0);
   };

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,12 +3,12 @@ import { updateKernel } from "./kernel.js";
 import { TelegramInterface } from "./interfaces/telegram.js";
 import { SlackInterface } from "./interfaces/slack.js";
 import { CliInterface } from "./interfaces/cli.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, saveConfigField } from "./config.js";
 import { readFile, appendFile } from "fs/promises";
 import { join, basename } from "path";
 import { randomBytes } from "crypto";
 import type { Interface, MessageHandler } from "./interfaces/types.js";
-import { registerAgent, writePidFile, removePidFile } from "./registry.js";
+import { registerAgent, writePidFile, removePidFile, assignPort } from "./registry.js";
 import { AgentServer } from "./server.js";
 import { PairingManager } from "./pairing.js";
 import { setMessageSender } from "./tools/message.js";
@@ -350,6 +350,15 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
       hourly: memoryDB.getSessionHourlyActivity(sessionId),
     };
   });
+
+  // Assign a sticky port if none configured
+  if (!config.port) {
+    config.port = assignPort();
+    if (config.port > 0) {
+      await saveConfigField(agentDir, "port", config.port);
+      log("kern", `assigned sticky port ${config.port}`);
+    }
+  }
 
   const port = await server.start("0.0.0.0", config.port);
   await registerAgent(agentDir);

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,25 +66,21 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   const config = await loadConfig(agentDir);
 
   // Auto-generate auth token if missing
-  // Support both KERN_TOKEN (new) and KERN_AUTH_TOKEN (legacy)
-  if (!process.env.KERN_TOKEN && process.env.KERN_AUTH_TOKEN) {
-    process.env.KERN_TOKEN = process.env.KERN_AUTH_TOKEN;
-  }
-  if (!process.env.KERN_TOKEN) {
+  if (!process.env.KERN_AUTH_TOKEN) {
     const envPath = join(agentDir, ".kern", ".env");
     let existingToken: string | null = null;
     try {
       const envContent = await readFile(envPath, "utf-8");
-      const match = envContent.match(/^KERN_TOKEN=(.+)$/m) || envContent.match(/^KERN_AUTH_TOKEN=(.+)$/m);
+      const match = envContent.match(/^KERN_AUTH_TOKEN=(.+)$/m);
       if (match) existingToken = match[1].trim();
     } catch {}
 
     if (existingToken) {
-      process.env.KERN_TOKEN = existingToken;
+      process.env.KERN_AUTH_TOKEN = existingToken;
     } else {
       const token = randomBytes(16).toString("hex");
-      await appendFile(envPath, `\nKERN_TOKEN=${token}\n`);
-      process.env.KERN_TOKEN = token;
+      await appendFile(envPath, `\nKERN_AUTH_TOKEN=${token}\n`);
+      process.env.KERN_AUTH_TOKEN = token;
       log("kern", `generated auth token: ${token.slice(0, 8)}...`);
     }
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,6 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   }
 
   const agentName = basename(agentDir);
-  await registerAgent(agentDir);
   process.chdir(agentDir);
 
   // Initialize pairing

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { basename, resolve, join } from "path";
 import { existsSync } from "fs";
-import { findAgent, loadRegistry, registerAgent, isProcessRunning, setPid } from "./registry.js";
+import { findAgent, registerAgent, isProcessRunning, readPid, removePidFile } from "./registry.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -15,7 +15,7 @@ export async function backupAgent(nameOrPath?: string): Promise<void> {
     process.exit(1);
   }
 
-  const agent = await findAgent(nameOrPath);
+  const agent = findAgent(nameOrPath);
   if (!agent) {
     console.error(`Agent not found: ${nameOrPath}`);
     process.exit(1);
@@ -86,7 +86,7 @@ export async function restoreAgent(tarFile?: string): Promise<void> {
   console.log(`  ${dim(tarFile)} → ${targetDir}`);
 
   // Check if agent exists
-  const existing = await findAgent(folderName);
+  const existing = findAgent(folderName);
   if (existing || existsSync(targetDir)) {
     const { confirm } = await import("@inquirer/prompts");
     const existsWhere = existing ? `in registry (${existing.path})` : `at ${targetDir}`;
@@ -100,13 +100,16 @@ export async function restoreAgent(tarFile?: string): Promise<void> {
     }
 
     // Stop if running
-    if (existing?.pid && isProcessRunning(existing.pid)) {
-      try {
-        process.kill(existing.pid, "SIGTERM");
-        await setPid(folderName, null);
-        console.log(`  ${yellow("●")} stopped running agent`);
-      } catch {}
-      await new Promise((r) => setTimeout(r, 500));
+    if (existing) {
+      const pid = readPid(existing.path);
+      if (pid && isProcessRunning(pid)) {
+        try {
+          process.kill(pid, "SIGTERM");
+          await removePidFile(existing.path);
+          console.log(`  ${yellow("●")} stopped running agent`);
+        } catch {}
+        await new Promise((r) => setTimeout(r, 500));
+      }
     }
   }
 
@@ -120,7 +123,7 @@ export async function restoreAgent(tarFile?: string): Promise<void> {
   }
 
   // Register
-  await registerAgent(folderName, targetDir);
+  await registerAgent(targetDir);
   console.log(`  ${green("✓")} registered`);
 
   console.log("");

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { readFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { config as loadDotenv } from "dotenv";
 import { log } from "./log.js";
 
@@ -127,4 +127,18 @@ export async function loadConfig(agentDir: string): Promise<KernConfig> {
   } catch {
     return configDefaults;
   }
+}
+
+/**
+ * Write a single field into agent's .kern/config.json, preserving existing fields.
+ */
+export async function saveConfigField(agentDir: string, key: string, value: unknown): Promise<void> {
+  const configPath = join(agentDir, ".kern", "config.json");
+  let config: Record<string, unknown> = {};
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    config = JSON.parse(raw);
+  } catch {}
+  config[key] = value;
+  await writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export interface KernConfig {
   provider: string;
   toolScope: ToolScope;
   maxSteps: number;
+  port: number;
 
   // Context window
   maxContextTokens: number;
@@ -47,6 +48,7 @@ export const configDefaults: KernConfig = {
   provider: "openrouter",
   toolScope: "full",
   maxSteps: 30,
+  port: 0,
   maxContextTokens: 100000,
   maxToolResultChars: 20000,
   summaryBudget: 0.75,
@@ -64,6 +66,7 @@ const FIELD_TYPES: Record<string, string> = {
   provider: "string",
   toolScope: "string",
   maxSteps: "number",
+  port: "number",
   maxContextTokens: "number",
   maxToolResultChars: "number",
   summaryBudget: "number",

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -4,7 +4,7 @@ import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { join } from "path";
 import { openSync } from "fs";
-import { findAgent, loadRegistry, registerAgent, setPid, isProcessRunning } from "./registry.js";
+import { findAgent, loadRegistry, registerAgent, readAgentInfo, readPid, writePidFile, removePidFile, isProcessRunning } from "./registry.js";
 import { isServiceInstalled } from "./install.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
@@ -13,10 +13,10 @@ const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
 async function startOne(name: string, path: string): Promise<void> {
-  // Check if already running
-  const existing = await findAgent(name);
-  if (existing?.pid && isProcessRunning(existing.pid)) {
-    console.log(`  ${green("●")} ${bold(name)} already running ${dim(`(pid ${existing.pid})`)}`);
+  // Check if already running via PID file
+  const existingPid = readPid(path);
+  if (existingPid && isProcessRunning(existingPid)) {
+    console.log(`  ${green("●")} ${bold(name)} already running ${dim(`(pid ${existingPid})`)}`);
     return;
   }
 
@@ -44,8 +44,8 @@ async function startOne(name: string, path: string): Promise<void> {
   child.unref();
 
   const pid = child.pid!;
-  await registerAgent(name, path);
-  await setPid(name, pid);
+  await registerAgent(path);
+  await writePidFile(path, pid);
 
   // Wait and verify the process stays alive
   await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -60,7 +60,7 @@ async function startOne(name: string, path: string): Promise<void> {
       } catch {}
     }
   } else {
-    await setPid(name, null);
+    await removePidFile(path);
     console.log(`  ${red("●")} ${bold(name)} failed to start`);
     // Show last few lines of log
     try {
@@ -77,7 +77,7 @@ async function startOne(name: string, path: string): Promise<void> {
 export async function startAgent(nameOrPath?: string): Promise<void> {
   if (nameOrPath) {
     // Try registry first
-    let agent = await findAgent(nameOrPath);
+    let agent = findAgent(nameOrPath);
 
     if (!agent) {
       // Check if it's a directory path
@@ -85,8 +85,8 @@ export async function startAgent(nameOrPath?: string): Promise<void> {
       const dir = resolve(nameOrPath);
       if (existsSync(dir) && (existsSync(join(dir, ".kern")) || existsSync(join(dir, "AGENTS.md")))) {
         const name = basename(dir);
-        await registerAgent(name, dir);
-        agent = { name, path: dir, pid: null, addedAt: new Date().toISOString() };
+        await registerAgent(dir);
+        agent = { name, path: dir, port: 0, token: null, pid: null };
       }
     }
 
@@ -101,8 +101,8 @@ export async function startAgent(nameOrPath?: string): Promise<void> {
     console.log("");
   } else {
     // Start all registered agents
-    const agents = await loadRegistry();
-    if (agents.length === 0) {
+    const paths = await loadRegistry();
+    if (paths.length === 0) {
       console.error("No agents registered. Run 'kern init <name>' first.");
       process.exit(1);
       return;
@@ -110,35 +110,33 @@ export async function startAgent(nameOrPath?: string): Promise<void> {
     console.log("");
     console.log(`  ${bold("starting all agents")}`);
     console.log("");
-    for (const agent of agents) {
-      await startOne(agent.name, agent.path);
+    for (const agentPath of paths) {
+      const info = readAgentInfo(agentPath);
+      const name = info?.name || basename(agentPath);
+      await startOne(name, agentPath);
     }
     console.log("");
   }
 }
 
-async function stopOne(name: string): Promise<void> {
-  const agent = await findAgent(name);
-  if (!agent) {
-    console.log(`  ${dim("●")} ${bold(name)} not found`);
-    return;
-  }
+async function stopOne(name: string, agentPath: string): Promise<void> {
+  const pid = readPid(agentPath);
 
-  if (!agent.pid) {
+  if (!pid) {
     console.log(`  ${dim("●")} ${bold(name)} not running`);
     return;
   }
 
-  if (!isProcessRunning(agent.pid)) {
+  if (!isProcessRunning(pid)) {
     console.log(`  ${dim("●")} ${bold(name)} not running ${dim("(stale pid cleared)")}`);
-    await setPid(name, null);
+    await removePidFile(agentPath);
     return;
   }
 
   try {
-    process.kill(agent.pid, "SIGTERM");
-    await setPid(name, null);
-    console.log(`  ${red("●")} ${bold(name)} stopped ${dim(`(was pid ${agent.pid})`)}`);
+    process.kill(pid, "SIGTERM");
+    await removePidFile(agentPath);
+    console.log(`  ${red("●")} ${bold(name)} stopped ${dim(`(was pid ${pid})`)}`);
   } catch (e: any) {
     console.error(`  Failed to stop ${name}: ${e.message}`);
   }
@@ -146,13 +144,19 @@ async function stopOne(name: string): Promise<void> {
 
 export async function stopAgent(name?: string): Promise<void> {
   if (name) {
+    const agent = findAgent(name);
+    if (!agent) {
+      console.error(`Agent not found: ${name}`);
+      process.exit(1);
+      return;
+    }
     console.log("");
-    await stopOne(name);
+    await stopOne(agent.name, agent.path);
     console.log("");
   } else {
     // Stop all
-    const agents = await loadRegistry();
-    if (agents.length === 0) {
+    const paths = await loadRegistry();
+    if (paths.length === 0) {
       console.log("No agents registered.");
       process.exit(0);
       return;
@@ -160,8 +164,10 @@ export async function stopAgent(name?: string): Promise<void> {
     console.log("");
     console.log(`  ${bold("stopping all agents")}`);
     console.log("");
-    for (const agent of agents) {
-      await stopOne(agent.name);
+    for (const agentPath of paths) {
+      const info = readAgentInfo(agentPath);
+      const name = info?.name || basename(agentPath);
+      await stopOne(name, agentPath);
     }
     console.log("");
   }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -1,27 +1,80 @@
-import { readFile } from "fs/promises";
+import { readFile, writeFile, mkdir } from "fs/promises";
 import { join } from "path";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 
 export interface GlobalConfig {
   web_port: number;
   web_host: string;
+  agents: string[];
 }
 
 const defaults: GlobalConfig = {
   web_port: 9000,
   web_host: "0.0.0.0",
+  agents: [],
 };
 
-const CONFIG_FILE = join(homedir(), ".kern", "config.json");
+const KERN_DIR = join(homedir(), ".kern");
+const CONFIG_FILE = join(KERN_DIR, "config.json");
+const LEGACY_AGENTS_FILE = join(KERN_DIR, "agents.json");
 
 export async function loadGlobalConfig(): Promise<GlobalConfig> {
-  if (!existsSync(CONFIG_FILE)) return defaults;
+  // Migrate legacy agents.json → config.json on first load
+  await migrateLegacyAgents();
+
+  if (!existsSync(CONFIG_FILE)) return { ...defaults };
   try {
     const raw = await readFile(CONFIG_FILE, "utf-8");
     const userConfig = JSON.parse(raw);
     return { ...defaults, ...userConfig };
   } catch {
-    return defaults;
+    return { ...defaults };
   }
+}
+
+export function loadGlobalConfigSync(): GlobalConfig {
+  if (!existsSync(CONFIG_FILE)) return { ...defaults };
+  try {
+    const raw = readFileSync(CONFIG_FILE, "utf-8");
+    const userConfig = JSON.parse(raw);
+    return { ...defaults, ...userConfig };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+export async function saveGlobalConfig(config: GlobalConfig): Promise<void> {
+  await mkdir(KERN_DIR, { recursive: true });
+  await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Migrate legacy ~/.kern/agents.json (array of objects) into config.json agents field.
+ * Runs once — deletes agents.json after migration.
+ */
+async function migrateLegacyAgents(): Promise<void> {
+  if (!existsSync(LEGACY_AGENTS_FILE)) return;
+  try {
+    const raw = await readFile(LEGACY_AGENTS_FILE, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return;
+
+    // Extract paths from legacy object entries
+    const paths: string[] = parsed.map((entry: any) => entry.path).filter(Boolean);
+
+    // Load existing config and merge agents
+    let config = { ...defaults };
+    if (existsSync(CONFIG_FILE)) {
+      try {
+        const configRaw = await readFile(CONFIG_FILE, "utf-8");
+        config = { ...defaults, ...JSON.parse(configRaw) };
+      } catch {}
+    }
+    config.agents = paths;
+
+    await saveGlobalConfig(config);
+    const { unlink } = await import("fs/promises");
+    await unlink(LEGACY_AGENTS_FILE);
+  } catch {}
 }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
+import { readFile, writeFile, mkdir, unlink } from "fs/promises";
 import { join } from "path";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -74,7 +74,6 @@ async function migrateLegacyAgents(): Promise<void> {
     config.agents = paths;
 
     await saveGlobalConfig(config);
-    const { unlink } = await import("fs/promises");
     await unlink(LEGACY_AGENTS_FILE);
   } catch {}
 }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, mkdir, unlink } from "fs/promises";
 import { join } from "path";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
+import { log } from "./log.js";
 
 export interface GlobalConfig {
   web_port: number;
@@ -75,5 +76,8 @@ async function migrateLegacyAgents(): Promise<void> {
 
     await saveGlobalConfig(config);
     await unlink(LEGACY_AGENTS_FILE);
-  } catch {}
+    log("config", `migrated ${paths.length} agent(s) from agents.json → config.json`);
+  } catch (err) {
+    log.warn("config", `agents.json migration failed: ${err}`);
+  }
 }

--- a/src/import.ts
+++ b/src/import.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { mkdir, writeFile } from "fs/promises";
 import { homedir } from "os";
-import { findAgent, loadRegistry } from "./registry.js";
+import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
 import { log } from "./log.js";
 
 interface OpenCodeMessage {
@@ -248,7 +248,7 @@ export async function importOpenCode(args: string[]): Promise<void> {
   const agentArg = getFlag(args, "agent");
 
   if (agentArg) {
-    const agent = await findAgent(agentArg);
+    const agent = findAgent(agentArg);
     if (!agent) {
       console.error(`Agent not found: ${agentArg}`);
       db.close();
@@ -257,7 +257,8 @@ export async function importOpenCode(args: string[]): Promise<void> {
     agentPath = agent.path;
     agentName = agent.name;
   } else {
-    const agents = await loadRegistry();
+    const paths = await loadRegistry();
+    const agents = paths.map((p) => readAgentInfo(p)).filter(Boolean) as { name: string; path: string }[];
     if (agents.length === 0) {
       console.error("No agents registered. Run 'kern init <name>' first.");
       db.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { startApp } from "./app.js";
 import { runInit } from "./init.js";
 import { showStatus } from "./status.js";
 import { startAgent, stopAgent } from "./daemon.js";
-import { findAgent, loadRegistry } from "./registry.js";
+import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
 import { readFile } from "fs/promises";
 import { join } from "path";
 
@@ -52,7 +52,7 @@ async function showHelp() {
 async function resolveAgentDir(nameOrPath?: string): Promise<string> {
   if (nameOrPath) {
     // Check registry
-    const agent = await findAgent(nameOrPath);
+    const agent = findAgent(nameOrPath);
     if (agent) return agent.path;
 
     // Check path
@@ -66,21 +66,22 @@ async function resolveAgentDir(nameOrPath?: string): Promise<string> {
   }
 
   // No arg — auto-select
-  const agents = await loadRegistry();
-  if (agents.length === 0) {
+  const paths = await loadRegistry();
+  if (paths.length === 0) {
     console.error("No agents registered. Run 'kern init <name>' first.");
     process.exit(1);
   }
-  if (agents.length === 1) {
-    return agents[0].path;
+  if (paths.length === 1) {
+    return paths[0];
   }
 
   // Multiple agents — prompt to select
   const { select } = await import("@inquirer/prompts");
-  return select({
-    message: "Select agent",
-    choices: agents.map((a) => ({ name: a.name, value: a.path })),
+  const choices = paths.map((p) => {
+    const info = readAgentInfo(p);
+    return { name: info?.name || p, value: p };
   });
+  return select({ message: "Select agent", choices });
 }
 
 async function main() {
@@ -180,7 +181,7 @@ async function main() {
     }
     const { removeAgent, findAgent, isProcessRunning } = await import("./registry.js");
     const { stopAgent } = await import("./daemon.js");
-    const agent = await findAgent(name);
+    const agent = findAgent(name);
     if (!agent) {
       console.error(`Agent not found: ${name}`);
       process.exit(1);
@@ -278,7 +279,7 @@ async function main() {
     }
     const { findAgent } = await import("./registry.js");
     const { PairingManager } = await import("./pairing.js");
-    const agent = await findAgent(agentName);
+    const agent = findAgent(agentName);
     if (!agent) {
       console.error(`Agent not found: ${agentName}`);
       process.exit(1);
@@ -308,40 +309,41 @@ async function main() {
 
   if (cmd === "tui") {
     const { connectTui } = await import("./tui.js");
-    const { findAgent, loadRegistry } = await import("./registry.js");
+    const { findAgent, loadRegistry, readAgentInfo, isProcessRunning } = await import("./registry.js");
     const { startAgent } = await import("./daemon.js");
 
     let agentName = args[1];
 
     // Auto-select if no arg
     if (!agentName) {
-      const agents = await loadRegistry();
-      if (agents.length === 0) {
+      const paths = await loadRegistry();
+      if (paths.length === 0) {
         console.error("No agents registered. Run 'kern init <name>' first.");
         process.exit(1);
-      } else if (agents.length === 1) {
-        agentName = agents[0].name;
+      } else if (paths.length === 1) {
+        const info = readAgentInfo(paths[0]);
+        agentName = info?.name || paths[0];
       } else {
         const { select } = await import("@inquirer/prompts");
-        agentName = await select({
-          message: "Select agent",
-          choices: agents.map((a) => ({ name: a.name, value: a.name })),
+        const choices = paths.map((p) => {
+          const info = readAgentInfo(p);
+          return { name: info?.name || p, value: info?.name || p };
         });
+        agentName = await select({ message: "Select agent", choices });
       }
     }
 
     // Check if running, auto-start if not
-    let agent = await findAgent(agentName);
+    let agent = findAgent(agentName);
     if (!agent) {
       console.error(`Agent not found: ${agentName}`);
       process.exit(1);
     }
 
-    const { isProcessRunning } = await import("./registry.js");
     if (!agent.pid || !isProcessRunning(agent.pid)) {
       await startAgent(agentName);
       // Reload to get the port
-      agent = await findAgent(agentName);
+      agent = findAgent(agentName);
     }
 
     if (!agent?.port) {
@@ -349,10 +351,7 @@ async function main() {
       process.exit(1);
     }
 
-    // Read auth token from agents.json registry
-    const authToken = agent.token || undefined;
-
-    await connectTui(agent.port, agentName, authToken);
+    await connectTui(agent.port, agentName, agent.token || undefined);
     return;
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -296,7 +296,7 @@ async function runConfig(name: string, dir: string): Promise<void> {
 export async function runInit(targetArg?: string, flags?: Record<string, string>): Promise<void> {
   // Check if target is an existing agent — go straight to config
   if (targetArg && !flags) {
-    const registered = await findAgent(targetArg);
+    const registered = findAgent(targetArg);
     const dir = registered ? registered.path : resolve(targetArg);
     if (existsSync(dir) && (existsSync(join(dir, "AGENTS.md")) || existsSync(join(dir, ".kern")))) {
       await runConfig(registered?.name || targetArg, dir);

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile, readFile } from "fs/promises";
 import { join, resolve } from "path";
 import { existsSync } from "fs";
 import { input, select, password } from "@inquirer/prompts";
-import { registerAgent, findAgent, isProcessRunning, setPid } from "./registry.js";
+import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile } from "./registry.js";
 import { startAgent } from "./daemon.js";
 import type { KernConfig } from "./config.js";
 
@@ -277,12 +277,15 @@ async function runConfig(name: string, dir: string): Promise<void> {
   print("  ✓ Config updated");
 
   // Restart if running, otherwise start
-  const agent = await findAgent(name);
-  if (agent?.pid && isProcessRunning(agent.pid)) {
-    process.kill(agent.pid, "SIGTERM");
-    await setPid(name, null);
-    print("  ✓ Stopped");
-    await new Promise((r) => setTimeout(r, 500));
+  const agent = findAgent(name);
+  if (agent) {
+    const pid = readPid(agent.path);
+    if (pid && isProcessRunning(pid)) {
+      process.kill(pid, "SIGTERM");
+      await removePidFile(agent.path);
+      print("  ✓ Stopped");
+      await new Promise((r) => setTimeout(r, 500));
+    }
   }
 
   print("  ✓ Starting...");
@@ -534,7 +537,7 @@ node_modules/
   }
 
   // Register and start
-  await registerAgent(name, dir);
+  await registerAgent(dir);
   print("");
   print("  ✓ Starting...");
   print("");

--- a/src/init.ts
+++ b/src/init.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile, readFile } from "fs/promises";
 import { join, resolve } from "path";
 import { existsSync } from "fs";
 import { input, select, password } from "@inquirer/prompts";
-import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile } from "./registry.js";
+import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "./registry.js";
 import { startAgent } from "./daemon.js";
 import type { KernConfig } from "./config.js";
 
@@ -445,6 +445,7 @@ No knowledge files yet. Create files in \`knowledge/\` as you learn about your d
     model,
     provider,
     toolScope: "full",
+    port: assignPort(),
   };
   // .kern/.env
   const envLines: string[] = [];

--- a/src/install.ts
+++ b/src/install.ts
@@ -3,7 +3,8 @@ import { existsSync } from "fs";
 import { mkdir, writeFile, unlink, readFile } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
-import { loadRegistry, findAgent, isProcessRunning, setPid } from "./registry.js";
+import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "./registry.js";
+import { basename } from "path";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -134,12 +135,13 @@ async function installAgent(agentName: string, agentPath: string): Promise<void>
 
   // Stop PID-based daemon if running (but not if it's the systemd-managed process)
   if (!existsSync(unitPath)) {
-    const agent = await findAgent(agentName);
-    if (agent?.pid && isProcessRunning(agent.pid)) {
+    const agent = findAgent(agentName);
+    const pid = agent ? readPid(agent.path) : null;
+    if (pid && isProcessRunning(pid)) {
       try {
-        process.kill(agent.pid, "SIGTERM");
-        console.log(`  ${dim("stopped pid-based daemon")} ${dim(`(pid ${agent.pid})`)}`);
-        await setPid(agentName, null);
+        process.kill(pid, "SIGTERM");
+        console.log(`  ${dim("stopped pid-based daemon")} ${dim(`(pid ${pid})`)}`);
+        if (agent) await removePidFile(agent.path);
         await new Promise((r) => setTimeout(r, 1000));
       } catch {}
     }
@@ -229,26 +231,30 @@ export async function install(nameOrFlag?: string): Promise<void> {
     return;
   }
 
-  const agents = nameOrFlag
-    ? [await findAgent(nameOrFlag)].filter(Boolean)
-    : await loadRegistry();
-
-  if (agents.length === 0) {
-    if (nameOrFlag) {
+  let agentPaths: string[];
+  if (nameOrFlag) {
+    const agent = findAgent(nameOrFlag);
+    if (!agent) {
       console.error(`Agent not found: ${nameOrFlag}`);
-    } else {
-      console.error("No agents registered. Run 'kern init <name>' first.");
+      process.exit(1);
     }
-    process.exit(1);
+    agentPaths = [agent.path];
+  } else {
+    agentPaths = await loadRegistry();
+    if (agentPaths.length === 0) {
+      console.error("No agents registered. Run 'kern init <name>' first.");
+      process.exit(1);
+    }
   }
 
   w("");
   w(`  ${bold("installing kern services")}`);
   w("");
 
-  for (const agent of agents) {
-    if (!agent) continue;
-    await installAgent(agent.name, agent.path);
+  for (const agentPath of agentPaths) {
+    const info = readAgentInfo(agentPath);
+    const name = info?.name || basename(agentPath);
+    await installAgent(name, agentPath);
   }
 
   // Also install web if installing all
@@ -290,9 +296,11 @@ export async function uninstall(name?: string): Promise<void> {
     w(`  ${bold("uninstalling kern services")}`);
     w("");
 
-    const agents = await loadRegistry();
-    for (const agent of agents) {
-      await uninstallOne(serviceName(agent.name), agent.name);
+    const paths = await loadRegistry();
+    for (const agentPath of paths) {
+      const info = readAgentInfo(agentPath);
+      const name = info?.name || basename(agentPath);
+      await uninstallOne(serviceName(name), name);
     }
     await uninstallOne(WEB_SERVICE, "web");
   }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,10 +1,9 @@
 import { execSync, spawnSync } from "child_process";
 import { existsSync } from "fs";
 import { mkdir, writeFile, unlink, readFile } from "fs/promises";
-import { join } from "path";
+import { join, basename } from "path";
 import { homedir } from "os";
 import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "./registry.js";
-import { basename } from "path";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,9 +1,24 @@
 import { readFile, writeFile, mkdir } from "fs/promises";
-import { join } from "path";
-import { existsSync } from "fs";
+import { join, basename } from "path";
+import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
+import { config as loadDotenv } from "dotenv";
 
-export interface AgentEntry {
+/**
+ * Registry is a simple list of agent directory paths.
+ * All agent state (port, token, PID) lives in the agent's own .kern/ directory.
+ */
+
+export interface AgentInfo {
+  name: string;
+  path: string;
+  port: number;
+  token: string | null;
+  pid: number | null;
+}
+
+// Legacy format for migration
+interface LegacyAgentEntry {
   name: string;
   path: string;
   pid?: number | null;
@@ -19,87 +34,144 @@ async function ensureDir(): Promise<void> {
   await mkdir(KERN_DIR, { recursive: true });
 }
 
-export async function loadRegistry(): Promise<AgentEntry[]> {
+// --- Registry: list of paths ---
+
+export async function loadRegistry(): Promise<string[]> {
   if (!existsSync(AGENTS_FILE)) return [];
   try {
     const raw = await readFile(AGENTS_FILE, "utf-8");
-    return JSON.parse(raw);
+    const parsed = JSON.parse(raw);
+
+    // Migrate legacy format: array of objects → array of strings
+    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "object") {
+      const legacy = parsed as LegacyAgentEntry[];
+      const paths = legacy.map((a) => a.path);
+      await saveRegistry(paths);
+      // Migrate tokens to agent .env files
+      for (const entry of legacy) {
+        if (entry.token) {
+          await migrateTokenToAgent(entry.path, entry.token);
+        }
+      }
+      return paths;
+    }
+
+    return parsed as string[];
   } catch {
     return [];
   }
 }
 
-async function saveRegistry(agents: AgentEntry[]): Promise<void> {
+async function saveRegistry(paths: string[]): Promise<void> {
   await ensureDir();
-  await writeFile(AGENTS_FILE, JSON.stringify(agents, null, 2) + "\n", "utf-8");
+  await writeFile(AGENTS_FILE, JSON.stringify(paths, null, 2) + "\n", "utf-8");
 }
 
-export async function registerAgent(name: string, path: string): Promise<void> {
-  const agents = await loadRegistry();
-  const existing = agents.findIndex((a) => a.path === path);
-  if (existing >= 0) {
-    agents[existing].name = name;
-  } else {
-    agents.push({
-      name,
-      path,
-      pid: null,
-      addedAt: new Date().toISOString(),
-    });
-  }
-  await saveRegistry(agents);
+async function migrateTokenToAgent(agentPath: string, token: string): Promise<void> {
+  const envPath = join(agentPath, ".kern", ".env");
+  try {
+    if (existsSync(envPath)) {
+      const content = await readFile(envPath, "utf-8");
+      if (content.includes("KERN_TOKEN=")) return; // already has token
+      // Migrate old KERN_AUTH_TOKEN to KERN_TOKEN
+      if (content.includes("KERN_AUTH_TOKEN=")) return; // will be renamed on load
+    }
+    await mkdir(join(agentPath, ".kern"), { recursive: true });
+    const { appendFile } = await import("fs/promises");
+    await appendFile(envPath, `KERN_TOKEN=${token}\n`);
+  } catch {}
 }
 
-export async function findAgent(nameOrPath: string): Promise<AgentEntry | null> {
-  const agents = await loadRegistry();
-  return agents.find((a) => a.name === nameOrPath || a.path === nameOrPath) || null;
-}
-
-export async function setPid(nameOrPath: string, pid: number | null): Promise<void> {
-  const agents = await loadRegistry();
-  const agent = agents.find((a) => a.name === nameOrPath || a.path === nameOrPath);
-  if (agent) {
-    agent.pid = pid;
-    if (!pid) agent.port = null;
-    await saveRegistry(agents);
-  }
-}
-
-export async function setPort(nameOrPath: string, port: number | null): Promise<void> {
-  const agents = await loadRegistry();
-  const agent = agents.find((a) => a.name === nameOrPath || a.path === nameOrPath);
-  if (agent) {
-    agent.port = port;
-    await saveRegistry(agents);
-  }
-}
-
-export async function setToken(nameOrPath: string, token: string | null): Promise<void> {
-  const agents = await loadRegistry();
-  const agent = agents.find((a) => a.name === nameOrPath || a.path === nameOrPath);
-  if (agent) {
-    agent.token = token;
-    await saveRegistry(agents);
-  }
-}
-
-export async function setPortAndToken(nameOrPath: string, port: number | null, token: string | null): Promise<void> {
-  const agents = await loadRegistry();
-  const agent = agents.find((a) => a.name === nameOrPath || a.path === nameOrPath);
-  if (agent) {
-    agent.port = port;
-    agent.token = token;
-    await saveRegistry(agents);
+export async function registerAgent(path: string): Promise<void> {
+  const paths = await loadRegistry();
+  if (!paths.includes(path)) {
+    paths.push(path);
+    await saveRegistry(paths);
   }
 }
 
 export async function removeAgent(nameOrPath: string): Promise<boolean> {
-  const agents = await loadRegistry();
-  const idx = agents.findIndex((a) => a.name === nameOrPath || a.path === nameOrPath);
+  const paths = await loadRegistry();
+  // Try direct path match
+  let idx = paths.indexOf(nameOrPath);
+  // Try name match
+  if (idx < 0) {
+    for (let i = 0; i < paths.length; i++) {
+      const info = readAgentInfo(paths[i]);
+      if (info && info.name === nameOrPath) {
+        idx = i;
+        break;
+      }
+    }
+  }
   if (idx < 0) return false;
-  agents.splice(idx, 1);
-  await saveRegistry(agents);
+  paths.splice(idx, 1);
+  await saveRegistry(paths);
   return true;
+}
+
+// --- Agent info: read from agent's own .kern/ directory ---
+
+export function readAgentInfo(agentPath: string): AgentInfo | null {
+  if (!existsSync(agentPath)) return null;
+
+  const configPath = join(agentPath, ".kern", "config.json");
+  const envPath = join(agentPath, ".kern", ".env");
+  const pidPath = join(agentPath, ".kern", "agent.pid");
+
+  // Read config for name and port
+  let name = basename(agentPath);
+  let port = 0;
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(raw);
+    if (config.name) name = config.name;
+    if (config.port) port = config.port;
+  } catch {}
+
+  // Read token from .env
+  let token: string | null = null;
+  try {
+    const env = loadDotenv({ path: envPath, override: false });
+    // Check KERN_TOKEN first, fall back to legacy KERN_AUTH_TOKEN
+    token = env.parsed?.KERN_TOKEN || env.parsed?.KERN_AUTH_TOKEN || null;
+  } catch {}
+
+  // Read PID
+  let pid: number | null = null;
+  try {
+    const raw = readFileSync(pidPath, "utf-8").trim();
+    pid = parseInt(raw, 10);
+    if (isNaN(pid)) pid = null;
+  } catch {}
+
+  return { name, port, token, pid, path: agentPath };
+}
+
+export function findAgent(nameOrPath: string): AgentInfo | null {
+  let paths: string[];
+  try {
+    if (!existsSync(AGENTS_FILE)) return null;
+    const raw = readFileSync(AGENTS_FILE, "utf-8");
+    const parsed = JSON.parse(raw);
+    // Handle legacy format synchronously
+    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "object") {
+      paths = (parsed as LegacyAgentEntry[]).map((a) => a.path);
+    } else {
+      paths = parsed as string[];
+    }
+  } catch {
+    return null;
+  }
+
+  for (const p of paths) {
+    const info = readAgentInfo(p);
+    if (!info) continue;
+    if (info.name === nameOrPath || info.path === nameOrPath || p === nameOrPath) {
+      return info;
+    }
+  }
+  return null;
 }
 
 export function isProcessRunning(pid: number): boolean {
@@ -108,5 +180,32 @@ export function isProcessRunning(pid: number): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+// --- PID file management ---
+
+export async function writePidFile(agentDir: string, pid: number): Promise<void> {
+  const pidPath = join(agentDir, ".kern", "agent.pid");
+  await mkdir(join(agentDir, ".kern"), { recursive: true });
+  await writeFile(pidPath, String(pid), "utf-8");
+}
+
+export async function removePidFile(agentDir: string): Promise<void> {
+  const pidPath = join(agentDir, ".kern", "agent.pid");
+  try {
+    const { unlink } = await import("fs/promises");
+    await unlink(pidPath);
+  } catch {}
+}
+
+export function readPid(agentDir: string): number | null {
+  const pidPath = join(agentDir, ".kern", "agent.pid");
+  try {
+    const raw = readFileSync(pidPath, "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    return isNaN(pid) ? null : pid;
+  } catch {
+    return null;
   }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, unlink } from "fs/promises";
 import { join, basename } from "path";
 import { existsSync, readFileSync } from "fs";
-import { config as loadDotenv } from "dotenv";
+import { parse as parseDotenv } from "dotenv";
 import { loadGlobalConfig, loadGlobalConfigSync, saveGlobalConfig } from "./global-config.js";
 
 /**
@@ -74,8 +74,9 @@ export function readAgentInfo(agentPath: string): AgentInfo | null {
   // Read token from .env
   let token: string | null = null;
   try {
-    const env = loadDotenv({ path: envPath, override: false });
-    token = env.parsed?.KERN_AUTH_TOKEN || null;
+    const envRaw = readFileSync(envPath, "utf-8");
+    const env = parseDotenv(envRaw);
+    token = env.KERN_AUTH_TOKEN || null;
   } catch {}
 
   // Read PID

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
+import { readFile, writeFile, mkdir, unlink, appendFile } from "fs/promises";
 import { join, basename } from "path";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -77,7 +77,6 @@ async function migrateTokenToAgent(agentPath: string, token: string): Promise<vo
       if (content.includes("KERN_AUTH_TOKEN=")) return; // will be renamed on load
     }
     await mkdir(join(agentPath, ".kern"), { recursive: true });
-    const { appendFile } = await import("fs/promises");
     await appendFile(envPath, `KERN_TOKEN=${token}\n`);
   } catch {}
 }
@@ -194,7 +193,6 @@ export async function writePidFile(agentDir: string, pid: number): Promise<void>
 export async function removePidFile(agentDir: string): Promise<void> {
   const pidPath = join(agentDir, ".kern", "agent.pid");
   try {
-    const { unlink } = await import("fs/promises");
     await unlink(pidPath);
   } catch {}
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,12 +1,12 @@
-import { readFile, writeFile, mkdir, unlink } from "fs/promises";
+import { writeFile, mkdir, unlink } from "fs/promises";
 import { join, basename } from "path";
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
 import { config as loadDotenv } from "dotenv";
+import { loadGlobalConfig, loadGlobalConfigSync, saveGlobalConfig } from "./global-config.js";
 
 /**
- * Registry is a simple list of agent directory paths.
- * All agent state (port, token, PID) lives in the agent's own .kern/ directory.
+ * Agent registry backed by ~/.kern/config.json `agents` field.
+ * All agent runtime state (port, token, PID) lives in the agent's own .kern/ directory.
  */
 
 export interface AgentInfo {
@@ -17,46 +17,29 @@ export interface AgentInfo {
   pid: number | null;
 }
 
-const KERN_DIR = join(homedir(), ".kern");
-const AGENTS_FILE = join(KERN_DIR, "agents.json");
-
-async function ensureDir(): Promise<void> {
-  await mkdir(KERN_DIR, { recursive: true });
-}
-
-// --- Registry: list of paths ---
+// --- Registry: reads/writes config.agents ---
 
 export async function loadRegistry(): Promise<string[]> {
-  if (!existsSync(AGENTS_FILE)) return [];
-  try {
-    const raw = await readFile(AGENTS_FILE, "utf-8");
-    return JSON.parse(raw) as string[];
-  } catch {
-    return [];
-  }
-}
-
-async function saveRegistry(paths: string[]): Promise<void> {
-  await ensureDir();
-  await writeFile(AGENTS_FILE, JSON.stringify(paths, null, 2) + "\n", "utf-8");
+  const config = await loadGlobalConfig();
+  return config.agents;
 }
 
 export async function registerAgent(path: string): Promise<void> {
-  const paths = await loadRegistry();
-  if (!paths.includes(path)) {
-    paths.push(path);
-    await saveRegistry(paths);
+  const config = await loadGlobalConfig();
+  if (!config.agents.includes(path)) {
+    config.agents.push(path);
+    await saveGlobalConfig(config);
   }
 }
 
 export async function removeAgent(nameOrPath: string): Promise<boolean> {
-  const paths = await loadRegistry();
+  const config = await loadGlobalConfig();
   // Try direct path match
-  let idx = paths.indexOf(nameOrPath);
+  let idx = config.agents.indexOf(nameOrPath);
   // Try name match
   if (idx < 0) {
-    for (let i = 0; i < paths.length; i++) {
-      const info = readAgentInfo(paths[i]);
+    for (let i = 0; i < config.agents.length; i++) {
+      const info = readAgentInfo(config.agents[i]);
       if (info && info.name === nameOrPath) {
         idx = i;
         break;
@@ -64,8 +47,8 @@ export async function removeAgent(nameOrPath: string): Promise<boolean> {
     }
   }
   if (idx < 0) return false;
-  paths.splice(idx, 1);
-  await saveRegistry(paths);
+  config.agents.splice(idx, 1);
+  await saveGlobalConfig(config);
   return true;
 }
 
@@ -107,16 +90,9 @@ export function readAgentInfo(agentPath: string): AgentInfo | null {
 }
 
 export function findAgent(nameOrPath: string): AgentInfo | null {
-  let paths: string[];
-  try {
-    if (!existsSync(AGENTS_FILE)) return null;
-    const raw = readFileSync(AGENTS_FILE, "utf-8");
-    paths = JSON.parse(raw) as string[];
-  } catch {
-    return null;
-  }
+  const config = loadGlobalConfigSync();
 
-  for (const p of paths) {
+  for (const p of config.agents) {
     const info = readAgentInfo(p);
     if (!info) continue;
     if (info.name === nameOrPath || info.path === nameOrPath || p === nameOrPath) {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -102,6 +102,25 @@ export function findAgent(nameOrPath: string): AgentInfo | null {
   return null;
 }
 
+/**
+ * Assign a sticky port to an agent. Picks from 4100-4999, avoiding ports already used by other agents.
+ */
+export function assignPort(): number {
+  const config = loadGlobalConfigSync();
+  const usedPorts = new Set<number>();
+  for (const p of config.agents) {
+    const info = readAgentInfo(p);
+    if (info && info.port > 0) usedPorts.add(info.port);
+  }
+
+  for (let port = 4100; port <= 4999; port++) {
+    if (!usedPorts.has(port)) return port;
+  }
+
+  // Fallback: let OS assign
+  return 0;
+}
+
 export function isProcessRunning(pid: number): boolean {
   try {
     process.kill(pid, 0);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, unlink, appendFile } from "fs/promises";
+import { readFile, writeFile, mkdir, unlink } from "fs/promises";
 import { join, basename } from "path";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -17,16 +17,6 @@ export interface AgentInfo {
   pid: number | null;
 }
 
-// Legacy format for migration
-interface LegacyAgentEntry {
-  name: string;
-  path: string;
-  pid?: number | null;
-  port?: number | null;
-  token?: string | null;
-  addedAt: string;
-}
-
 const KERN_DIR = join(homedir(), ".kern");
 const AGENTS_FILE = join(KERN_DIR, "agents.json");
 
@@ -40,23 +30,7 @@ export async function loadRegistry(): Promise<string[]> {
   if (!existsSync(AGENTS_FILE)) return [];
   try {
     const raw = await readFile(AGENTS_FILE, "utf-8");
-    const parsed = JSON.parse(raw);
-
-    // Migrate legacy format: array of objects → array of strings
-    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "object") {
-      const legacy = parsed as LegacyAgentEntry[];
-      const paths = legacy.map((a) => a.path);
-      await saveRegistry(paths);
-      // Migrate tokens to agent .env files
-      for (const entry of legacy) {
-        if (entry.token) {
-          await migrateTokenToAgent(entry.path, entry.token);
-        }
-      }
-      return paths;
-    }
-
-    return parsed as string[];
+    return JSON.parse(raw) as string[];
   } catch {
     return [];
   }
@@ -65,20 +39,6 @@ export async function loadRegistry(): Promise<string[]> {
 async function saveRegistry(paths: string[]): Promise<void> {
   await ensureDir();
   await writeFile(AGENTS_FILE, JSON.stringify(paths, null, 2) + "\n", "utf-8");
-}
-
-async function migrateTokenToAgent(agentPath: string, token: string): Promise<void> {
-  const envPath = join(agentPath, ".kern", ".env");
-  try {
-    if (existsSync(envPath)) {
-      const content = await readFile(envPath, "utf-8");
-      if (content.includes("KERN_TOKEN=")) return; // already has token
-      // Migrate old KERN_AUTH_TOKEN to KERN_TOKEN
-      if (content.includes("KERN_AUTH_TOKEN=")) return; // will be renamed on load
-    }
-    await mkdir(join(agentPath, ".kern"), { recursive: true });
-    await appendFile(envPath, `KERN_TOKEN=${token}\n`);
-  } catch {}
 }
 
 export async function registerAgent(path: string): Promise<void> {
@@ -132,8 +92,7 @@ export function readAgentInfo(agentPath: string): AgentInfo | null {
   let token: string | null = null;
   try {
     const env = loadDotenv({ path: envPath, override: false });
-    // Check KERN_TOKEN first, fall back to legacy KERN_AUTH_TOKEN
-    token = env.parsed?.KERN_TOKEN || env.parsed?.KERN_AUTH_TOKEN || null;
+    token = env.parsed?.KERN_AUTH_TOKEN || null;
   } catch {}
 
   // Read PID
@@ -152,13 +111,7 @@ export function findAgent(nameOrPath: string): AgentInfo | null {
   try {
     if (!existsSync(AGENTS_FILE)) return null;
     const raw = readFileSync(AGENTS_FILE, "utf-8");
-    const parsed = JSON.parse(raw);
-    // Handle legacy format synchronously
-    if (Array.isArray(parsed) && parsed.length > 0 && typeof parsed[0] === "object") {
-      paths = (parsed as LegacyAgentEntry[]).map((a) => a.path);
-    } else {
-      paths = parsed as string[];
-    }
+    paths = JSON.parse(raw) as string[];
   } catch {
     return null;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -151,7 +151,7 @@ export class AgentServer {
   }
 
   private checkAuth(req: IncomingMessage): boolean {
-    const token = process.env.KERN_TOKEN || process.env.KERN_AUTH_TOKEN;
+    const token = process.env.KERN_AUTH_TOKEN;
     if (!token) return true; // shouldn't happen — token is always generated
 
     // Check Authorization: Bearer header

--- a/src/server.ts
+++ b/src/server.ts
@@ -107,9 +107,9 @@ export class AgentServer {
     this.currentSessionIdFn = fn;
   }
 
-  async start(host: string = "127.0.0.1"): Promise<number> {
+  async start(host: string = "0.0.0.0", port: number = 0): Promise<number> {
     return new Promise((resolve) => {
-      this.server.listen(0, host, () => {
+      this.server.listen(port, host, () => {
         this.port = (this.server.address() as any).port;
         log("server", `listening on ${host}:${this.port}`);
         resolve(this.port);
@@ -151,7 +151,7 @@ export class AgentServer {
   }
 
   private checkAuth(req: IncomingMessage): boolean {
-    const token = process.env.KERN_AUTH_TOKEN;
+    const token = process.env.KERN_TOKEN || process.env.KERN_AUTH_TOKEN;
     if (!token) return true; // shouldn't happen — token is always generated
 
     // Check Authorization: Bearer header

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,9 +1,9 @@
-import { loadRegistry, isProcessRunning } from "./registry.js";
+import { loadRegistry, readAgentInfo, isProcessRunning } from "./registry.js";
 import { getServiceStatus, getWebServiceStatus } from "./install.js";
 import { loadGlobalConfig } from "./global-config.js";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
-import { join } from "path";
+import { join, basename } from "path";
 import { homedir } from "os";
 
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
@@ -12,46 +12,50 @@ const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
 const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 
 export async function showStatus(): Promise<void> {
-  const agents = await loadRegistry();
+  const paths = await loadRegistry();
   const w = (s: string) => process.stdout.write(s + "\n");
 
   w("");
   w(`  ${bold("kern agents")}`);
   w("");
 
-  if (agents.length === 0) {
+  if (paths.length === 0) {
     w(`  ${dim("No agents registered. Run")} kern init <name> ${dim("to create one.")}`);
     w("");
     return;
   }
 
   let hasUninstalled = false;
-  for (const agent of agents) {
-    const exists = existsSync(agent.path);
-    const running = agent.pid ? isProcessRunning(agent.pid) : false;
-    const hasConfig = exists && existsSync(join(agent.path, ".kern", "config.json"));
+  for (const agentPath of paths) {
+    const exists = existsSync(agentPath);
+    const info = exists ? readAgentInfo(agentPath) : null;
+    const name = info?.name || basename(agentPath);
+    const running = info?.pid ? isProcessRunning(info.pid) : false;
 
     // Read config
     let model = "";
     let provider = "";
     let toolScope = "";
-    if (hasConfig) {
+    let configPort = 0;
+    const configPath = join(agentPath, ".kern", "config.json");
+    if (exists && existsSync(configPath)) {
       try {
-        const config = JSON.parse(await readFile(join(agent.path, ".kern", "config.json"), "utf-8"));
+        const config = JSON.parse(await readFile(configPath, "utf-8"));
         model = config.model || "";
         provider = config.provider || "";
         toolScope = config.toolScope || "";
+        configPort = config.port || 0;
       } catch {}
     }
 
-
-    const installStatus = getServiceStatus(agent.name);
+    const installStatus = getServiceStatus(name);
     const active = installStatus === "active" || running;
     const dot = !exists ? red("●") : active ? green("●") : dim("●");
-    const nameStr = bold(agent.name);
+    const nameStr = bold(name);
     const modelStr = provider && model ? dim(`${provider}/${model}`) : dim("no config");
-    const portStr = agent.port ? `:${agent.port}` : "";
-    const pidStr = agent.pid && (running || installStatus === "active") ? `pid ${agent.pid}` : "";
+    const port = info?.port || configPort;
+    const portStr = port ? `:${port}` : "";
+    const pidStr = info?.pid && (running || installStatus === "active") ? `pid ${info.pid}` : "";
     const details = [pidStr, portStr].filter(Boolean).join(", ");
     const statusStr = !exists
       ? red("not found")
@@ -62,12 +66,12 @@ export async function showStatus(): Promise<void> {
     if (!installStatus) hasUninstalled = true;
 
     w(`  ${dot} ${nameStr}  ${modelStr}  ${statusStr}`);
-    w(`    ${dim("path:")}  ${agent.path}`);
+    w(`    ${dim("path:")}  ${agentPath}`);
     w(`    ${dim("tools:")} ${toolScope || "—"}  ${dim("mode:")} ${mode}`);
     w("");
   }
 
-  // Web status — check PID first (reliable), systemd as supplementary
+  // Web status
   const config = await loadGlobalConfig();
   const webInstall = getWebServiceStatus();
   const pidFile = join(homedir(), ".kern", "web.pid");

--- a/src/web.ts
+++ b/src/web.ts
@@ -174,7 +174,7 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     const agents = await loadAgents();
     const result = agents.map((a) => ({
       name: a.name,
-      running: !!(a.pid && isProcessRunning(a.pid!)),
+      running: !!(a.pid && isProcessRunning(a.pid)),
     }));
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(result));
@@ -188,7 +188,7 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     const agents = await loadAgents();
     const agent = agents.find((a) => a.name === agentName);
 
-    if (!agent || !agent.port || !agent.pid || !isProcessRunning(agent.pid!)) {
+    if (!agent || !agent.port || !agent.pid || !isProcessRunning(agent.pid)) {
       res.writeHead(404, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "agent not found or not running" }));
       return;

--- a/src/web.ts
+++ b/src/web.ts
@@ -24,11 +24,10 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { homedir } from "os";
 import { randomBytes } from "crypto";
-import { isProcessRunning, type AgentEntry } from "./registry.js";
+import { loadRegistry, readAgentInfo, isProcessRunning, type AgentInfo } from "./registry.js";
 import { loadGlobalConfig } from "./global-config.js";
 
 const KERN_DIR = join(homedir(), ".kern");
-const AGENTS_FILE = join(KERN_DIR, "agents.json");
 const ENV_FILE = join(KERN_DIR, ".env");
 
 /** Load or auto-generate the web auth token from ~/.kern/.env */
@@ -48,13 +47,14 @@ async function getWebToken(): Promise<string> {
 
 let webToken: string;
 
-async function loadAgents(): Promise<AgentEntry[]> {
-  if (!existsSync(AGENTS_FILE)) return [];
-  try {
-    return JSON.parse(await readFile(AGENTS_FILE, "utf-8"));
-  } catch {
-    return [];
+async function loadAgents(): Promise<AgentInfo[]> {
+  const paths = await loadRegistry();
+  const agents: AgentInfo[] = [];
+  for (const p of paths) {
+    const info = readAgentInfo(p);
+    if (info) agents.push(info);
   }
+  return agents;
 }
 
 function log(msg: string) {
@@ -69,11 +69,11 @@ const staticFiles: Record<string, { file: string; contentType: string }> = {
 };
 
 /** Proxy a request to an agent's HTTP server, injecting its auth token */
-function proxyToAgent(req: IncomingMessage, res: ServerResponse, agent: AgentEntry, targetPath: string) {
+function proxyToAgent(req: IncomingMessage, res: ServerResponse, agent: AgentInfo, targetPath: string) {
   const proxyReq = httpRequest(
     {
       hostname: "127.0.0.1",
-      port: agent.port!,
+      port: agent.port,
       path: targetPath,
       method: req.method,
       headers: {
@@ -174,7 +174,7 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     const agents = await loadAgents();
     const result = agents.map((a) => ({
       name: a.name,
-      running: !!(a.pid && isProcessRunning(a.pid)),
+      running: !!(a.pid && isProcessRunning(a.pid!)),
     }));
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(result));
@@ -188,7 +188,7 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     const agents = await loadAgents();
     const agent = agents.find((a) => a.name === agentName);
 
-    if (!agent || !agent.port || !agent.pid || !isProcessRunning(agent.pid)) {
+    if (!agent || !agent.port || !agent.pid || !isProcessRunning(agent.pid!)) {
       res.writeHead(404, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "agent not found or not running" }));
       return;


### PR DESCRIPTION
## Self-contained agents (#126)

All agent runtime state now lives in the agent's own `.kern/` directory. The global `~/.kern/config.json` holds the agent list and web settings — one file for everything.

### Changes

**Global config (`~/.kern/config.json`)**
- New `agents: string[]` field — list of registered agent directory paths
- Legacy `agents.json` (object array) auto-migrates on first load and gets deleted
- Web settings (`web_port`, `web_host`) remain in the same file

**Agent-local state (`.kern/` per agent)**
- `config.json` — new `port` field for fixed port (default `0` = random)
- `.env` — `KERN_AUTH_TOKEN` (auto-generated on first start)
- `agent.pid` — PID file written on start, removed on stop

**Server**
- Binds `0.0.0.0` by default, enabling direct connections over Tailscale or LAN

### Files changed
- `src/global-config.ts` — `agents` field, save/sync functions, legacy migration
- `src/registry.ts` — reads/writes `config.agents` instead of separate file
- `src/app.ts` — writes PID file, registers agent path
- `src/server.ts` — binds `0.0.0.0` by default
- `src/daemon.ts`, `src/init.ts`, `src/index.ts`, `src/status.ts`, `src/web.ts`, `src/install.ts`, `src/backup.ts`, `src/import.ts` — updated to new registry API
- `docs/` — config, architecture, commands, interfaces docs updated