### PR TITLE
feat: direct agent connections (#124)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -34,9 +34,8 @@ export default function Home() {
 
   // Register memory inspector tabs as modal surfaces
   useMemorySurfaces({
-    agentName: activeAgent?.name || "",
+    baseUrl: activeAgent?.baseUrl || "",
     token: activeAgent?.token || null,
-    serverUrl: activeAgent?.serverUrl,
   });
 
   const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true });
@@ -178,7 +177,7 @@ export default function Home() {
             {activeAgent && renderPluginHeaders({
               agentName: activeAgent.name,
               token: activeAgent.token,
-              serverUrl: activeAgent.serverUrl,
+              baseUrl: activeAgent.baseUrl,
             })}
             <button
               onClick={() => setModalSurface(MEMORY_SURFACE_ID)}
@@ -201,7 +200,7 @@ export default function Home() {
           thinking={thinking}
           agentName={activeAgent?.name}
           token={activeAgent?.token ?? undefined}
-          serverUrl={activeAgent?.serverUrl}
+          baseUrl={activeAgent?.baseUrl}
           layout={prefs.chatLayout}
           showTools={prefs.showTools}
           coloredTools={prefs.coloredTools}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -21,7 +21,7 @@ import type { Attachment } from "../lib/types";
 export default function Home() {
   const { token, setToken } = useAuth();
   const validToken = token ?? null;
-  const { agents, activeAgent, active, setActive, addServer, removeServer } = useServers(validToken);
+  const { agents, activeAgent, active, setActive, addServer, removeServer, addDirectAgent, removeDirectAgent } = useServers(validToken);
   const [dragOver, setDragOver] = useState(false);
   const [externalAttachments, setExternalAttachments] = useState<Attachment[]>([]);
   const { prefs, setPrefs } = usePreferences();
@@ -128,6 +128,8 @@ export default function Home() {
         onLogout={handleLogout}
         onAddServer={addServer}
         onRemoveServer={removeServer}
+        onAddDirectAgent={addDirectAgent}
+        onRemoveDirectAgent={removeDirectAgent}
       />
 
       <div

--- a/web/components/Chat.tsx
+++ b/web/components/Chat.tsx
@@ -10,7 +10,7 @@ export interface ChatProps {
   thinking: boolean;
   agentName?: string;
   token?: string;
-  serverUrl?: string;
+  baseUrl?: string;
   layout: "bubble" | "flat";
   showTools?: boolean;
   coloredTools?: boolean;
@@ -20,8 +20,8 @@ export interface ChatProps {
   loadingMore?: boolean;
 }
 
-export function Chat({ messages, streamParts, thinking, agentName, token, serverUrl, layout, showTools = true, coloredTools = true, peekLastTool = true, loadMore, hasMore, loadingMore }: ChatProps) {
-  const shared = { messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore };
+export function Chat({ messages, streamParts, thinking, agentName, token, baseUrl, layout, showTools = true, coloredTools = true, peekLastTool = true, loadMore, hasMore, loadingMore }: ChatProps) {
+  const shared = { messages, streamParts, thinking, agentName, token, baseUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore };
 
   if (layout === "flat") {
     return <FlatLayout {...shared} />;

--- a/web/components/MessageContent.tsx
+++ b/web/components/MessageContent.tsx
@@ -5,12 +5,11 @@ import type { MessageProps } from "../lib/messages";
 import { renderMarkdown } from "../lib/markdown";
 import { formatTime } from "../lib/messages";
 
-export function MediaAttachments({ media, agentName, token, serverUrl }: { media: MediaItem[]; agentName?: string; token?: string; serverUrl?: string }) {
+export function MediaAttachments({ media, baseUrl, token }: { media: MediaItem[]; baseUrl?: string; token?: string }) {
   if (!media.length) return null;
   const qs = token ? `?token=${token}` : "";
-  const base = serverUrl ? `${serverUrl}/api/agents/${agentName}` : `/api/agents/${agentName}`;
   const resolveUrl = (url: string) =>
-    url.startsWith("data:") ? url : `${base}/media/${url}${qs}`;
+    url.startsWith("data:") ? url : `${baseUrl}/media/${url}${qs}`;
   return (
     <div className="flex flex-wrap gap-2 mt-1">
       {media.map((m, i) =>

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -75,12 +75,18 @@ interface SidebarProps {
   onLogout?: () => void;
   onAddServer?: (url: string, token: string) => void;
   onRemoveServer?: (url: string) => void;
+  onAddDirectAgent?: (name: string, url: string, token: string) => void;
+  onRemoveDirectAgent?: (url: string) => void;
 }
 
-export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, onAddServer, onRemoveServer }: SidebarProps) {
+export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, onAddServer, onRemoveServer, onAddDirectAgent, onRemoveDirectAgent }: SidebarProps) {
   const [showAddModal, setShowAddModal] = useState(false);
+  const [showAddAgentModal, setShowAddAgentModal] = useState(false);
   const [newUrl, setNewUrl] = useState("");
   const [newToken, setNewToken] = useState("");
+  const [newAgentName, setNewAgentName] = useState("");
+  const [newAgentUrl, setNewAgentUrl] = useState("");
+  const [newAgentToken, setNewAgentToken] = useState("");
 
   // Mini/full state persisted in localStorage
   const [mini, setMini] = useState(() => {
@@ -113,11 +119,23 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
     return () => window.removeEventListener("resize", check);
   }, [userSet]);
 
-  // Group agents by server origin
-  const grouped = new Map<string, AgentInfo[]>();
+  // Check if an agent is a direct connection (not from a proxy)
+  const isDirectAgent = (agent: AgentInfo) => !agent.baseUrl.includes("/api/agents/");
+
+  // Separate proxy agents and direct agents
+  const proxyAgents: AgentInfo[] = [];
+  const directAgentList: AgentInfo[] = [];
   for (const agent of agents) {
-    // Extract server origin from baseUrl: "http://host:port/api/agents/name" → "http://host:port"
-    // Local proxy agents have baseUrl like "/api/agents/name" → "local"
+    if (isDirectAgent(agent)) {
+      directAgentList.push(agent);
+    } else {
+      proxyAgents.push(agent);
+    }
+  }
+
+  // Group proxy agents by server origin
+  const grouped = new Map<string, AgentInfo[]>();
+  for (const agent of proxyAgents) {
     const match = agent.baseUrl.match(/^(https?:\/\/[^/]+)/);
     const server = match ? match[1] : "local";
     if (!grouped.has(server)) grouped.set(server, []);
@@ -130,6 +148,15 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
     setNewUrl("");
     setNewToken("");
     setShowAddModal(false);
+  }
+
+  function handleAddAgent() {
+    if (!newAgentName.trim() || !newAgentUrl.trim()) return;
+    onAddDirectAgent?.(newAgentName.trim(), newAgentUrl.trim().replace(/\/$/, ""), newAgentToken.trim());
+    setNewAgentName("");
+    setNewAgentUrl("");
+    setNewAgentToken("");
+    setShowAddAgentModal(false);
   }
 
   // Get the active agent name for plugin sidebar context
@@ -197,13 +224,58 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
           </div>
         ))}
 
+        {/* Direct agents */}
+        {directAgentList.length > 0 && (
+          <div className="mb-1.5">
+            {directAgentList.map((agent) => {
+              const key = agentKey(agent);
+              return (
+                <div key={key} className="relative group">
+                  <AgentRow
+                    agent={agent}
+                    isActive={key === active}
+                    activeThinking={key === active ? activeThinking : undefined}
+                    mini={mini}
+                    onSelect={() => onSelect(key)}
+                  />
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onRemoveDirectAgent?.(agent.baseUrl); }}
+                    className="absolute top-2 right-2 text-[10px] text-[var(--text-muted)] hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                    title="Remove agent"
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
         {agents.length === 0 && (
           <div className="text-xs text-[var(--text-muted)] px-2 py-4">
             No agents found.
           </div>
         )}
 
-        {/* Add server row — after agents */}
+        {/* Add agent row */}
+        <button
+          onClick={() => setShowAddAgentModal(true)}
+          className="flex items-center gap-2.5 w-full rounded-lg text-sm text-left transition-colors cursor-pointer p-2.5 mb-0.5 overflow-hidden hover:bg-white/[0.05]"
+          title="Add agent"
+        >
+          <div className="relative flex-shrink-0">
+            <div className="w-10 h-10 flex items-center justify-center border border-dashed border-[var(--text-muted)]"
+              style={{ borderRadius: "22%" }}>
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round">
+                <line x1="8" y1="4" x2="8" y2="12" />
+                <line x1="4" y1="8" x2="12" y2="8" />
+              </svg>
+            </div>
+          </div>
+          <span className="text-[var(--text-muted)] text-xs whitespace-nowrap">Add agent</span>
+        </button>
+
+        {/* Add server row */}
         <button
           onClick={() => setShowAddModal(true)}
           className="flex items-center gap-2.5 w-full rounded-lg text-sm text-left transition-colors cursor-pointer p-2.5 mb-0.5 overflow-hidden hover:bg-white/[0.05]"
@@ -212,9 +284,11 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
           <div className="relative flex-shrink-0">
             <div className="w-10 h-10 flex items-center justify-center border border-dashed border-[var(--text-muted)]"
               style={{ borderRadius: "22%" }}>
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round">
-                <line x1="8" y1="4" x2="8" y2="12" />
-                <line x1="4" y1="8" x2="12" y2="8" />
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round">
+                <rect x="2" y="3" width="12" height="4" rx="1" />
+                <rect x="2" y="9" width="12" height="4" rx="1" />
+                <circle cx="5" cy="5" r="0.5" fill="var(--text-muted)" />
+                <circle cx="5" cy="11" r="0.5" fill="var(--text-muted)" />
               </svg>
             </div>
           </div>
@@ -271,6 +345,51 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
               <button
                 onClick={handleAddServer}
                 disabled={!newUrl.trim()}
+                className="text-xs bg-[var(--accent)] text-white px-3 py-1.5 rounded disabled:opacity-30 hover:opacity-90"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Add agent modal */}
+      {showAddAgentModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowAddAgentModal(false)}>
+          <div className="bg-[var(--bg-surface)] border border-[var(--border)] rounded-lg p-4 w-80" onClick={(e) => e.stopPropagation()}>
+            <div className="text-sm font-semibold mb-3">Add Agent</div>
+            <input
+              type="text"
+              placeholder="Agent name"
+              value={newAgentName}
+              onChange={(e) => setNewAgentName(e.target.value)}
+              className="w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded mb-2 text-[var(--text)] placeholder-[var(--text-muted)] outline-none focus:border-[var(--accent-dim)]"
+            />
+            <input
+              type="text"
+              placeholder="Agent URL (e.g. http://host:4000)"
+              value={newAgentUrl}
+              onChange={(e) => setNewAgentUrl(e.target.value)}
+              className="w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded mb-2 text-[var(--text)] placeholder-[var(--text-muted)] outline-none focus:border-[var(--accent-dim)]"
+            />
+            <input
+              type="password"
+              placeholder="Access token"
+              value={newAgentToken}
+              onChange={(e) => setNewAgentToken(e.target.value)}
+              className="w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded mb-3 text-[var(--text)] placeholder-[var(--text-muted)] outline-none focus:border-[var(--accent-dim)]"
+            />
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setShowAddAgentModal(false)}
+                className="text-xs text-[var(--text-muted)] hover:text-[var(--text-dim)] px-3 py-1.5"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAddAgent}
+                disabled={!newAgentName.trim() || !newAgentUrl.trim()}
                 className="text-xs bg-[var(--accent)] text-white px-3 py-1.5 rounded disabled:opacity-30 hover:opacity-90"
               >
                 Add

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -113,10 +113,13 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onLogout, on
     return () => window.removeEventListener("resize", check);
   }, [userSet]);
 
-  // Group agents by server
+  // Group agents by server origin
   const grouped = new Map<string, AgentInfo[]>();
   for (const agent of agents) {
-    const server = agent.serverUrl || "local";
+    // Extract server origin from baseUrl: "http://host:port/api/agents/name" → "http://host:port"
+    // Local proxy agents have baseUrl like "/api/agents/name" → "local"
+    const match = agent.baseUrl.match(/^(https?:\/\/[^/]+)/);
+    const server = match ? match[1] : "local";
     if (!grouped.has(server)) grouped.set(server, []);
     grouped.get(server)!.push(agent);
   }

--- a/web/components/inspector/ContextTab.tsx
+++ b/web/components/inspector/ContextTab.tsx
@@ -49,15 +49,15 @@ function parsePromptSections(prompt: string): PromptSectionData[] {
 }
 
 // ─── Context Tab ────────────────────────────────────────
-export function ContextTab({ agentName, token, serverUrl }: TabProps) {
+export function ContextTab({ baseUrl, token }: TabProps) {
   const [prompt, setPrompt] = useState<string | null>(null);
   const [status, setStatus] = useState<any>(null);
   const [view, setView] = useState<"structured" | "raw">("structured");
 
   useEffect(() => {
-    api.getSystemPrompt(agentName, token, serverUrl).then(setPrompt).catch(() => {});
-    api.getStatus(agentName, token, serverUrl).then(setStatus).catch(() => {});
-  }, [agentName, token, serverUrl]);
+    api.getSystemPrompt(baseUrl, token).then(setPrompt).catch(() => {});
+    api.getStatus(baseUrl, token).then(setStatus).catch(() => {});
+  }, [baseUrl, token]);
 
   if (prompt === null) return <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>;
 

--- a/web/components/inspector/MediaTab.tsx
+++ b/web/components/inspector/MediaTab.tsx
@@ -20,16 +20,16 @@ function formatBytes(bytes: number) {
   return (bytes / 1048576).toFixed(1) + " MB";
 }
 
-export function MediaTab({ agentName, token, serverUrl }: TabProps) {
+export function MediaTab({ baseUrl, token }: TabProps) {
   const [data, setData] = useState<{ files: any[]; stats: any } | null>(null);
   const [filter, setFilter] = useState<"all" | "images" | "documents">("all");
   const [selected, setSelected] = useState<any>(null);
 
   useEffect(() => {
-    api.getMediaList(agentName, token, serverUrl)
+    api.getMediaList(baseUrl, token)
       .then((d) => setData(d || { files: [], stats: {} }))
       .catch(() => setData({ files: [], stats: {} }));
-  }, [agentName, token, serverUrl]);
+  }, [baseUrl, token]);
 
   if (!data) return <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>;
 
@@ -42,8 +42,7 @@ export function MediaTab({ agentName, token, serverUrl }: TabProps) {
     : files;
 
   const mediaUrl = (file: string) => {
-    const base = serverUrl ? `${serverUrl}/api/agents/${agentName}` : `/api/agents/${agentName}`;
-    return `${base}/media/${file}${token ? "?token=" + encodeURIComponent(token) : ""}`;
+    return `${baseUrl}/media/${file}${token ? "?token=" + encodeURIComponent(token) : ""}`;
   };
 
   return (

--- a/web/components/inspector/NotesTab.tsx
+++ b/web/components/inspector/NotesTab.tsx
@@ -5,16 +5,16 @@ import * as api from "../../lib/api";
 import { renderMarkdown } from "../../lib/markdown";
 import { TabProps, accent, ActionBtn, EmptyState } from "./shared";
 
-export function NotesTab({ agentName, token, serverUrl }: TabProps) {
+export function NotesTab({ baseUrl, token }: TabProps) {
   const [summaries, setSummaries] = useState<any[] | null>(null);
   const [regenerating, setRegenerating] = useState(false);
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
 
   const load = useCallback(() => {
-    api.getSummaries(agentName, token, serverUrl).then((d) => {
+    api.getSummaries(baseUrl, token).then((d) => {
       setSummaries(Array.isArray(d) ? d : (d?.summaries || []));
     }).catch(() => setSummaries([]));
-  }, [agentName, token, serverUrl]);
+  }, [baseUrl, token]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -35,7 +35,7 @@ export function NotesTab({ agentName, token, serverUrl }: TabProps) {
         <ActionBtn
           onClick={() => {
             setRegenerating(true);
-            api.regenerateSummary(agentName, token, serverUrl).then(load).finally(() => setRegenerating(false));
+            api.regenerateSummary(baseUrl, token).then(load).finally(() => setRegenerating(false));
           }}
           disabled={regenerating}
         >

--- a/web/components/inspector/RecallTab.tsx
+++ b/web/components/inspector/RecallTab.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import * as api from "../../lib/api";
 import { TabProps, accent, StatCard, ActionBtn, EmptyState } from "./shared";
 
-export function RecallTab({ agentName, token, serverUrl }: TabProps) {
+export function RecallTab({ baseUrl, token }: TabProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<any[] | null>(null);
   const [stats, setStats] = useState<any>(null);
@@ -12,14 +12,14 @@ export function RecallTab({ agentName, token, serverUrl }: TabProps) {
   const [expandedResults, setExpandedResults] = useState<Set<number>>(new Set());
 
   useEffect(() => {
-    api.getRecallStats(agentName, token, serverUrl).then(setStats).catch(() => setStats(null));
-  }, [agentName, token, serverUrl]);
+    api.getRecallStats(baseUrl, token).then(setStats).catch(() => setStats(null));
+  }, [baseUrl, token]);
 
   const search = () => {
     if (!query.trim()) return;
     setSearching(true);
     setExpandedResults(new Set());
-    api.recallSearch(agentName, token, serverUrl, query)
+    api.recallSearch(baseUrl, token, query)
       .then((d) => setResults(d?.results || []))
       .catch(() => setResults([]))
       .finally(() => setSearching(false));

--- a/web/components/inspector/SegmentsTab.tsx
+++ b/web/components/inspector/SegmentsTab.tsx
@@ -5,7 +5,7 @@ import * as api from "../../lib/api";
 import { renderMarkdown } from "../../lib/markdown";
 import { TabProps, accent, accentDim, StatCard, ActionBtn, EmptyState } from "./shared";
 
-export function SegmentsTab({ agentName, token, serverUrl }: TabProps) {
+export function SegmentsTab({ baseUrl, token }: TabProps) {
   const [segments, setSegments] = useState<any>(null);
   const [contextIds, setContextIds] = useState<Set<number>>(new Set());
   const [filter, setFilter] = useState<"all" | "context">("context");
@@ -14,11 +14,11 @@ export function SegmentsTab({ agentName, token, serverUrl }: TabProps) {
   const [resummarizing, setResummarizing] = useState(false);
 
   const load = useCallback(() => {
-    api.getSegments(agentName, token, serverUrl).then(setSegments).catch(() => setSegments({ segments: [] }));
-    api.getContextSegments(agentName, token, serverUrl).then((d) => {
+    api.getSegments(baseUrl, token).then(setSegments).catch(() => setSegments({ segments: [] }));
+    api.getContextSegments(baseUrl, token).then((d) => {
       if (d?.segments) setContextIds(new Set(d.segments.map((s: any) => s.id)));
     }).catch(() => {});
-  }, [agentName, token, serverUrl]);
+  }, [baseUrl, token]);
 
   useEffect(() => { load(); }, [load]);
   useEffect(() => { const iv = setInterval(load, 5000); return () => clearInterval(iv); }, [load]);
@@ -61,7 +61,7 @@ export function SegmentsTab({ agentName, token, serverUrl }: TabProps) {
           </div>
           <div style={{ display: "flex", gap: 6 }}>
             <ActionBtn
-              onClick={() => { if (confirm("Rebuild segments from scratch?")) { setRebuilding(true); api.rebuildSegments(agentName, token, serverUrl).finally(() => { setRebuilding(false); load(); }); } }}
+              onClick={() => { if (confirm("Rebuild segments from scratch?")) { setRebuilding(true); api.rebuildSegments(baseUrl, token).finally(() => { setRebuilding(false); load(); }); } }}
               disabled={rebuilding}
             >
               ↻ {rebuilding ? "Rebuilding…" : "Rebuild"}
@@ -156,7 +156,7 @@ export function SegmentsTab({ agentName, token, serverUrl }: TabProps) {
               <ActionBtn
                 onClick={() => {
                   setResummarizing(true);
-                  api.resummarizeSegment(agentName, token, serverUrl, selected.id)
+                  api.resummarizeSegment(baseUrl, token, selected.id)
                     .then(load)
                     .finally(() => setResummarizing(false));
                 }}

--- a/web/components/inspector/SessionsTab.tsx
+++ b/web/components/inspector/SessionsTab.tsx
@@ -41,13 +41,13 @@ function ActivityChart({ data, color, label }: { data: { key: string; count: num
   );
 }
 
-export function SessionsTab({ agentName, token, serverUrl }: TabProps) {
+export function SessionsTab({ baseUrl, token }: TabProps) {
   const [data, setData] = useState<{ sessions: any[]; currentSessionId: string | null } | null>(null);
   const [activity, setActivity] = useState<any>(null);
   const [activeSession, setActiveSession] = useState<string | null>(null);
 
   useEffect(() => {
-    api.getSessions(agentName, token, serverUrl).then((d) => {
+    api.getSessions(baseUrl, token).then((d) => {
       if (d?.sessions) {
         setData(d);
         setActiveSession(d.currentSessionId || d.sessions?.[0]?.session_id || null);
@@ -55,13 +55,13 @@ export function SessionsTab({ agentName, token, serverUrl }: TabProps) {
         setData({ sessions: [], currentSessionId: null });
       }
     }).catch(() => setData({ sessions: [], currentSessionId: null }));
-  }, [agentName, token, serverUrl]);
+  }, [baseUrl, token]);
 
   useEffect(() => {
     if (activeSession) {
-      api.getSessionActivity(agentName, token, serverUrl, activeSession).then(setActivity).catch(() => {});
+      api.getSessionActivity(baseUrl, token, activeSession).then(setActivity).catch(() => {});
     }
-  }, [agentName, token, serverUrl, activeSession]);
+  }, [baseUrl, token, activeSession]);
 
   if (!data) return <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading...</div>;
   if (!data.sessions.length) return <EmptyState text="No session data available" />;

--- a/web/components/inspector/index.tsx
+++ b/web/components/inspector/index.tsx
@@ -10,9 +10,8 @@ import { MediaTab } from "./MediaTab";
 import { ContextTab } from "./ContextTab";
 
 interface Props {
-  agentName: string;
+  baseUrl: string;
   token: string | null;
-  serverUrl?: string;
 }
 
 const MEMORY_TABS = [
@@ -29,9 +28,9 @@ const MEMORY_TABS = [
  * Call once at app root. Surfaces are re-registered when agent changes
  * so each tab gets fresh props.
  */
-export function useMemorySurfaces({ agentName, token, serverUrl }: Props) {
-  const propsRef = useRef({ agentName, token, serverUrl });
-  propsRef.current = { agentName, token, serverUrl };
+export function useMemorySurfaces({ baseUrl, token }: Props) {
+  const propsRef = useRef({ baseUrl, token });
+  propsRef.current = { baseUrl, token };
 
   useEffect(() => {
     // Register all memory tabs as modal surfaces
@@ -42,8 +41,8 @@ export function useMemorySurfaces({ agentName, token, serverUrl }: Props) {
         label: tab.label,
         mode: "modal",
         render: () => {
-          const { agentName: a, token: t, serverUrl: s } = propsRef.current;
-          return <tab.Component agentName={a} token={t} serverUrl={s} />;
+          const { baseUrl: b, token: t } = propsRef.current;
+          return <tab.Component baseUrl={b} token={t} />;
         },
       });
     }

--- a/web/components/inspector/shared.tsx
+++ b/web/components/inspector/shared.tsx
@@ -3,9 +3,8 @@
 import React from "react";
 
 export interface TabProps {
-  agentName: string;
+  baseUrl: string;
   token: string | null;
-  serverUrl?: string;
 }
 
 // Warm amber accent used throughout the overlay

--- a/web/components/layouts/BubbleLayout.tsx
+++ b/web/components/layouts/BubbleLayout.tsx
@@ -15,7 +15,7 @@ interface BubbleLayoutProps {
   thinking: boolean;
   agentName?: string;
   token?: string;
-  serverUrl?: string;
+  baseUrl?: string;
   showTools: boolean;
   coloredTools: boolean;
   peekLastTool: boolean;
@@ -24,7 +24,7 @@ interface BubbleLayoutProps {
   loadingMore?: boolean;
 }
 
-export function BubbleLayout({ messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore }: BubbleLayoutProps) {
+export function BubbleLayout({ messages, streamParts, thinking, agentName, token, baseUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore }: BubbleLayoutProps) {
   const { containerRef, showScrollBtn, scrollToBottom, allMsgs, lastToolId, groups, showDots, loadingMore: isLoadingMore } = useChat({
     agentName, messages, streamParts, thinking, showTools, peekLastTool, loadMore, hasMore, loadingMore,
   });
@@ -41,7 +41,7 @@ export function BubbleLayout({ messages, streamParts, thinking, agentName, token
     }
 
     // Delegate plugin-owned roles to plugin renderers
-    const pluginNode = renderPluginMessage(msg, { agentName: agentName || "", token: token || "", serverUrl });
+    const pluginNode = renderPluginMessage(msg, { agentName: agentName || "", token: token || "", baseUrl: baseUrl || "" });
     if (pluginNode) {
       return <div key={msg.id} className="flex justify-start">{pluginNode}</div>;
     }
@@ -61,7 +61,7 @@ export function BubbleLayout({ messages, streamParts, thinking, agentName, token
           )}
 
           {msg.media && msg.media.length > 0 && (
-            <MediaAttachments media={msg.media} agentName={agentName} token={token} serverUrl={serverUrl} />
+            <MediaAttachments media={msg.media} baseUrl={baseUrl} token={token} />
           )}
 
           {(msg.text || !msg.media?.length) && (

--- a/web/components/layouts/FlatLayout.tsx
+++ b/web/components/layouts/FlatLayout.tsx
@@ -15,7 +15,7 @@ interface FlatLayoutProps {
   thinking: boolean;
   agentName?: string;
   token?: string;
-  serverUrl?: string;
+  baseUrl?: string;
   showTools: boolean;
   coloredTools: boolean;
   peekLastTool: boolean;
@@ -34,7 +34,7 @@ function Avatar({ name, isUser }: { name: string; isUser: boolean }) {
   );
 }
 
-export function FlatLayout({ messages, streamParts, thinking, agentName, token, serverUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore }: FlatLayoutProps) {
+export function FlatLayout({ messages, streamParts, thinking, agentName, token, baseUrl, showTools, coloredTools, peekLastTool, loadMore, hasMore, loadingMore }: FlatLayoutProps) {
   const { containerRef, showScrollBtn, scrollToBottom, allMsgs, lastToolId, groups, showDots, loadingMore: isLoadingMore } = useChat({
     agentName, messages, streamParts, thinking, showTools, peekLastTool, loadMore, hasMore, loadingMore,
   });
@@ -61,7 +61,7 @@ export function FlatLayout({ messages, streamParts, thinking, agentName, token, 
     }
 
     // Delegate plugin-owned roles to plugin renderers
-    const pluginNode = renderPluginMessage(msg, { agentName: agentName || "", token: token || "", serverUrl });
+    const pluginNode = renderPluginMessage(msg, { agentName: agentName || "", token: token || "", baseUrl: baseUrl || "" });
     if (pluginNode) {
       return <div key={msg.id} style={{ marginLeft: 42 }}>{pluginNode}</div>;
     }
@@ -114,7 +114,7 @@ export function FlatLayout({ messages, streamParts, thinking, agentName, token, 
           )}
 
           {msg.media && msg.media.length > 0 && (
-            <MediaAttachments media={msg.media} agentName={agentName} token={token} serverUrl={serverUrl} />
+            <MediaAttachments media={msg.media} baseUrl={baseUrl} token={token} />
           )}
 
           {!isHeartbeat && !isNoReply && (msg.text || !msg.media?.length) && (

--- a/web/hooks/useAgent.ts
+++ b/web/hooks/useAgent.ts
@@ -118,21 +118,20 @@ export function useAgent(
   // Track if we're in an active turn (between thinking/tool and finish)
   const inTurnRef = useRef(false);
 
-  const name = agent?.name ?? null;
+  const baseUrl = agent?.baseUrl ?? null;
   const token = agent?.token ?? null;
-  const serverUrl = agent?.serverUrl;
   const withHistory = opts.withHistory;
 
   // Load history + status on agent change (only when withHistory)
   useEffect(() => {
-    if (!name || !withHistory) return;
+    if (!baseUrl || !withHistory) return;
     let cancelled = false;
 
     async function load() {
       try {
         const [history, statusData] = await Promise.all([
-          api.getHistory(name!, token, 100, serverUrl),
-          api.getStatus(name!, token, serverUrl),
+          api.getHistory(baseUrl!, token, 100),
+          api.getStatus(baseUrl!, token),
         ]);
         if (cancelled) return;
         setMessages(historyToMessages(history));
@@ -165,18 +164,18 @@ export function useAgent(
     load();
 
     return () => { cancelled = true; };
-  }, [name, token, serverUrl, withHistory]);
+  }, [baseUrl, token, withHistory]);
 
   // Reset unread on agent change or when becoming active
   useEffect(() => {
     setUnread(0);
-  }, [name]);
+  }, [baseUrl]);
 
   // SSE connection — always active for running agents
   useEffect(() => {
-    if (!name) return;
+    if (!baseUrl) return;
 
-    const sse = api.connectSSE(name, token, {
+    const sse = api.connectSSE(baseUrl, token, {
       onEvent(ev: StreamEvent) {
         if (withHistory) {
           // Full mode: process streaming parts
@@ -222,7 +221,7 @@ export function useAgent(
             setActivity("");
             setActivityDetail("");
             inTurnRef.current = false;
-            api.getStatus(name!, token, serverUrl).then(setStatus).catch(() => {});
+            api.getStatus(baseUrl!, token).then(setStatus).catch(() => {});
           } else if (result.append.length > 0) {
             setMessages((prev) => [...prev, ...result.append]);
           }
@@ -269,21 +268,21 @@ export function useAgent(
       onDisconnect() {
         setConnected(false);
       },
-    }, serverUrl);
+    });
 
     sseRef.current = sse;
     return () => {
       sse.close();
       sseRef.current = null;
     };
-  }, [name, token, serverUrl, withHistory]);
+  }, [baseUrl, token, withHistory]);
 
   const loadMore = useCallback(
     async () => {
-      if (!name || !withHistory || oldestIndexRef.current === undefined || oldestIndexRef.current <= 0 || loadingMore) return;
+      if (!baseUrl || !withHistory || oldestIndexRef.current === undefined || oldestIndexRef.current <= 0 || loadingMore) return;
       setLoadingMore(true);
       try {
-        const history = await api.getHistory(name, token, 100, serverUrl, oldestIndexRef.current);
+        const history = await api.getHistory(baseUrl, token, 100, oldestIndexRef.current);
         if (history.length === 0) {
           setHasMore(false);
           return;
@@ -299,12 +298,12 @@ export function useAgent(
         setLoadingMore(false);
       }
     },
-    [name, token, serverUrl, withHistory, loadingMore]
+    [baseUrl, token, withHistory, loadingMore]
   );
 
   const send = useCallback(
     async (text: string, attachments?: Attachment[]) => {
-      if (!name) return;
+      if (!baseUrl) return;
 
       // Append user message to chat (with media preview from attachments)
       const media: import("../lib/types").MediaItem[] | undefined =
@@ -336,13 +335,12 @@ export function useAgent(
         inTurnRef.current = true;
       }
 
-      await api.sendMessage(name, token, text, {
+      await api.sendMessage(baseUrl, token, text, {
         connectionId: sseRef.current?.connectionId,
         attachments,
-        serverUrl,
       });
     },
-    [name, token, serverUrl]
+    [baseUrl, token]
   );
 
   if (!agent) return EMPTY_STATE;

--- a/web/hooks/useServers.ts
+++ b/web/hooks/useServers.ts
@@ -33,11 +33,12 @@ export function useServers(token: string | null) {
     for (const server of servers) {
       try {
         const raw = await api.fetchAgents(server.token, server.url);
+        const base = server.url || "";
         for (const a of raw) {
           all.push({
             name: a.name,
             running: a.running,
-            serverUrl: server.url || undefined,
+            baseUrl: `${base}/api/agents/${encodeURIComponent(a.name)}`,
             token: server.token,
           });
         }
@@ -82,7 +83,7 @@ export function useServers(token: string | null) {
   const removeServer = useCallback((url: string) => {
     const servers = getServers().slice(1).filter((s) => s.url !== url);
     localStorage.setItem("kern-servers", JSON.stringify(servers));
-    setAgents((prev) => prev.filter((a) => (a.serverUrl || "") !== url));
+    setAgents((prev) => prev.filter((a) => !a.baseUrl.startsWith(url)));
   }, [getServers]);
 
   const activeAgent = agents.find((a) => agentKey(a) === active) ?? null;
@@ -91,5 +92,5 @@ export function useServers(token: string | null) {
 }
 
 export function agentKey(agent: AgentInfo): string {
-  return agent.serverUrl ? `${agent.serverUrl}::${agent.name}` : agent.name;
+  return `${agent.baseUrl}`;
 }

--- a/web/hooks/useServers.ts
+++ b/web/hooks/useServers.ts
@@ -1,8 +1,23 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { AgentInfo, ServerConfig } from "../lib/types";
+import type { AgentInfo, ServerConfig, DirectAgent } from "../lib/types";
 import * as api from "../lib/api";
+
+const DIRECT_AGENTS_KEY = "kern-direct-agents";
+
+function loadDirectAgents(): DirectAgent[] {
+  try {
+    const stored = localStorage.getItem(DIRECT_AGENTS_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveDirectAgents(agents: DirectAgent[]) {
+  localStorage.setItem(DIRECT_AGENTS_KEY, JSON.stringify(agents));
+}
 
 export function useServers(token: string | null) {
   const [agents, setAgents] = useState<AgentInfo[]>([]);
@@ -27,9 +42,10 @@ export function useServers(token: string | null) {
 
   const discover = useCallback(async () => {
     if (!token) return;
-    const servers = getServers();
     const all: AgentInfo[] = [];
 
+    // Discover from proxy servers
+    const servers = getServers();
     for (const server of servers) {
       try {
         const raw = await api.fetchAgents(server.token, server.url);
@@ -43,6 +59,22 @@ export function useServers(token: string | null) {
           });
         }
       } catch { /* ignore unreachable servers */ }
+    }
+
+    // Discover direct agents
+    const directAgents = loadDirectAgents();
+    for (const da of directAgents) {
+      let running = false;
+      try {
+        const status = await api.getStatus(da.url, da.token);
+        running = !!status;
+      } catch { /* agent unreachable */ }
+      all.push({
+        name: da.name,
+        running,
+        baseUrl: da.url,
+        token: da.token,
+      });
     }
 
     setAgents(all);
@@ -86,9 +118,24 @@ export function useServers(token: string | null) {
     setAgents((prev) => prev.filter((a) => !a.baseUrl.startsWith(url)));
   }, [getServers]);
 
+  // Direct agent management
+  const addDirectAgent = useCallback((name: string, url: string, agentToken: string) => {
+    const directAgents = loadDirectAgents();
+    if (directAgents.some((d) => d.url === url)) return;
+    directAgents.push({ name, url, token: agentToken });
+    saveDirectAgents(directAgents);
+    discover();
+  }, [discover]);
+
+  const removeDirectAgent = useCallback((url: string) => {
+    const directAgents = loadDirectAgents().filter((d) => d.url !== url);
+    saveDirectAgents(directAgents);
+    setAgents((prev) => prev.filter((a) => a.baseUrl !== url));
+  }, []);
+
   const activeAgent = agents.find((a) => agentKey(a) === active) ?? null;
 
-  return { agents, activeAgent, active, setActive, addServer, removeServer, refresh: discover };
+  return { agents, activeAgent, active, setActive, addServer, removeServer, addDirectAgent, removeDirectAgent, refresh: discover };
 }
 
 export function agentKey(agent: AgentInfo): string {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,5 +1,5 @@
 // Pure API functions — no React, no state
-// All agent requests go through the web proxy: /api/agents/{name}/*
+// All functions take a resolved baseUrl — no URL building here.
 
 import type { StreamEvent, StatusData, HistoryMessage, Attachment } from "./types";
 
@@ -9,32 +9,24 @@ function headers(token?: string | null): Record<string, string> {
   return h;
 }
 
-/** Build proxied base URL for an agent */
-export function agentUrl(name: string, serverUrl?: string): string {
-  const base = serverUrl || "";
-  return `${base}/api/agents/${encodeURIComponent(name)}`;
-}
-
-// SSE connection — uses proxied events endpoint
+// SSE connection
 export interface SSEConnection {
   close: () => void;
   connectionId: string | null;
 }
 
 export function connectSSE(
-  agentName: string,
+  baseUrl: string,
   token: string | null,
   callbacks: {
     onEvent: (ev: StreamEvent) => void;
     onConnect?: () => void;
     onDisconnect?: () => void;
   },
-  serverUrl?: string
 ): SSEConnection {
-  const base = agentUrl(agentName, serverUrl);
   const url = token
-    ? `${base}/events?token=${encodeURIComponent(token)}`
-    : `${base}/events`;
+    ? `${baseUrl}/events?token=${encodeURIComponent(token)}`
+    : `${baseUrl}/events`;
   const es = new EventSource(url);
   let connectionId: string | null = null;
   let closed = false;
@@ -71,7 +63,7 @@ export function connectSSE(
   };
 }
 
-// Discovery — returns raw agent list from a server
+// Discovery — returns raw agent list from a server (proxy-only)
 export interface RawAgent {
   name: string;
   running: boolean;
@@ -84,15 +76,14 @@ export async function fetchAgents(token?: string | null, serverUrl?: string): Pr
   return res.json();
 }
 
-// Agent REST API — all through proxy
+// Agent REST API — all take resolved baseUrl
 export async function sendMessage(
-  agentName: string,
+  baseUrl: string,
   token: string | null,
   text: string,
   opts: {
     connectionId?: string | null;
     attachments?: Attachment[];
-    serverUrl?: string;
   } = {}
 ): Promise<{ ok: boolean }> {
   const payload: Record<string, unknown> = {
@@ -111,7 +102,7 @@ export async function sendMessage(
       size: a.size || 0,
     }));
   }
-  const res = await fetch(`${agentUrl(agentName, opts.serverUrl)}/message`, {
+  const res = await fetch(`${baseUrl}/message`, {
     method: "POST",
     headers: headers(token),
     body: JSON.stringify(payload),
@@ -119,75 +110,75 @@ export async function sendMessage(
   return res.json();
 }
 
-export async function getStatus(agentName: string, token?: string | null, serverUrl?: string): Promise<StatusData> {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/status`, { headers: headers(token) });
+export async function getStatus(baseUrl: string, token?: string | null): Promise<StatusData> {
+  const res = await fetch(`${baseUrl}/status`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getHistory(agentName: string, token?: string | null, limit = 100, serverUrl?: string, before?: number): Promise<HistoryMessage[]> {
+export async function getHistory(baseUrl: string, token?: string | null, limit = 100, before?: number): Promise<HistoryMessage[]> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (before !== undefined) params.set("before", String(before));
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/history?${params}`, { headers: headers(token) });
+  const res = await fetch(`${baseUrl}/history?${params}`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getSystemPrompt(agentName: string, token?: string | null, serverUrl?: string): Promise<string> {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/context/system`, { headers: headers(token) });
+export async function getSystemPrompt(baseUrl: string, token?: string | null): Promise<string> {
+  const res = await fetch(`${baseUrl}/context/system`, { headers: headers(token) });
   return res.text();
 }
 
-export async function getContextSegments(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/context/segments`, { headers: headers(token) });
+export async function getContextSegments(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/context/segments`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getSessions(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/sessions`, { headers: headers(token) });
+export async function getSessions(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/sessions`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getSessionActivity(agentName: string, token: string | null, serverUrl?: string, sessionId?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/sessions/${sessionId}/activity`, { headers: headers(token) });
+export async function getSessionActivity(baseUrl: string, token: string | null, sessionId?: string) {
+  const res = await fetch(`${baseUrl}/sessions/${sessionId}/activity`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getSummaries(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/summaries`, { headers: headers(token) });
+export async function getSummaries(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/summaries`, { headers: headers(token) });
   return res.json();
 }
 
-export async function regenerateSummary(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/summaries/regenerate`, { method: "POST", headers: headers(token) });
+export async function regenerateSummary(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/summaries/regenerate`, { method: "POST", headers: headers(token) });
   return res.json();
 }
 
-export async function recallSearch(agentName: string, token: string | null, serverUrl?: string, query?: string, limit = 10) {
+export async function recallSearch(baseUrl: string, token: string | null, query?: string, limit = 10) {
   const params = new URLSearchParams({ q: query || "", limit: String(limit) });
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/recall/search?${params}`, { headers: headers(token) });
+  const res = await fetch(`${baseUrl}/recall/search?${params}`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getRecallStats(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/recall/stats`, { headers: headers(token) });
+export async function getRecallStats(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/recall/stats`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getMediaList(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/media/list`, { headers: headers(token) });
+export async function getMediaList(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/media/list`, { headers: headers(token) });
   return res.json();
 }
 
-export async function getSegments(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/segments`, { headers: headers(token) });
+export async function getSegments(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/segments`, { headers: headers(token) });
   return res.json();
 }
 
-export async function rebuildSegments(agentName: string, token?: string | null, serverUrl?: string) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/segments/rebuild`, { method: "POST", headers: headers(token) });
+export async function rebuildSegments(baseUrl: string, token?: string | null) {
+  const res = await fetch(`${baseUrl}/segments/rebuild`, { method: "POST", headers: headers(token) });
   return res.json();
 }
 
-export async function resummarizeSegment(agentName: string, token: string | null, serverUrl?: string, segmentId?: number) {
-  const res = await fetch(`${agentUrl(agentName, serverUrl)}/segments/${segmentId}/resummarize`, { method: "POST", headers: headers(token) });
+export async function resummarizeSegment(baseUrl: string, token: string | null, segmentId?: number) {
+  const res = await fetch(`${baseUrl}/segments/${segmentId}/resummarize`, { method: "POST", headers: headers(token) });
   return res.json();
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -12,6 +12,12 @@ export interface ServerConfig {
   token: string;
 }
 
+export interface DirectAgent {
+  name: string;
+  url: string;
+  token: string;
+}
+
 // Discriminated union for SSE events
 export type StreamEvent =
   | { type: "connection"; connectionId: string }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -3,7 +3,7 @@
 export interface AgentInfo {
   name: string;
   running: boolean;
-  serverUrl?: string; // undefined = local proxy
+  baseUrl: string; // fully resolved — all API calls use this directly
   token: string;
 }
 

--- a/web/plugins/dashboard/components.tsx
+++ b/web/plugins/dashboard/components.tsx
@@ -121,10 +121,10 @@ export function DashboardIframe({ html }: { html: string }) {
 }
 
 /** Dashboard header button with dropdown */
-export function DashboardButton({ agentName, token, serverUrl, onOpenDashboard }: {
+export function DashboardButton({ agentName, token, baseUrl, onOpenDashboard }: {
   agentName?: string;
   token?: string;
-  serverUrl?: string;
+  baseUrl?: string;
   onOpenDashboard: (name: string) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -132,15 +132,14 @@ export function DashboardButton({ agentName, token, serverUrl, onOpenDashboard }
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!open || !agentName) return;
-    const base = serverUrl || "";
+    if (!open || !baseUrl) return;
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
-    fetch(`${base}/api/agents/${agentName}/dashboards`, { headers })
+    fetch(`${baseUrl}/dashboards`, { headers })
       .then(r => r.json())
       .then(d => setDashboards(d.dashboards || []))
       .catch(() => setDashboards([]));
-  }, [open, agentName, token, serverUrl]);
+  }, [open, baseUrl, token]);
 
   useEffect(() => {
     if (!open) return;
@@ -186,7 +185,7 @@ export function DashboardButton({ agentName, token, serverUrl, onOpenDashboard }
 }
 
 /** Sidebar section showing dashboards from all agents */
-export function DashboardSidebar({ agents, mini }: { agents: { name: string; running: boolean; serverUrl?: string; token: string }[]; activeAgent: string | null; mini: boolean }) {
+export function DashboardSidebar({ agents, mini }: { agents: { name: string; running: boolean; baseUrl: string; token: string }[]; activeAgent: string | null; mini: boolean }) {
   const store = getDashboardStoreFromImport();
   const dashboards = store?.allDashboards || [];
   const activeDashboard = store?.activeDashboard || null;
@@ -201,23 +200,23 @@ export function DashboardSidebar({ agents, mini }: { agents: { name: string; run
           <span className="text-[10px] text-[var(--text-muted)] uppercase tracking-wider font-semibold">Dashboards</span>
         </div>
       )}
-      {dashboards.map((d: { name: string; agentName: string; serverUrl: string }) => {
+      {dashboards.map((d: { name: string; baseUrl: string }) => {
         const isActive = activeDashboard === d.name;
-        const agent = agents.find(a => a.name === d.agentName && (a.serverUrl || "") === d.serverUrl);
+        const agent = agents.find(a => a.baseUrl === d.baseUrl);
         return (
           <button
-            key={`${d.agentName}-${d.name}`}
+            key={`${d.baseUrl}-${d.name}`}
             onClick={() => {
               if (isActive) {
                 store?.closePanel();
               } else if (agent) {
-                store?.loadAndOpen(d.name, agent.name, agent.serverUrl || "", agent.token || "");
+                store?.loadAndOpen(d.name, agent.baseUrl, agent.token || "");
               }
             }}
             className={`flex items-center w-full text-left transition-colors cursor-pointer rounded-lg overflow-hidden p-2.5 ${
               mini ? "justify-center" : "gap-2"
             } ${isActive ? "bg-white/[0.08]" : "hover:bg-white/[0.05]"}`}
-            title={mini ? `${d.name} (${d.agentName})` : d.name}
+            title={mini ? `${d.name}${agent ? ` (${agent.name})` : ""}` : d.name}
           >
             <span
               className="flex-shrink-0 w-2 h-2"
@@ -233,7 +232,7 @@ export function DashboardSidebar({ agents, mini }: { agents: { name: string; run
                   {d.name}
                 </span>
                 <span className="text-[10px] text-[var(--text-muted)] ml-auto opacity-50 flex-shrink-0">
-                  {d.agentName}
+                  {agent?.name}
                 </span>
               </>
             )}

--- a/web/plugins/dashboard/index.ts
+++ b/web/plugins/dashboard/index.ts
@@ -24,32 +24,29 @@ import { getDashboardStore } from "./useDashboards";
 
 export interface DashboardInfo {
   name: string;
-  agentName: string;
-  serverUrl: string;
+  baseUrl: string;
 }
 
 // --- API helpers ---
 
-export async function fetchDashboards(agentName: string, serverUrl: string, token: string): Promise<DashboardInfo[]> {
+export async function fetchDashboards(baseUrl: string, token: string): Promise<DashboardInfo[]> {
   try {
-    const base = serverUrl || "";
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
-    const res = await fetch(`${base}/api/agents/${agentName}/dashboards`, { headers });
+    const res = await fetch(`${baseUrl}/dashboards`, { headers });
     if (!res.ok) return [];
     const data = await res.json();
-    return (data.dashboards || []).map((name: string) => ({ name, agentName, serverUrl }));
+    return (data.dashboards || []).map((name: string) => ({ name, baseUrl }));
   } catch {
     return [];
   }
 }
 
-export async function loadDashboardHtml(name: string, agentName: string, serverUrl: string, token: string): Promise<string | null> {
+export async function loadDashboardHtml(name: string, baseUrl: string, token: string): Promise<string | null> {
   try {
-    const base = serverUrl || "";
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
-    const res = await fetch(`${base}/api/agents/${agentName}/d/${name}/`, { headers });
+    const res = await fetch(`${baseUrl}/d/${name}/`, { headers });
     if (!res.ok) return null;
     return await res.text();
   } catch {
@@ -157,8 +154,8 @@ export const dashboardPlugin: UIPlugin = {
     return createElement(DashboardButton, {
       agentName: ctx.agentName,
       token: ctx.token,
-      serverUrl: ctx.serverUrl,
-      onOpenDashboard: (name: string) => store?.loadAndOpen(name, ctx.agentName, ctx.serverUrl || "", ctx.token),
+      baseUrl: ctx.baseUrl,
+      onOpenDashboard: (name: string) => store?.loadAndOpen(name, ctx.baseUrl, ctx.token),
     });
   },
 };

--- a/web/plugins/dashboard/useDashboards.ts
+++ b/web/plugins/dashboard/useDashboards.ts
@@ -16,7 +16,7 @@ interface DashboardStore {
   activeAgent: AgentInfo | null;
   openPanel: (html: string, title: string, dashboard?: string) => void;
   closePanel: () => void;
-  loadAndOpen: (name: string, agentName: string, serverUrl: string, token: string) => void;
+  loadAndOpen: (name: string, baseUrl: string, token: string) => void;
 }
 
 // Singleton store reference so plugin definition can access state without React context
@@ -44,11 +44,11 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
     if (!agents.length) { setAllDashboards([]); return; }
     const running = agents.filter(a => a.running);
     Promise.all(running.map(async (agent) => {
-      return fetchDashboards(agent.name, agent.serverUrl || "", agent.token || "");
+      return fetchDashboards(agent.baseUrl, agent.token || "");
     })).then(results => setAllDashboards(results.flat()));
   }, [agents]);
 
-  const dashboardList = allDashboards.filter(d => d.agentName === activeAgent?.name).map(d => d.name);
+  const dashboardList = allDashboards.filter(d => d.baseUrl === activeAgent?.baseUrl).map(d => d.name);
 
   const openPanel = useCallback((html: string, title: string, dashboard?: string) => {
     setPanelHtml({ html, title, dashboard });
@@ -62,8 +62,8 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
     unregisterSurface(SURFACE_ID);
   }, []);
 
-  const loadAndOpen = useCallback((name: string, agentName: string, serverUrl: string, token: string) => {
-    loadDashboardHtml(name, agentName, serverUrl, token)
+  const loadAndOpen = useCallback((name: string, baseUrl: string, token: string) => {
+    loadDashboardHtml(name, baseUrl, token)
       .then(html => {
         if (html) {
           setPanelHtml({ html, title: name, dashboard: name });
@@ -100,7 +100,7 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
   useEffect(() => {
     if (!activeAgent) return;
     const saved = localStorage.getItem("kern-active-dashboard");
-    if (saved) loadAndOpen(saved, activeAgent.name, activeAgent.serverUrl || "", activeAgent.token || "");
+    if (saved) loadAndOpen(saved, activeAgent.baseUrl, activeAgent.token || "");
   }, [activeAgent]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Close panel if active dashboard no longer exists

--- a/web/plugins/registry.tsx
+++ b/web/plugins/registry.tsx
@@ -40,7 +40,7 @@ export interface UIPlugin {
 export interface RenderContext {
   agentName: string;
   token: string;
-  serverUrl?: string;
+  baseUrl: string;
 }
 
 export interface SidebarContext {
@@ -51,7 +51,7 @@ export interface SidebarContext {
 
 export interface HeaderContext {
   agentName: string;
-  serverUrl?: string;
+  baseUrl: string;
   token: string;
 }
 


### PR DESCRIPTION
## Summary
- Replace the `(agentName, token, serverUrl)` triple with a single `baseUrl` on `AgentInfo` across all web UI code
- Add `DirectAgent` type and localStorage-backed storage for direct agent connections
- Sidebar gets separate "Add agent" (direct) and "Add server" (proxy) buttons with modal forms
- Direct agents health-checked via `/status` on discovery, rendered in their own sidebar section with hover-remove

## Details

**Commit 1 — baseUrl refactor** (no behavior change)
- `AgentInfo.baseUrl` is the single source of truth for all API calls
- All API functions take `(baseUrl, token)` — zero branching for proxy vs direct
- Inspector tabs, dashboard plugin, layouts all simplified to `{ baseUrl, token }`

**Commit 2 — direct agent feature**
- `DirectAgent { name, url, token }` stored in `localStorage("kern-direct-agents")`
- `useServers` discovers both proxy servers and direct agents in a single pass
- Sidebar separates proxy agents (grouped by server) from direct agents
- "Add agent" modal with name, URL, token fields; trailing slash stripped
- Direct agents show hover-visible remove (×) button

Closes #124

## Test plan
- [ ] Add a direct agent via sidebar modal, verify it appears and connects
- [ ] Remove a direct agent via hover × button
- [ ] Verify proxy agents still group by server as before
- [ ] Verify direct agents persist across page reload (localStorage)
- [ ] Verify unreachable direct agent shows as offline (dimmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)