### PR TITLE
Port assignment: bind-check to avoid cross-user collisions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Each agent is a separate process. The web server is a separate process. They com
 - Runs the message queue, tool executor, and model calls
 - Serves SSE for real-time streaming to connected clients (TUI, web UI)
 
-The agent never binds to `0.0.0.0` — it's only reachable from localhost. All external access goes through the web proxy.
+Agents bind to `0.0.0.0` so they're reachable over the network (e.g. via Tailscale). The web proxy is optional — clients can connect directly if they have the agent's port and token.
 
 ### Agent HTTP endpoints
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -353,10 +353,10 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
 
   // Assign a sticky port if none configured
   if (!config.port) {
-    config.port = assignPort();
+    config.port = await assignPort();
     if (config.port > 0) {
       await saveConfigField(agentDir, "port", config.port);
-      log("kern", `assigned sticky port ${config.port}`);
+      log("kern", `assigned sticky port :${config.port}`);
     }
   }
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -51,7 +51,9 @@ async function startOne(name: string, path: string): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   if (isProcessRunning(pid)) {
-    console.log(`  ${green("●")} ${bold(name)} started ${dim(`(pid ${pid})`)}`);
+    const info = readAgentInfo(path);
+    const portStr = info?.port ? `, :${info.port}` : "";
+    console.log(`  ${green("●")} ${bold(name)} started ${dim(`(pid ${pid}${portStr})`)}`);
     if (!isServiceInstalled(name)) {
       try {
         const { execSync } = await import("child_process");

--- a/src/init.ts
+++ b/src/init.ts
@@ -445,7 +445,7 @@ No knowledge files yet. Create files in \`knowledge/\` as you learn about your d
     model,
     provider,
     toolScope: "full",
-    port: assignPort(),
+    port: await assignPort(),
   };
   // .kern/.env
   const envLines: string[] = [];

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,8 +1,10 @@
 import { writeFile, mkdir, unlink } from "fs/promises";
 import { join, basename } from "path";
 import { existsSync, readFileSync } from "fs";
+import { createServer } from "net";
 import { parse as parseDotenv } from "dotenv";
 import { loadGlobalConfig, loadGlobalConfigSync, saveGlobalConfig } from "./global-config.js";
+import { log } from "./log.js";
 
 /**
  * Agent registry backed by ~/.kern/config.json `agents` field.
@@ -104,21 +106,42 @@ export function findAgent(nameOrPath: string): AgentInfo | null {
 }
 
 /**
- * Assign a sticky port to an agent. Picks from 4100-4999, avoiding ports already used by other agents.
+ * Check if a port is available by attempting to bind it.
  */
-export function assignPort(): number {
+function checkPort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.once("error", () => resolve(false));
+    srv.listen(port, "0.0.0.0", () => {
+      srv.close(() => resolve(true));
+    });
+  });
+}
+
+/**
+ * Assign a sticky port to an agent. Picks from 4100-4999, skipping registry-known ports
+ * and bind-checking to avoid cross-user collisions.
+ */
+export async function assignPort(): Promise<number> {
   const config = loadGlobalConfigSync();
-  const usedPorts = new Set<number>();
+  const knownPorts = new Set<number>();
   for (const p of config.agents) {
     const info = readAgentInfo(p);
-    if (info && info.port > 0) usedPorts.add(info.port);
+    if (info && info.port > 0) knownPorts.add(info.port);
   }
 
   for (let port = 4100; port <= 4999; port++) {
-    if (!usedPorts.has(port)) return port;
+    if (knownPorts.has(port)) continue;
+    if (await checkPort(port)) {
+      if (port > 4100) {
+        log("kern", `assigned port ${port} (${port - 4100} skipped)`);
+      }
+      return port;
+    }
+    log.debug("kern", `port ${port} in use, trying ${port + 1}`);
   }
 
-  // Fallback: let OS assign
+  log.warn("kern", "port range 4100-4999 exhausted, falling back to OS-assigned port");
   return 0;
 }
 


### PR DESCRIPTION
Fixes #129

`assignPort()` now bind-checks candidate ports instead of only scanning the current user's registry.

### Changes
- **registry.ts**: `assignPort()` is now async, attempts `net.createServer().listen()` on each candidate port
  - Skips registry-known ports first (fast path)
  - Bind-checks remaining candidates (catches cross-user collisions)
  - Debug logs per skipped port, info log for final assignment
  - Warns on range exhaustion, falls back to OS-assigned port 0
- **app.ts / init.ts**: `await assignPort()`

### Test
```
$ node -e "require('./dist/registry.js').assignPort().then(p => console.log(p))"
DBG [kern] port 4100 in use, trying 4101
DBG [kern] port 4101 in use, trying 4102  
DBG [kern] port 4102 in use, trying 4103
[kern] assigned port 4103 (3 skipped)
4103
```
Root user correctly detected kern user's 4100-4102 and assigned 4103.