### PR TITLE
Add name to agent config (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Direct agent connections** ([#124](https://github.com/oguzbilgic/kern-ai/issues/124)) — connect to any agent from the web UI without running `kern web`. Click **+** in the sidebar, enter the agent's URL and token.
   - `kern web` is now optional — useful for multi-agent proxy, but not required
   - Login page removed — the web UI loads instantly, agents are added from the sidebar
+- **Agent name auto-migration** ([#131](https://github.com/oguzbilgic/kern-ai/issues/131)) — `name` field auto-set to directory basename on first startup if missing, persisted to config, and exposed in `/status` API for reliable UI display
 
 ## v0.24.1
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,7 +16,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `name` | directory name | Agent name. Written during `kern init`. Falls back to the directory basename if not set. |
+| `name` | directory name | Agent name. Auto-set to directory basename on first startup if missing. Exposed in `/status` response. |
 | `model` | `anthropic/claude-opus-4.6` | Model ID. Format depends on provider. |
 | `provider` | `openrouter` | API provider: `openrouter`, `anthropic`, `openai`, `ollama` |
 | `toolScope` | `full` | Tool access level: `full`, `write`, `read` |

--- a/docs/config.md
+++ b/docs/config.md
@@ -16,6 +16,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 
 | Field | Default | Description |
 |-------|---------|-------------|
+| `name` | directory name | Agent name. Written during `kern init`. Falls back to the directory basename if not set. |
 | `model` | `anthropic/claude-opus-4.6` | Model ID. Format depends on provider. |
 | `provider` | `openrouter` | API provider: `openrouter`, `anthropic`, `openai`, `ollama` |
 | `toolScope` | `full` | Tool access level: `full`, `write`, `read` |

--- a/src/app.ts
+++ b/src/app.ts
@@ -109,7 +109,14 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     }
   }
 
-  const agentName = basename(agentDir);
+  // Auto-migrate name into config if missing
+  if (!config.name) {
+    config.name = basename(agentDir);
+    await saveConfigField(agentDir, "name", config.name);
+    log("kern", `assigned name: ${config.name}`);
+  }
+
+  const agentName = config.name;
   process.chdir(agentDir);
 
   // Initialize pairing
@@ -244,7 +251,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   };
 
   server.setStatusFn(() => {
-    return { ...getStatusDataFn(), agentName };
+    return getStatusDataFn();
   });
 
   server.setMessageHandler(async (text, userId, iface, channel, attachments) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export type ToolScope = "full" | "write" | "read";
 
 export interface KernConfig {
   // Core
+  name: string;
   model: string;
   provider: string;
   toolScope: ToolScope;
@@ -44,6 +45,7 @@ const TOOL_SCOPES: Record<ToolScope, string[]> = {
 };
 
 export const configDefaults: KernConfig = {
+  name: "",
   model: "anthropic/claude-opus-4.6",
   provider: "openrouter",
   toolScope: "full",

--- a/src/init.ts
+++ b/src/init.ts
@@ -239,6 +239,7 @@ async function runConfig(name: string, dir: string): Promise<void> {
 
   // Build new config
   const config: Partial<KernConfig> = {
+    name,
     model,
     provider,
     toolScope: currentConfig.toolScope || "full",
@@ -442,6 +443,7 @@ No knowledge files yet. Create files in \`knowledge/\` as you learn about your d
 
   // .kern/config.json
   const config: Partial<KernConfig> = {
+    name,
     model,
     provider,
     toolScope: "full",

--- a/src/tools/kern.ts
+++ b/src/tools/kern.ts
@@ -1,7 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { readFile } from "fs/promises";
-import { join } from "path";
+import { join, basename } from "path";
 import { existsSync } from "fs";
 import type { SessionStats } from "../context.js";
 
@@ -116,6 +116,7 @@ export interface ContextBreakdown {
 
 export interface StatusData {
   version: string;
+  name: string;
   agent: string;
   model: string;
   provider: string;
@@ -194,6 +195,7 @@ export function getStatusData(): StatusData {
 
   return {
     version: _version,
+    name: _config.name || basename(_agentDir),
     agent: _agentDir,
     model: _config.model,
     provider: _config.provider,

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -53,7 +53,7 @@ export function useAgents() {
     for (const d of directs) {
       const status = await api.pingAgent(d.url, d.token);
       directList.push({
-        name: status?.agent?.split("/").pop() || new URL(d.url).hostname,
+        name: status?.name || new URL(d.url).hostname,
         running: status !== null,
         token: d.token,
         baseUrl: d.url,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -35,6 +35,7 @@ export type StreamEvent =
   | { type: "plugin"; plugin: string; data: Record<string, unknown> };
 
 export interface StatusData {
+  name?: string;
   agent?: string;
   version?: string;
   model?: string;


### PR DESCRIPTION
Adds `name` field to `KernConfig` with auto-migration on startup.

- `name: string` added to config interface and defaults
- Both init paths (fresh + reconfigure) write the name
- Auto-migrate on startup: if `config.name` is missing, set to `basename(agentDir)` and persist
- `name` added to `StatusData` and `/status` JSON response
- Frontend uses `status.name` instead of heuristic path/hostname parsing
- Removed redundant `agentName` spread in server status handler

Closes #131.