### PR TITLE
Extract proxy from kern web into kern proxy (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
   - `kern web` is now optional — useful for multi-agent proxy, but not required
   - Login page removed — the web UI loads instantly, agents are added from the sidebar
 - **Agent name auto-migration** ([#131](https://github.com/oguzbilgic/kern-ai/issues/131)) — `name` field auto-set to directory basename on first startup if missing, persisted to config, and exposed in `/status` API for reliable UI display
+- **`kern proxy`** ([#127](https://github.com/oguzbilgic/kern-ai/issues/127)) — authenticated reverse proxy extracted from `kern web` into its own command
+  - `kern proxy <start|stop|status|token>` — manages the proxy server with agent discovery, token auth, and API routing
+  - `kern web` is now a minimal static file server with no auth or proxy routes
+  - Token renamed from `KERN_WEB_TOKEN` to `KERN_PROXY_TOKEN` (legacy token accepted as fallback)
+  - Proxy uses `proxy_port` config (default 9000), web uses `web_port` (default 8080)
+  - `kern install --proxy` installs a systemd service for the proxy
 
 ## v0.24.1
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ kern init my-agent
 kern tui
 ```
 
-The init wizard scaffolds your agent, asks for a provider and API key, then starts it. `kern tui` opens an interactive chat. `kern web start` opens it in the browser.
+The init wizard scaffolds your agent, asks for a provider and API key, then starts it. `kern tui` opens an interactive chat. `kern web start` serves the UI in the browser.
 
 For automation: `kern init my-agent --api-key sk-or-...` (no prompts, defaults to openrouter + opus 4.6). For Ollama: `kern init my-agent --provider ollama --api-key http://localhost:11434 --model gemma4:31b`.
 
@@ -69,34 +69,36 @@ kern init <name>          # create or configure an agent
 kern start [name|path]    # start agents in background
 kern stop [name]          # stop agents
 kern restart [name]       # restart agents
-kern install [name|--web] # install systemd services (auto-restart, boot persistence)
+kern install [name|--web|--proxy] # install systemd services (auto-restart, boot persistence)
 kern uninstall [name]     # remove systemd services
 kern tui [name]           # interactive chat
-kern web <start|stop|status|token>  # web UI server
+kern web <start|stop|status>      # static web UI server
+kern proxy <start|stop|status|token>  # authenticated reverse proxy
 kern logs [name]          # follow agent logs
-kern list                 # show all agents and web status
+kern list                 # show all agents, web, and proxy status
 kern remove <name>        # unregister an agent
 kern backup <name>        # backup agent to .tar.gz
 kern restore <file>       # restore agent from backup
 kern import opencode      # import session from OpenCode
 ```
 
-Agents auto-register when you init, start, or run them. `kern list` shows every agent and the web daemon with running state and mode (systemd/daemon).
+Agents auto-register when you init, start, or run them. `kern list` shows every agent, web, and proxy with running state and mode (systemd/daemon).
 
 ### Web UI
 
-`kern web start` launches an optional web proxy server (default port 9000) that discovers local agents and proxies requests to them.
+`kern web start` serves the web UI as static files (default port 8080). Connect to agents directly from the sidebar by entering their URL and token.
+
+`kern proxy start` launches an optional authenticated reverse proxy (default port 9000) that discovers local agents and proxies requests to them.
 
 ```bash
-kern web start    # start web UI proxy, prints URL with token
-kern web stop     # stop it
-kern web status   # check if running
-kern web token    # print the URL with token again
+kern web start      # start static web server
+kern proxy start    # start proxy, prints URL with token
+kern proxy token    # print URL with token again
 ```
 
 The web UI can connect to agents two ways:
 - **Direct** — enter the agent's URL and `KERN_AUTH_TOKEN` in the sidebar. No proxy needed.
-- **Via proxy** — connect to a `kern web` server with `KERN_WEB_TOKEN`. The proxy discovers and forwards to local agents.
+- **Via proxy** — connect to a `kern proxy` server with `KERN_PROXY_TOKEN`. The proxy discovers and forwards to local agents.
 
 Agents bind to `0.0.0.0` on sticky ports (4100-4999), accessible over Tailscale or LAN. Add agents or remote proxy servers from the sidebar.
 
@@ -203,18 +205,18 @@ Structured, leveled logs with colored labels. Stored in `.kern/logs/kern.log`. A
 
 `maxContextTokens` controls the sliding context window — older messages are trimmed to stay within budget. `maxToolResultChars` caps individual tool results in context (full results stay in session JSONL and are searchable via recall). `summaryBudget` controls what fraction of the context window is reserved for compressed segment summaries when old messages are trimmed (default 75%, cached via prompt caching so effectively free). Set to `0` to disable.
 
-Agent auth tokens are auto-generated on first start and stored in `.kern/.env`. The web proxy injects them automatically — no manual setup needed.
+Agent auth tokens are auto-generated on first start and stored in `.kern/.env`. The proxy injects them automatically — no manual setup needed.
 
 ### Global: `~/.kern/config.json`
 
 ```json
 {
-  "web_port": 9000,
-  "web_host": "0.0.0.0"
+  "web_port": 8080,
+  "proxy_port": 9000
 }
 ```
 
-Controls the `kern web` server. Optional — defaults apply if the file doesn't exist.
+Controls the `kern web` and `kern proxy` servers. Optional — defaults apply if the file doesn't exist.
 
 ### Tool scopes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,17 +5,18 @@ How kern's processes fit together.
 ## Overview
 
 ```
-Browser ──→ agent A (:4100)           # direct connection
-Browser ──→ kern web (:9000) ──→ agent A (:4100)   # via proxy
-                               ├─→ agent B (:4101)
-                               └─→ agent C (:4102)
+Browser ──→ agent A (:4100)              # direct connection
+Browser ──→ kern proxy (:9000) ──→ agent A (:4100)   # via proxy
+                                 ├─→ agent B (:4101)
+                                 └─→ agent C (:4102)
+Browser ──→ kern web (:8080)             # static files only
 
 TUI ──────────────────────────→ agent A (:4100)
 Telegram ←────────────────────→ agent A (long poll)
 Slack ←───────────────────────→ agent A (socket mode)
 ```
 
-Each agent is a separate process. The web server is an optional proxy. Browsers can connect directly to agents or through the proxy.
+Each agent is a separate process. `kern web` serves the UI as static files. `kern proxy` is an optional authenticated reverse proxy for multi-agent access. Browsers can connect directly to agents or through the proxy.
 
 ## Agent process
 
@@ -27,7 +28,7 @@ Each agent is a separate process. The web server is an optional proxy. Browsers 
 - Runs the message queue, tool executor, and model calls
 - Serves SSE for real-time streaming to connected clients (TUI, web UI)
 
-Agents bind to `0.0.0.0` so they're reachable over the network (e.g. via Tailscale). The web proxy is optional — clients can connect directly if they have the agent's port and token.
+Agents bind to `0.0.0.0` so they're reachable over the network (e.g. via Tailscale). The proxy is optional — clients can connect directly if they have the agent's port and token.
 
 ### Agent HTTP endpoints
 
@@ -49,35 +50,39 @@ These are internal — the web proxy forwards to them, TUI connects directly.
 
 ### Auth
 
-Each agent generates a random token on first start, stored in `.kern/.env` as `KERN_AUTH_TOKEN`. Every request must include `Authorization: Bearer <token>`. The TUI and web proxy read the token from the agent's `.kern/.env` file.
+Each agent generates a random token on first start, stored in `.kern/.env` as `KERN_AUTH_TOKEN`. Every request must include `Authorization: Bearer <token>`. The TUI and proxy read the token from the agent's `.kern/.env` file.
 
 ## Web server
 
-`kern web start` launches a separate HTTP server (default port 9000, configurable in `~/.kern/config.json`).
+`kern web start` launches a minimal static file server (default port 8080, configurable via `web_port` in `~/.kern/config.json`). It serves only the web UI static files — no auth, no proxy, no agent discovery. Connect to agents directly from the sidebar by entering their URL and token.
 
-It serves two things:
-1. **Static files** — the web UI (HTML, CSS, JS)
-2. **Agent proxy** — forwards `/api/agents/:name/*` to the correct agent process
+## Proxy server
+
+`kern proxy start` launches an authenticated reverse proxy (default port 9000, configurable via `proxy_port` in `~/.kern/config.json`). It also serves the web UI static files.
+
+It provides:
+1. **Agent discovery** — `GET /api/agents` returns all registered agents
+2. **Agent proxy** — forwards `/api/agents/:name/*` to the correct agent process with token injection
 
 ### Proxy flow
 
 ```
 Browser → GET /api/agents/vega/status
-       → kern web reads ~/.kern/config.json agents list
+       → kern proxy reads ~/.kern/config.json agents list
        → finds vega: { port: 4100, token: "abc..." }
        → forwards to 127.0.0.1:4100/status with Authorization header
        → streams response back to browser
 ```
 
-The proxy injects agent tokens on behalf of the browser, so proxy clients don't need to know individual agent credentials.
+The proxy injects agent tokens on behalf of the browser, so proxy clients don't need individual agent credentials.
 
-### Web auth
+### Proxy auth
 
-The web UI serves static files without authentication — anyone who can reach the URL can load the page.
+**Static files** are served without authentication.
 
-**Proxy routes** (`/api/*`) are protected by `KERN_WEB_TOKEN` (auto-generated on first `kern web start`, stored in `~/.kern/.env`). The token is passed as a Bearer header or `?token=` query param.
+**Proxy routes** (`/api/*`) are protected by `KERN_PROXY_TOKEN` (auto-generated on first `kern proxy start`, stored in `~/.kern/.env`). Also accepts legacy `KERN_WEB_TOKEN`. The token is passed as a Bearer header or `?token=` query param.
 
-**Direct connections** bypass the proxy entirely. The browser connects to the agent's port with `KERN_AUTH_TOKEN`. No web server needed.
+**Direct connections** bypass the proxy entirely. The browser connects to the agent's port with `KERN_AUTH_TOKEN`. No proxy needed.
 
 Users add agents or proxy servers from the sidebar UI, entering the URL and token manually.
 
@@ -87,16 +92,17 @@ Users add agents or proxy servers from the sidebar UI, entering the URL and toke
 
 ```json
 {
-  "web_port": 9000,
+  "web_port": 8080,
+  "proxy_port": 9000,
   "agents": ["/root/vega", "/home/kern/atlas"]
 }
 ```
 
-The web server and TUI read this file to discover agents, then read each agent's `.kern/` directory for port, token, and PID. `kern list` reads it to show status. PIDs are checked with `kill -0` to detect stale entries.
+The proxy, TUI, and CLI read this file to discover agents, then read each agent's `.kern/` directory for port, token, and PID. `kern list` reads it to show status. PIDs are checked with `kill -0` to detect stale entries.
 
 ## TUI
 
-`kern tui [name]` connects directly to an agent's HTTP server — no web proxy involved. It reads the agent's port and token from the agent's `.kern/` directory, opens an SSE connection for streaming, and sends messages via POST. It's a direct localhost connection.
+`kern tui [name]` connects directly to an agent's HTTP server — no proxy involved. It reads the agent's port and token from the agent's `.kern/` directory, opens an SSE connection for streaming, and sends messages via POST. It's a direct localhost connection.
 
 ## Telegram & Slack
 
@@ -109,7 +115,7 @@ Both inject messages into the same queue as TUI and web. The agent doesn't know 
 
 ## Service management
 
-`kern install` creates systemd user services for agents and the web server. This gives you:
+`kern install` creates systemd user services for agents, the web server, and the proxy. This gives you:
 
 - Auto-restart on crash
 - Start on boot (with lingering enabled)
@@ -118,6 +124,7 @@ Both inject messages into the same queue as TUI and web. The agent doesn't know 
 ```bash
 kern install vega       # install agent as systemd service
 kern install --web      # install web server as systemd service
+kern install --proxy    # install proxy server as systemd service
 kern uninstall vega     # remove service
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -152,25 +152,39 @@ Restore an agent from a backup archive.
 - If agent already exists: warns and asks to confirm overwrite
 - If agent is running: stops it before overwriting
 
-## kern web \<start|stop|status|token\>
+## kern web \<start|stop|status\>
 
-Manage the web UI server.
+Minimal static file server for the web UI. No auth, no proxy.
 
 ```bash
-kern web start    # start web UI, prints URL with auth token
+kern web start    # start static web server
 kern web stop     # stop it
 kern web status   # check if running
-kern web token    # print URL with auth token
 ```
 
-- Serves the web UI and proxies all agent API requests
-- Agents bind to `127.0.0.1` — only reachable through the proxy
-- `KERN_WEB_TOKEN` auto-generated on first start, stored in `~/.kern/.env`
-- All `/api/*` routes require the web token (Bearer header or `?token=` query param)
-- `kern web start` and `kern web token` always print the full URL with token
-- Port configurable in `~/.kern/config.json` (default 9000)
+- Serves the web UI static files only — no API proxy, no auth
+- Port configurable via `web_port` in `~/.kern/config.json` (default 8080)
 - PID tracked in `~/.kern/web.pid`, logs in `~/.kern/web.log`
-- If installed via `kern install`, start/stop/restart delegate to systemd
+- If installed via `kern install --web`, start/stop/restart delegate to systemd
+- Connect to agents directly from the sidebar (enter URL + token)
+
+## kern proxy \<start|stop|status|token\>
+
+Authenticated reverse proxy for multi-agent access. Also serves the web UI.
+
+```bash
+kern proxy start    # start proxy, prints URL with auth token
+kern proxy stop     # stop it
+kern proxy status   # check if running
+kern proxy token    # print URL with auth token
+```
+
+- Proxies all agent API requests (`/api/agents/:name/*`) with token injection
+- `KERN_PROXY_TOKEN` auto-generated on first start, stored in `~/.kern/.env` (also accepts legacy `KERN_WEB_TOKEN`)
+- All `/api/*` routes require the proxy token (Bearer header or `?token=` query param)
+- Port configurable via `proxy_port` in `~/.kern/config.json` (default 9000)
+- PID tracked in `~/.kern/proxy.pid`, logs in `~/.kern/proxy.log`
+- If installed via `kern install --proxy`, start/stop/restart delegate to systemd
 
 ## kern import opencode
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -69,12 +69,12 @@ Only set the API keys for providers/interfaces you use.
 - TUI and web proxy read it from the agent's `.kern/.env` automatically
 - Web proxy injects it into proxied requests — the browser never sees agent tokens
 
-**`KERN_WEB_TOKEN`** — web proxy auth token stored in `~/.kern/.env`.
+**`KERN_PROXY_TOKEN`** — proxy auth token stored in `~/.kern/.env`.
 
-- Auto-generated on first `kern web start`
+- Auto-generated on first `kern proxy start`
 - Required on all `/api/*` proxy routes (Bearer header or `?token=` query param)
-- Printed by `kern web start` and `kern web token`
-- Web UI prompts for it on first visit, saves to localStorage
+- Printed by `kern proxy start` and `kern proxy token`
+- Legacy `KERN_WEB_TOKEN` also accepted as fallback
 
 You never need to set either token manually unless you want specific values.
 
@@ -84,16 +84,16 @@ Global settings and agent registry. Optional — defaults apply if the file does
 
 ```json
 {
-  "web_port": 9000,
-  "web_host": "0.0.0.0",
+  "web_port": 8080,
+  "proxy_port": 9000,
   "agents": ["/home/user/my-agent"]
 }
 ```
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `web_port` | `9000` | Port for the `kern web` UI server. |
-| `web_host` | `0.0.0.0` | Bind address for the web UI server. |
+| `web_port` | `8080` | Port for the `kern web` static file server. |
+| `proxy_port` | `9000` | Port for the `kern proxy` authenticated reverse proxy. |
 | `agents` | `[]` | List of registered agent directory paths. Managed automatically by `kern init` and `kern start`. |
 
 ## .kern/ local files

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -1,7 +1,8 @@
-import { readFile, writeFile, mkdir, unlink } from "fs/promises";
+import { readFile, writeFile, mkdir, unlink, appendFile } from "fs/promises";
 import { join } from "path";
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
+import { randomBytes } from "crypto";
 import { log } from "./log.js";
 
 export interface GlobalConfig {
@@ -82,4 +83,21 @@ async function migrateLegacyAgents(): Promise<void> {
   } catch (err) {
     log.warn("config", `agents.json migration failed: ${err}`);
   }
+}
+
+const ENV_FILE = join(homedir(), ".kern", ".env");
+
+/** Load or auto-generate the proxy auth token from ~/.kern/.env */
+export async function getProxyToken(): Promise<string> {
+  if (existsSync(ENV_FILE)) {
+    const content = await readFile(ENV_FILE, "utf-8");
+    // Check new name first, fall back to legacy KERN_WEB_TOKEN
+    const match = content.match(/^KERN_PROXY_TOKEN=(.+)$/m)
+      || content.match(/^KERN_WEB_TOKEN=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  const token = randomBytes(16).toString("hex");
+  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_PROXY_TOKEN=${token}\n`);
+  log("proxy", `generated proxy token: ${token.slice(0, 8)}...`);
+  return token;
 }

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -7,12 +7,14 @@ import { log } from "./log.js";
 export interface GlobalConfig {
   web_port: number;
   web_host: string;
+  proxy_port: number;
   agents: string[];
 }
 
 const defaults: GlobalConfig = {
-  web_port: 9000,
+  web_port: 8080,
   web_host: "0.0.0.0",
+  proxy_port: 9000,
   agents: [],
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,11 @@ async function showHelp() {
   w(`    ${cyan("kern import")} ${dim("opencode <name>")}  import session from OpenCode`);
   w(`    ${cyan("kern restore")} ${dim("<file>")}         restore agent from backup`);
   w(`    ${cyan("kern logs")} ${dim("[name] [-f] [-n 50] [--level warn]")}  show agent logs`);
-  w(`    ${cyan("kern install")} ${dim("[name|--web]")}    install systemd services`);
+  w(`    ${cyan("kern install")} ${dim("[name|--web|--proxy]")} install systemd services`);
   w(`    ${cyan("kern uninstall")} ${dim("[name]")}        remove systemd services`);
   w(`    ${cyan("kern tui")} ${dim("[name]")}             interactive chat`);
-  w(`    ${cyan("kern web")} ${dim("<start|stop|status|token>")}  web UI server`);
+  w(`    ${cyan("kern web")} ${dim("<start|stop|status>")}        static web UI server`);
+  w(`    ${cyan("kern proxy")} ${dim("<start|stop|status|token>")} authenticated proxy server`);
   w("");
 }
 
@@ -362,10 +363,9 @@ async function main() {
   }
 
   if (cmd === "web") {
-    const subcmd = args[1]; // start, stop, status
-    const { webStart, webStop, webStatus, webToken } = await import("./web-daemon.js");
+    const subcmd = args[1];
+    const { webStart, webStop, webStatus } = await import("./web-daemon.js");
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      // Delegate to systemd if installed
       const { getWebServiceStatus } = await import("./install.js");
       if (getWebServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
@@ -377,10 +377,32 @@ async function main() {
       else { await webStop(); await new Promise(r => setTimeout(r, 500)); await webStart(); }
     } else if (subcmd === "status") {
       await webStatus();
-    } else if (subcmd === "token") {
-      await webToken();
     } else {
-      console.error("Usage: kern web <start|stop|status|token>");
+      console.error("Usage: kern web <start|stop|status>");
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (cmd === "proxy") {
+    const subcmd = args[1];
+    const { proxyStart, proxyStop, proxyStatus, proxyToken } = await import("./proxy-daemon.js");
+    if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
+      const { getProxyServiceStatus } = await import("./install.js");
+      if (getProxyServiceStatus() !== null) {
+        const { spawnSync } = await import("child_process");
+        spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });
+        return;
+      }
+      if (subcmd === "start") await proxyStart();
+      else if (subcmd === "stop") await proxyStop();
+      else { await proxyStop(); await new Promise(r => setTimeout(r, 500)); await proxyStart(); }
+    } else if (subcmd === "status") {
+      await proxyStatus();
+    } else if (subcmd === "token") {
+      await proxyToken();
+    } else {
+      console.error("Usage: kern proxy <start|stop|status|token>");
       process.exit(1);
     }
     return;

--- a/src/install.ts
+++ b/src/install.ts
@@ -13,6 +13,7 @@ const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
 
 const SERVICE_PREFIX = "kern-agent-";
 const WEB_SERVICE = "kern-web";
+const PROXY_SERVICE = "kern-proxy";
 const SYSTEMD_DIR = join(homedir(), ".config", "systemd", "user");
 
 function hasSystemd(): boolean {
@@ -78,6 +79,11 @@ export function getWebServiceStatus(): "active" | "installed" | null {
   return isActive(WEB_SERVICE) ? "active" : "installed";
 }
 
+export function getProxyServiceStatus(): "active" | "installed" | null {
+  if (!isInstalled(PROXY_SERVICE)) return null;
+  return isActive(PROXY_SERVICE) ? "active" : "installed";
+}
+
 function agentServiceUnit(agentName: string, agentPath: string): string {
   const kernEntry = join(import.meta.dirname, "index.js");
   const nodeBin = process.execPath;
@@ -108,6 +114,25 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=${nodeBin} --no-deprecation ${webEntry}
+Restart=always
+RestartSec=5
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function proxyServiceUnit(): string {
+  const proxyEntry = join(import.meta.dirname, "proxy.js");
+  const nodeBin = process.execPath;
+  return `[Unit]
+Description=kern proxy server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${nodeBin} --no-deprecation ${proxyEntry}
 Restart=always
 RestartSec=5
 Environment=NODE_ENV=production
@@ -204,6 +229,44 @@ async function installWeb(): Promise<void> {
   }
 }
 
+async function installProxy(): Promise<void> {
+  const unitPath = join(SYSTEMD_DIR, `${PROXY_SERVICE}.service`);
+
+  if (existsSync(unitPath) && isActive(PROXY_SERVICE)) {
+    console.log(`  ${green("●")} ${bold("proxy")} already installed and running`);
+    return;
+  }
+
+  if (!existsSync(unitPath)) {
+    const pidFile = join(homedir(), ".kern", "proxy.pid");
+    if (existsSync(pidFile)) {
+      try {
+        const pid = parseInt(await readFile(pidFile, "utf-8"), 10);
+        if (pid && isProcessRunning(pid)) {
+          process.kill(pid, "SIGTERM");
+          console.log(`  ${dim("stopped pid-based proxy daemon")} ${dim(`(pid ${pid})`)}`);
+          await new Promise((r) => setTimeout(r, 1000));
+        }
+        await unlink(pidFile).catch(() => {});
+      } catch {}
+    }
+  }
+
+  await writeFile(unitPath, proxyServiceUnit());
+
+  systemctl("daemon-reload");
+  systemctl("enable", PROXY_SERVICE);
+  systemctl("restart", PROXY_SERVICE);
+
+  await new Promise((r) => setTimeout(r, 1500));
+  if (isActive(PROXY_SERVICE)) {
+    console.log(`  ${green("●")} ${bold("proxy")} installed and running`);
+  } else {
+    console.log(`  ${red("●")} ${bold("proxy")} installed but failed to start`);
+    console.log(`    ${dim(`journalctl --user -u ${PROXY_SERVICE} -n 10`)}`);
+  }
+}
+
 export async function install(nameOrFlag?: string): Promise<void> {
   const w = (s: string) => process.stdout.write(s + "\n");
 
@@ -221,11 +284,16 @@ export async function install(nameOrFlag?: string): Promise<void> {
     w("");
   }
 
-  const webOnly = nameOrFlag === "--web";
-
-  if (webOnly) {
+  if (nameOrFlag === "--web") {
     w("");
     await installWeb();
+    w("");
+    return;
+  }
+
+  if (nameOrFlag === "--proxy") {
+    w("");
+    await installProxy();
     w("");
     return;
   }
@@ -302,6 +370,7 @@ export async function uninstall(name?: string): Promise<void> {
       await uninstallOne(serviceName(name), name);
     }
     await uninstallOne(WEB_SERVICE, "web");
+    await uninstallOne(PROXY_SERVICE, "proxy");
   }
 
   systemctl("daemon-reload");

--- a/src/proxy-daemon.ts
+++ b/src/proxy-daemon.ts
@@ -1,0 +1,127 @@
+import { spawn } from "child_process";
+import { readFile, writeFile, unlink, mkdir, appendFile } from "fs/promises";
+import { join } from "path";
+import { existsSync, openSync } from "fs";
+import { homedir } from "os";
+import { randomBytes } from "crypto";
+import { isProcessRunning } from "./registry.js";
+import { loadGlobalConfig } from "./global-config.js";
+
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+
+const KERN_DIR = join(homedir(), ".kern");
+const PID_FILE = join(KERN_DIR, "proxy.pid");
+const LOG_FILE = join(KERN_DIR, "proxy.log");
+const ENV_FILE = join(KERN_DIR, ".env");
+
+/** Read or generate the proxy token from ~/.kern/.env */
+async function getProxyToken(): Promise<string> {
+  if (existsSync(ENV_FILE)) {
+    const content = await readFile(ENV_FILE, "utf-8");
+    const match = content.match(/^KERN_PROXY_TOKEN=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  const token = randomBytes(16).toString("hex");
+  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_PROXY_TOKEN=${token}\n`);
+  return token;
+}
+
+async function readPid(): Promise<number | null> {
+  if (!existsSync(PID_FILE)) return null;
+  try {
+    const pid = parseInt(await readFile(PID_FILE, "utf-8"), 10);
+    return isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+export async function proxyStart(): Promise<void> {
+  const config = await loadGlobalConfig();
+  const port = config.proxy_port;
+  const token = await getProxyToken();
+
+  const pid = await readPid();
+  if (pid && isProcessRunning(pid)) {
+    console.log(`\n  ${green("●")} ${bold("proxy")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    return;
+  }
+
+  await mkdir(KERN_DIR, { recursive: true });
+  const logFd = openSync(LOG_FILE, "a");
+  const proxyEntry = join(import.meta.dirname, "proxy.js");
+
+  const child = spawn("node", ["--no-deprecation", proxyEntry], {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+  });
+
+  child.unref();
+  const newPid = child.pid!;
+  await writeFile(PID_FILE, String(newPid));
+
+  await new Promise((r) => setTimeout(r, 1000));
+
+  if (isProcessRunning(newPid)) {
+    console.log(`\n  ${green("●")} ${bold("proxy")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}?token=${token}\n`);
+  } else {
+    try { await unlink(PID_FILE); } catch {}
+    console.log(`\n  ${red("●")} ${bold("proxy")} failed to start\n`);
+    try {
+      const log = await readFile(LOG_FILE, "utf-8");
+      const lines = log.trim().split("\n").slice(-5);
+      for (const line of lines) {
+        console.log(`    ${dim(line)}`);
+      }
+    } catch {}
+  }
+}
+
+export async function proxyStop(): Promise<void> {
+  const pid = await readPid();
+  if (!pid || !isProcessRunning(pid)) {
+    console.log(`\n  ${dim("●")} ${bold("proxy")} not running\n`);
+    try { await unlink(PID_FILE); } catch {}
+    return;
+  }
+
+  try {
+    process.kill(pid, "SIGTERM");
+    try { await unlink(PID_FILE); } catch {}
+    console.log(`\n  ${red("●")} ${bold("proxy")} stopped ${dim(`(was pid ${pid})`)}\n`);
+  } catch (e: any) {
+    console.error(`  Failed to stop proxy: ${e.message}`);
+  }
+}
+
+export async function proxyStatus(): Promise<void> {
+  const config = await loadGlobalConfig();
+  const { getProxyServiceStatus } = await import("./install.js");
+  const installStatus = getProxyServiceStatus();
+
+  const pid = await readPid();
+  const pidRunning = pid && isProcessRunning(pid);
+  const running = pidRunning || installStatus === "active";
+  const mode = installStatus ? "systemd" : pidRunning ? "daemon" : "—";
+
+  if (running) {
+    console.log(`\n  ${green("●")} ${bold("proxy")} running ${dim(`(:${config.proxy_port})`)}`);
+  } else {
+    console.log(`\n  ${dim("●")} ${bold("proxy")} stopped`);
+    if (pid) {
+      try { await unlink(PID_FILE); } catch {}
+    }
+  }
+  console.log(`    ${dim("mode:")} ${mode}\n`);
+}
+
+export async function proxyToken(): Promise<void> {
+  const config = await loadGlobalConfig();
+  const token = await getProxyToken();
+  console.log(`\n  → http://localhost:${config.proxy_port}?token=${token}\n`);
+}

--- a/src/proxy-daemon.ts
+++ b/src/proxy-daemon.ts
@@ -1,11 +1,10 @@
 import { spawn } from "child_process";
-import { readFile, writeFile, unlink, mkdir, appendFile } from "fs/promises";
+import { readFile, writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync, openSync } from "fs";
 import { homedir } from "os";
-import { randomBytes } from "crypto";
 import { isProcessRunning } from "./registry.js";
-import { loadGlobalConfig } from "./global-config.js";
+import { loadGlobalConfig, getProxyToken } from "./global-config.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -15,19 +14,6 @@ const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 const KERN_DIR = join(homedir(), ".kern");
 const PID_FILE = join(KERN_DIR, "proxy.pid");
 const LOG_FILE = join(KERN_DIR, "proxy.log");
-const ENV_FILE = join(KERN_DIR, ".env");
-
-/** Read or generate the proxy token from ~/.kern/.env */
-async function getProxyToken(): Promise<string> {
-  if (existsSync(ENV_FILE)) {
-    const content = await readFile(ENV_FILE, "utf-8");
-    const match = content.match(/^KERN_PROXY_TOKEN=(.+)$/m);
-    if (match) return match[1].trim();
-  }
-  const token = randomBytes(16).toString("hex");
-  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_PROXY_TOKEN=${token}\n`);
-  return token;
-}
 
 async function readPid(): Promise<number | null> {
   if (!existsSync(PID_FILE)) return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -20,31 +20,13 @@
  */
 
 import { createServer, request as httpRequest, type IncomingMessage, type ServerResponse } from "http";
-import { readFile, writeFile, appendFile } from "fs/promises";
-import { join } from "path";
+import { readFile, writeFile } from "fs/promises";
+import { join, resolve } from "path";
 import { existsSync } from "fs";
 import { homedir } from "os";
-import { randomBytes } from "crypto";
+
 import { loadRegistry, readAgentInfo, isProcessRunning, type AgentInfo } from "./registry.js";
-import { loadGlobalConfig } from "./global-config.js";
-
-const KERN_DIR = join(homedir(), ".kern");
-const ENV_FILE = join(KERN_DIR, ".env");
-
-/** Load or auto-generate the proxy auth token from ~/.kern/.env */
-async function getProxyToken(): Promise<string> {
-  if (existsSync(ENV_FILE)) {
-    const content = await readFile(ENV_FILE, "utf-8");
-    // Check new name first, fall back to legacy KERN_WEB_TOKEN
-    const match = content.match(/^KERN_PROXY_TOKEN=(.+)$/m)
-      || content.match(/^KERN_WEB_TOKEN=(.+)$/m);
-    if (match) return match[1].trim();
-  }
-  const token = randomBytes(16).toString("hex");
-  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_PROXY_TOKEN=${token}\n`);
-  log(`generated proxy token: ${token.slice(0, 8)}...`);
-  return token;
-}
+import { loadGlobalConfig, getProxyToken } from "./global-config.js";
 
 let proxyToken: string;
 
@@ -62,12 +44,6 @@ function log(msg: string) {
   const ts = new Date().toISOString();
   process.stderr.write(`${ts} [proxy] ${msg}\n`);
 }
-
-const staticFiles: Record<string, { file: string; contentType: string }> = {
-  "/manifest.json": { file: "manifest.json", contentType: "application/manifest+json" },
-  "/sw.js": { file: "sw.js", contentType: "application/javascript" },
-  "/icon.svg": { file: "icon.svg", contentType: "image/svg+xml" },
-};
 
 /** Proxy a request to an agent's HTTP server, injecting its auth token */
 function proxyToAgent(req: IncomingMessage, res: ServerResponse, agent: AgentInfo, targetPath: string) {
@@ -130,13 +106,10 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
   if (req.method === "GET" && !url.startsWith("/api/")) {
     const serveDir = join(import.meta.dirname, "..", "web", "out");
 
-    let filePath: string;
-    if (url === "/") {
-      filePath = join(serveDir, "index.html");
-    } else if (url.includes("/../") || url.endsWith("/..")) {
+    const filePath = url === "/" ? join(serveDir, "index.html") : join(serveDir, decodeURIComponent(url));
+    const resolved = resolve(filePath);
+    if (!resolved.startsWith(serveDir + "/") && resolved !== serveDir) {
       res.writeHead(403); res.end(); return;
-    } else {
-      filePath = join(serveDir, url);
     }
 
     if (existsSync(filePath)) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+/**
+ * kern proxy — authenticated reverse proxy for multi-agent access.
+ * Also serves the web UI static files.
+ *
+ * Routes:
+ *   GET  /                              → web UI (index.html)
+ *   GET  /api/agents                    → list of registered agents
+ *   GET  /api/agents/:name/events       → SSE proxy to agent
+ *   POST /api/agents/:name/message      → proxy to agent
+ *   GET  /api/agents/:name/status       → proxy to agent
+ *   GET  /api/agents/:name/history      → proxy to agent
+ *   GET  /api/agents/:name/health       → proxy to agent
+ *   GET  /api/agents/:name/segments     → proxy to agent (semantic segment DAG)
+ *   POST /api/agents/:name/segments/rebuild → proxy to agent (clear + re-index)
+ *   GET  /manifest.json                 → PWA manifest
+ *   GET  /sw.js                         → service worker
+ *   GET  /icon.svg                      → app icon
+ */
+
+import { createServer, request as httpRequest, type IncomingMessage, type ServerResponse } from "http";
+import { readFile, writeFile, appendFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { randomBytes } from "crypto";
+import { loadRegistry, readAgentInfo, isProcessRunning, type AgentInfo } from "./registry.js";
+import { loadGlobalConfig } from "./global-config.js";
+
+const KERN_DIR = join(homedir(), ".kern");
+const ENV_FILE = join(KERN_DIR, ".env");
+
+/** Load or auto-generate the proxy auth token from ~/.kern/.env */
+async function getProxyToken(): Promise<string> {
+  if (existsSync(ENV_FILE)) {
+    const content = await readFile(ENV_FILE, "utf-8");
+    // Check new name first, fall back to legacy KERN_WEB_TOKEN
+    const match = content.match(/^KERN_PROXY_TOKEN=(.+)$/m)
+      || content.match(/^KERN_WEB_TOKEN=(.+)$/m);
+    if (match) return match[1].trim();
+  }
+  const token = randomBytes(16).toString("hex");
+  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_PROXY_TOKEN=${token}\n`);
+  log(`generated proxy token: ${token.slice(0, 8)}...`);
+  return token;
+}
+
+let proxyToken: string;
+
+async function loadAgents(): Promise<AgentInfo[]> {
+  const paths = await loadRegistry();
+  const agents: AgentInfo[] = [];
+  for (const p of paths) {
+    const info = readAgentInfo(p);
+    if (info) agents.push(info);
+  }
+  return agents;
+}
+
+function log(msg: string) {
+  const ts = new Date().toISOString();
+  process.stderr.write(`${ts} [proxy] ${msg}\n`);
+}
+
+const staticFiles: Record<string, { file: string; contentType: string }> = {
+  "/manifest.json": { file: "manifest.json", contentType: "application/manifest+json" },
+  "/sw.js": { file: "sw.js", contentType: "application/javascript" },
+  "/icon.svg": { file: "icon.svg", contentType: "image/svg+xml" },
+};
+
+/** Proxy a request to an agent's HTTP server, injecting its auth token */
+function proxyToAgent(req: IncomingMessage, res: ServerResponse, agent: AgentInfo, targetPath: string) {
+  const proxyReq = httpRequest(
+    {
+      hostname: "127.0.0.1",
+      port: agent.port,
+      path: targetPath,
+      method: req.method,
+      headers: {
+        ...req.headers,
+        host: `127.0.0.1:${agent.port}`,
+        authorization: agent.token ? `Bearer ${agent.token}` : "",
+      },
+    },
+    (proxyRes) => {
+      // Copy status + headers from agent response
+      res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+      // Pipe the response — works for SSE streams and regular responses
+      proxyRes.pipe(res);
+    },
+  );
+
+  proxyReq.on("error", (err) => {
+    log(`proxy error for ${agent.name}: ${err.message}`);
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "agent unreachable" }));
+    }
+  });
+
+  // Abort proxy request if client disconnects (important for SSE streams)
+  res.on("close", () => proxyReq.destroy());
+
+  // Pipe request body (for POST /message)
+  req.pipe(proxyReq);
+}
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  const rawUrl = req.url || "/";
+  const url = rawUrl.split("?")[0];
+
+  // CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  if (req.method === "OPTIONS") {
+    res.writeHead(200);
+    res.end();
+    return;
+  }
+
+  // Static file serving — Next.js static export from web/out/
+  const STATIC_MIME: Record<string, string> = {
+    ".html": "text/html", ".css": "text/css", ".js": "application/javascript",
+    ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png",
+    ".ico": "image/x-icon", ".txt": "text/plain", ".woff2": "font/woff2",
+  };
+
+  if (req.method === "GET" && !url.startsWith("/api/")) {
+    const serveDir = join(import.meta.dirname, "..", "web", "out");
+
+    let filePath: string;
+    if (url === "/") {
+      filePath = join(serveDir, "index.html");
+    } else if (url.includes("/../") || url.endsWith("/..")) {
+      res.writeHead(403); res.end(); return;
+    } else {
+      filePath = join(serveDir, url);
+    }
+
+    if (existsSync(filePath)) {
+      const ext = filePath.substring(filePath.lastIndexOf("."));
+      const contentType = STATIC_MIME[ext] ?? "application/octet-stream";
+      const content = await readFile(filePath);
+      res.writeHead(200, { "Content-Type": contentType });
+      res.end(content);
+    } else {
+      // SPA fallback — serve index.html for client-side routing
+      const indexPath = join(serveDir, "index.html");
+      if (existsSync(indexPath)) {
+        const html = await readFile(indexPath);
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(html);
+      } else {
+        res.writeHead(404); res.end();
+      }
+    }
+    return;
+  }
+
+  // Auth check — all /api/* routes require proxy token
+  if (url.startsWith("/api/")) {
+    const authHeader = req.headers.authorization;
+    const queryToken = new URL(rawUrl, "http://localhost").searchParams.get("token");
+    if (authHeader !== `Bearer ${proxyToken}` && queryToken !== proxyToken) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+  }
+
+  // Agent list API — returns agents (no port/token — proxy handles auth)
+  if (url === "/api/agents" && req.method === "GET") {
+    const agents = await loadAgents();
+    const result = agents.map((a) => ({
+      name: a.name,
+      running: !!(a.pid && isProcessRunning(a.pid)),
+    }));
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
+    return;
+  }
+
+  // Agent proxy — /api/agents/:name/:endpoint
+  const proxyMatch = url.match(/^\/api\/agents\/([^/]+)\/(.+)$/);
+  if (proxyMatch) {
+    const [, agentName, endpoint] = proxyMatch;
+    const agents = await loadAgents();
+    const agent = agents.find((a) => a.name === agentName);
+
+    if (!agent || !agent.port || !agent.pid || !isProcessRunning(agent.pid)) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "agent not found or not running" }));
+      return;
+    }
+
+    // Build target URL — preserve query string
+    const queryString = rawUrl.includes("?") ? rawUrl.slice(rawUrl.indexOf("?")) : "";
+    const targetPath = `/${endpoint}${queryString}`;
+
+    proxyToAgent(req, res, agent, targetPath);
+    return;
+  }
+
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ error: "not found" }));
+});
+
+async function start() {
+  proxyToken = await getProxyToken();
+  const config = await loadGlobalConfig();
+  const port = config.proxy_port;
+  server.listen(port, "0.0.0.0", async () => {
+    log(`listening on 0.0.0.0:${port}`);
+    const pidFile = join(homedir(), ".kern", "proxy.pid");
+    await writeFile(pidFile, String(process.pid));
+  });
+}
+
+start();

--- a/src/status.ts
+++ b/src/status.ts
@@ -90,10 +90,31 @@ export async function showStatus(): Promise<void> {
     : dim("stopped");
   const webMode = webInstall ? "systemd" : webRunning ? "daemon" : "—";
 
-  w(`  ${bold("kern web")}`);
+  // Proxy status
+  const { getProxyServiceStatus } = await import("./install.js");
+  const proxyInstall = getProxyServiceStatus();
+  const proxyPidFile = join(homedir(), ".kern", "proxy.pid");
+  let proxyPid: number | null = null;
+  let proxyRunning = false;
+  if (existsSync(proxyPidFile)) {
+    try {
+      proxyPid = parseInt(await readFile(proxyPidFile, "utf-8"), 10);
+      proxyRunning = !!proxyPid && isProcessRunning(proxyPid);
+    } catch {}
+  }
+  if (!proxyRunning) proxyRunning = proxyInstall === "active";
+  const proxyDot = proxyRunning ? green("●") : dim("●");
+  const proxyStatusStr = proxyRunning
+    ? green("running") + dim(` (:${config.proxy_port})`)
+    : dim("stopped");
+  const proxyMode = proxyInstall ? "systemd" : proxyRunning ? "daemon" : "—";
+
+  w(`  ${bold("kern services")}`);
   w("");
-  w(`  ${webDot} ${bold("web")}  ${webStatus}`);
+  w(`  ${webDot} ${bold("web")}    ${webStatus}`);
   w(`    ${dim("mode:")} ${webMode}`);
+  w(`  ${proxyDot} ${bold("proxy")}  ${proxyStatusStr}`);
+  w(`    ${dim("mode:")} ${proxyMode}`);
   w("");
 
   if (hasUninstalled) {

--- a/src/web-daemon.ts
+++ b/src/web-daemon.ts
@@ -1,9 +1,8 @@
 import { spawn } from "child_process";
-import { readFile, writeFile, unlink, mkdir, appendFile } from "fs/promises";
+import { readFile, writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync, openSync } from "fs";
 import { homedir } from "os";
-import { randomBytes } from "crypto";
 import { isProcessRunning } from "./registry.js";
 import { loadGlobalConfig } from "./global-config.js";
 
@@ -15,19 +14,6 @@ const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 const KERN_DIR = join(homedir(), ".kern");
 const PID_FILE = join(KERN_DIR, "web.pid");
 const LOG_FILE = join(KERN_DIR, "web.log");
-const ENV_FILE = join(KERN_DIR, ".env");
-
-/** Read or generate the web token from ~/.kern/.env */
-async function getWebToken(): Promise<string> {
-  if (existsSync(ENV_FILE)) {
-    const content = await readFile(ENV_FILE, "utf-8");
-    const match = content.match(/^KERN_WEB_TOKEN=(.+)$/m);
-    if (match) return match[1].trim();
-  }
-  const token = randomBytes(16).toString("hex");
-  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_WEB_TOKEN=${token}\n`);
-  return token;
-}
 
 async function readPid(): Promise<number | null> {
   if (!existsSync(PID_FILE)) return null;
@@ -42,13 +28,11 @@ async function readPid(): Promise<number | null> {
 export async function webStart(): Promise<void> {
   const config = await loadGlobalConfig();
   const port = config.web_port;
-  const token = await getWebToken();
 
-  // Check if already running
   const pid = await readPid();
   if (pid && isProcessRunning(pid)) {
     console.log(`\n  ${green("●")} ${bold("web")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    console.log(`  → http://localhost:${port}\n`);
     return;
   }
 
@@ -65,12 +49,11 @@ export async function webStart(): Promise<void> {
   const newPid = child.pid!;
   await writeFile(PID_FILE, String(newPid));
 
-  // Wait and verify
   await new Promise((r) => setTimeout(r, 1000));
 
   if (isProcessRunning(newPid)) {
     console.log(`\n  ${green("●")} ${bold("web")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    console.log(`  → http://localhost:${port}\n`);
   } else {
     try { await unlink(PID_FILE); } catch {}
     console.log(`\n  ${red("●")} ${bold("web")} failed to start\n`);
@@ -120,10 +103,4 @@ export async function webStatus(): Promise<void> {
     }
   }
   console.log(`    ${dim("mode:")} ${mode}\n`);
-}
-
-export async function webToken(): Promise<void> {
-  const config = await loadGlobalConfig();
-  const token = await getWebToken();
-  console.log(`\n  → http://localhost:${config.web_port}?token=${token}\n`);
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,7 +7,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { readFile, writeFile } from "fs/promises";
-import { join } from "path";
+import { join, resolve } from "path";
 import { existsSync } from "fs";
 import { homedir } from "os";
 import { loadGlobalConfig } from "./global-config.js";
@@ -61,15 +61,14 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     }
   }
 
-  // Path traversal guard
-  if (url.includes("/../") || url.endsWith("/..")) {
+  // Static file or SPA fallback
+  const filePath = url === "/" ? join(serveDir, "index.html") : join(serveDir, decodeURIComponent(url));
+  const resolved = resolve(filePath);
+  if (!resolved.startsWith(serveDir + "/") && resolved !== serveDir) {
     res.writeHead(403);
     res.end();
     return;
   }
-
-  // Static file or SPA fallback
-  const filePath = url === "/" ? join(serveDir, "index.html") : join(serveDir, url);
 
   if (existsSync(filePath)) {
     const ext = filePath.substring(filePath.lastIndexOf("."));

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,66 +1,27 @@
 #!/usr/bin/env node
 
 /**
- * kern web — serves the web UI, provides agent discovery, and proxies to agents.
- *
- * Routes:
- *   GET  /                              → web UI (index.html)
- *   GET  /api/agents                    → list of registered agents
- *   GET  /api/agents/:name/events       → SSE proxy to agent
- *   POST /api/agents/:name/message      → proxy to agent
- *   GET  /api/agents/:name/status       → proxy to agent
- *   GET  /api/agents/:name/history      → proxy to agent
- *   GET  /api/agents/:name/health       → proxy to agent
- *   GET  /api/agents/:name/segments     → proxy to agent (semantic segment DAG)
- *   POST /api/agents/:name/segments/rebuild → proxy to agent (clear + re-index)
- *   GET  /manifest.json                 → PWA manifest
- *   GET  /sw.js                         → service worker
- *   GET  /icon.svg                      → app icon
+ * kern web — minimal static file server for the web UI.
+ * No auth, no proxy, no agent discovery. For multi-agent proxy, use `kern proxy`.
  */
 
-import { createServer, request as httpRequest, type IncomingMessage, type ServerResponse } from "http";
-import { readFile, writeFile, appendFile } from "fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 import { existsSync } from "fs";
 import { homedir } from "os";
-import { randomBytes } from "crypto";
-import { loadRegistry, readAgentInfo, isProcessRunning, type AgentInfo } from "./registry.js";
 import { loadGlobalConfig } from "./global-config.js";
-
-const KERN_DIR = join(homedir(), ".kern");
-const ENV_FILE = join(KERN_DIR, ".env");
-
-/** Load or auto-generate the web auth token from ~/.kern/.env */
-async function getWebToken(): Promise<string> {
-  // Check existing .env
-  if (existsSync(ENV_FILE)) {
-    const content = await readFile(ENV_FILE, "utf-8");
-    const match = content.match(/^KERN_WEB_TOKEN=(.+)$/m);
-    if (match) return match[1].trim();
-  }
-  // Generate and persist
-  const token = randomBytes(16).toString("hex");
-  await appendFile(ENV_FILE, `${existsSync(ENV_FILE) ? "\n" : ""}KERN_WEB_TOKEN=${token}\n`);
-  log(`generated web token: ${token.slice(0, 8)}...`);
-  return token;
-}
-
-let webToken: string;
-
-async function loadAgents(): Promise<AgentInfo[]> {
-  const paths = await loadRegistry();
-  const agents: AgentInfo[] = [];
-  for (const p of paths) {
-    const info = readAgentInfo(p);
-    if (info) agents.push(info);
-  }
-  return agents;
-}
 
 function log(msg: string) {
   const ts = new Date().toISOString();
   process.stderr.write(`${ts} [web] ${msg}\n`);
 }
+
+const STATIC_MIME: Record<string, string> = {
+  ".html": "text/html", ".css": "text/css", ".js": "application/javascript",
+  ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png",
+  ".ico": "image/x-icon", ".txt": "text/plain", ".woff2": "font/woff2",
+};
 
 const staticFiles: Record<string, { file: string; contentType: string }> = {
   "/manifest.json": { file: "manifest.json", contentType: "application/manifest+json" },
@@ -68,150 +29,70 @@ const staticFiles: Record<string, { file: string; contentType: string }> = {
   "/icon.svg": { file: "icon.svg", contentType: "image/svg+xml" },
 };
 
-/** Proxy a request to an agent's HTTP server, injecting its auth token */
-function proxyToAgent(req: IncomingMessage, res: ServerResponse, agent: AgentInfo, targetPath: string) {
-  const proxyReq = httpRequest(
-    {
-      hostname: "127.0.0.1",
-      port: agent.port,
-      path: targetPath,
-      method: req.method,
-      headers: {
-        ...req.headers,
-        host: `127.0.0.1:${agent.port}`,
-        authorization: agent.token ? `Bearer ${agent.token}` : "",
-      },
-    },
-    (proxyRes) => {
-      // Copy status + headers from agent response
-      res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
-      // Pipe the response — works for SSE streams and regular responses
-      proxyRes.pipe(res);
-    },
-  );
-
-  proxyReq.on("error", (err) => {
-    log(`proxy error for ${agent.name}: ${err.message}`);
-    if (!res.headersSent) {
-      res.writeHead(502, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "agent unreachable" }));
-    }
-  });
-
-  // Abort proxy request if client disconnects (important for SSE streams)
-  res.on("close", () => proxyReq.destroy());
-
-  // Pipe request body (for POST /message)
-  req.pipe(proxyReq);
-}
-
 const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-  const rawUrl = req.url || "/";
-  const url = rawUrl.split("?")[0];
+  const url = (req.url || "/").split("?")[0];
 
   // CORS
   res.setHeader("Access-Control-Allow-Origin", "*");
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
   if (req.method === "OPTIONS") {
     res.writeHead(200);
     res.end();
     return;
   }
 
-  // Static file serving — Next.js static export from web/out/
-  const STATIC_MIME: Record<string, string> = {
-    ".html": "text/html", ".css": "text/css", ".js": "application/javascript",
-    ".json": "application/json", ".svg": "image/svg+xml", ".png": "image/png",
-    ".ico": "image/x-icon", ".txt": "text/plain", ".woff2": "font/woff2",
-  };
-
-  if (req.method === "GET" && !url.startsWith("/api/")) {
-    const serveDir = join(import.meta.dirname, "..", "web", "out");
-
-    let filePath: string;
-    if (url === "/") {
-      filePath = join(serveDir, "index.html");
-    } else if (url.includes("/../") || url.endsWith("/..")) {
-      res.writeHead(403); res.end(); return;
-    } else {
-      filePath = join(serveDir, url);
-    }
-
-    if (existsSync(filePath)) {
-      const ext = filePath.substring(filePath.lastIndexOf("."));
-      const contentType = STATIC_MIME[ext] ?? "application/octet-stream";
-      const content = await readFile(filePath);
-      res.writeHead(200, { "Content-Type": contentType });
-      res.end(content);
-    } else {
-      // SPA fallback — serve index.html for client-side routing
-      const indexPath = join(serveDir, "index.html");
-      if (existsSync(indexPath)) {
-        const html = await readFile(indexPath);
-        res.writeHead(200, { "Content-Type": "text/html" });
-        res.end(html);
-      } else {
-        res.writeHead(404); res.end();
-      }
-    }
+  if (req.method !== "GET") {
+    res.writeHead(405);
+    res.end();
     return;
   }
 
-  // Auth check — all /api/* routes require web token
-  if (url.startsWith("/api/")) {
-    const authHeader = req.headers.authorization;
-    const queryToken = new URL(rawUrl, "http://localhost").searchParams.get("token");
-    if (authHeader !== `Bearer ${webToken}` && queryToken !== webToken) {
-      res.writeHead(401, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "unauthorized" }));
+  const serveDir = join(import.meta.dirname, "..", "web", "out");
+
+  // Known static files
+  if (staticFiles[url]) {
+    const sf = staticFiles[url];
+    const fp = join(serveDir, sf.file);
+    if (existsSync(fp)) {
+      res.writeHead(200, { "Content-Type": sf.contentType });
+      res.end(await readFile(fp));
       return;
     }
   }
 
-  // Agent list API — returns agents (no port/token — proxy handles auth)
-  if (url === "/api/agents" && req.method === "GET") {
-    const agents = await loadAgents();
-    const result = agents.map((a) => ({
-      name: a.name,
-      running: !!(a.pid && isProcessRunning(a.pid)),
-    }));
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(result));
+  // Path traversal guard
+  if (url.includes("/../") || url.endsWith("/..")) {
+    res.writeHead(403);
+    res.end();
     return;
   }
 
-  // Agent proxy — /api/agents/:name/:endpoint
-  const proxyMatch = url.match(/^\/api\/agents\/([^/]+)\/(.+)$/);
-  if (proxyMatch) {
-    const [, agentName, endpoint] = proxyMatch;
-    const agents = await loadAgents();
-    const agent = agents.find((a) => a.name === agentName);
+  // Static file or SPA fallback
+  const filePath = url === "/" ? join(serveDir, "index.html") : join(serveDir, url);
 
-    if (!agent || !agent.port || !agent.pid || !isProcessRunning(agent.pid)) {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "agent not found or not running" }));
-      return;
+  if (existsSync(filePath)) {
+    const ext = filePath.substring(filePath.lastIndexOf("."));
+    res.writeHead(200, { "Content-Type": STATIC_MIME[ext] ?? "application/octet-stream" });
+    res.end(await readFile(filePath));
+  } else {
+    // SPA fallback
+    const indexPath = join(serveDir, "index.html");
+    if (existsSync(indexPath)) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(await readFile(indexPath));
+    } else {
+      res.writeHead(404);
+      res.end();
     }
-
-    // Build target URL — preserve query string
-    const queryString = rawUrl.includes("?") ? rawUrl.slice(rawUrl.indexOf("?")) : "";
-    const targetPath = `/${endpoint}${queryString}`;
-
-    proxyToAgent(req, res, agent, targetPath);
-    return;
   }
-
-  res.writeHead(404, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ error: "not found" }));
 });
 
 async function start() {
-  webToken = await getWebToken();
   const config = await loadGlobalConfig();
-  server.listen(config.web_port, config.web_host, async () => {
-    log(`listening on ${config.web_host}:${config.web_port}`);
-    // Write PID so status checks work regardless of how the server was started
+  const port = config.web_port;
+  server.listen(port, "0.0.0.0", async () => {
+    log(`listening on 0.0.0.0:${port}`);
     const pidFile = join(homedir(), ".kern", "web.pid");
     await writeFile(pidFile, String(process.pid));
   });


### PR DESCRIPTION
Splits `kern web` into two distinct commands:

## `kern web` — static file server
- Serves the web UI static files only
- No auth, no proxy routes, no agent discovery
- Default port 8080 (`web_port` in global config)
- Minimal ~100 lines

## `kern proxy` — authenticated reverse proxy  
- Agent discovery via `~/.kern/config.json` registry
- Proxies `/api/agents/:name/*` with token injection
- Also serves web UI static files for convenience
- `KERN_PROXY_TOKEN` auto-generated on first start (legacy `KERN_WEB_TOKEN` accepted as fallback)
- Default port 9000 (`proxy_port` in global config)
- `kern proxy <start|stop|status|token>` CLI commands

## Service management
- `kern install --proxy` creates systemd user service
- `kern uninstall` removes both web and proxy services
- `kern list` shows status of both web and proxy

## Config changes
- `proxy_port` added to `~/.kern/config.json` (default 9000)
- `web_port` default changed from 9000 to 8080
- `web_host` removed from proxy (binds 0.0.0.0)

## Migration
- Existing `KERN_WEB_TOKEN` in `~/.kern/.env` works as proxy token automatically
- Existing `kern web` users can switch to `kern proxy` for the same behavior with auth

Closes #127