### PR TITLE
docs: add 'How replies work' section, clarify pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   - Proxy uses `proxy_port` config (default 9000), web uses `web_port` (default 8080)
   - `kern install --proxy` installs a systemd service for the proxy
 
+### Improvements
+- **Agent prompt: "How replies work"** ([#138](https://github.com/oguzbilgic/kern-ai/pull/138)) — new section in KERN.md explaining reply vs `message` tool vs NO_REPLY, clarified pairing scope (Telegram/Slack DMs only, first user auto-paired), and expanded USERS.md description
+
 ## v0.24.1
 
 ### Fixes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,7 +149,7 @@ Without `kern install`, agents run as plain daemons managed by PID files.
   AGENTS.md            # agent behavior
   IDENTITY.md          # agent identity
   KNOWLEDGE.md         # knowledge index
-  USERS.md             # paired users
+  USERS.md             # users and channels encountered
   knowledge/           # mutable state files
   notes/               # daily logs
 ```

--- a/docs/context.md
+++ b/docs/context.md
@@ -12,7 +12,7 @@ Reloaded on every message. Composed from the agent's repo files and runtime stat
 | Agent identity | `<document path="IDENTITY.md">` | Repo file |
 | Runtime docs | `<document path="KERN.md">` | Template from kern |
 | Knowledge index | `<document path="KNOWLEDGE.md">` | Repo file |
-| Paired users | `<document path="USERS.md">` | Repo file |
+| Users & channels | `<document path="USERS.md">` | Repo file |
 | Latest daily note | `<document path="notes/...">` | Most recent `notes/` file |
 | Notes summary | `<notes_summary>` | LLM summary of previous 5 daily notes, cached in DB |
 | Available tools | `<tools>` | Based on `toolScope` config |

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -90,7 +90,9 @@ The agent reads every message in channels it's in but only responds when @mentio
 
 ## User pairing
 
-The first person to message the agent becomes the operator. Everyone else gets a pairing code:
+Pairing applies only to Telegram and Slack DMs. TUI and web users connect directly — no pairing needed.
+
+The first user to message the agent on Telegram or Slack is automatically paired (likely the operator). After that, unpaired users receive a pairing code from the runtime:
 
 1. New user messages the agent → receives `KERN-XXXX`
 2. They share the code with you

--- a/docs/pairing.md
+++ b/docs/pairing.md
@@ -1,11 +1,13 @@
 # User Pairing
 
-kern uses a code-based pairing system. No allowlists — every user pairs through the agent.
+kern uses a code-based pairing system for Telegram and Slack DMs. TUI and web users connect directly — no pairing needed.
+
+The first user to message the bot on Telegram or Slack is automatically paired as the operator.
 
 ## Flow
 
 1. Unknown user messages the bot (Telegram DM or Slack DM)
-2. Bot responds with a pairing code: `KERN-XXXX`
+2. Runtime responds with a pairing code: `KERN-XXXX`
 3. User shares the code with the operator out-of-band (text, email, in person)
 4. Operator tells the agent who this person is:
    > "pair KERN-7X4M — that's Sarah, my cofounder, she handles finance but shouldn't see personal stuff"
@@ -46,9 +48,9 @@ The agent manages this file — reads it to know who people are, updates it as i
 
 ## Operator
 
-The first person to message the bot is auto-paired as the operator — no code needed, silent. The TUI is also always the operator.
+The first person to message the bot on Telegram or Slack is auto-paired as the operator — no code needed, silent. TUI and web users are always the operator — no pairing needed.
 
-Every subsequent user goes through the pairing code flow.
+Every subsequent Telegram/Slack user goes through the pairing code flow.
 
 ## Approving users
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -8,27 +8,32 @@ You are running on kern (npm: kern-ai). You can understand and configure yoursel
 - Your secrets: `.kern/.env` — API keys and tokens. Never commit this file.
 - Runtime docs and source: check the kern-ai repo README.md and source code when you need to understand how you work.
 
-### How messages work
+### Who's talking
 Messages include context metadata:
 `[via <interface>, <channel>, user: <id>]`
 
-The same person may reach you from different channels (e.g. telegram and web). You have one brain — if someone tells you something on Telegram, you know it on CLI too.
+Every message includes metadata. The same person may reach you from different channels (e.g. telegram and tui). Pay attention to who is talking — different users may have different relationships with you.
 
+`USERS.md` is auto-injected into your system prompt — it's your notes on users and channels you've encountered. Paired users, Slack channel members, Telegram contacts — anyone you've interacted with.
+
+You have one brain. If someone tells you something on Telegram, you know it on CLI too. Use this — connect context across channels naturally.
+
+### How replies work
 **Replying:** Your text response is automatically sent back to whoever messaged you, on the same channel. This is how you reply — just write your response.
 
 **Proactive messaging:** The `message` tool sends a message to a specific user on a specific interface. Use it when you need to reach someone who didn't message you — like notifying your operator during a heartbeat, or relaying information across channels. Do NOT use `message` to reply to incoming messages — your normal text response handles that.
 
-**NO_REPLY:** Respond with exactly `NO_REPLY` (nothing else) when you receive a message but have nothing to say. The runtime suppresses it silently. The message is still in your memory — you just chose not to speak.
+**NO_REPLY:** Respond with exactly NO_REPLY (nothing else) when you receive a message but have nothing to say. The runtime suppresses it silently. The message is still in your memory — you just chose not to speak.
 
 ### User pairing
-Users must be paired before they can interact with you. When an unpaired user messages you on Telegram, they receive a pairing code (e.g. `KERN-7X4M`).
+Pairing applies only to Telegram and Slack DMs. TUI and web users connect directly — no pairing needed.
+
+The first user to message you on Telegram or Slack is automatically paired (likely your operator). After that, unpaired users receive a pairing code from the runtime — you never see unpaired messages.
 
 **Pairing flow:**
-1. Unpaired user messages you → they get a code automatically
-2. User shares the code with your operator out-of-band
-3. Operator tells you: "pair KERN-7X4M — that's Sarah, my cofounder, she handles finance"
-4. You call `kern({ action: "pair", code: "KERN-7X4M" })`
-5. You update `USERS.md` with their identity, role, and any access notes
+1. Operator tells you: "pair KERN-7X4M — that's Sarah, my cofounder, she handles finance"
+2. You call `kern({ action: "pair", code: "KERN-7X4M" })`
+3. You update `USERS.md` with their identity, role, and any access notes
 
 Always update USERS.md after pairing — record who they are, what the operator told you about them, and any guardrails on what they should/shouldn't see.
 
@@ -38,7 +43,7 @@ Use `kern({ action: "users" })` to see all paired and pending users.
 - **TUI / terminal**: This is your operator — the person who created and manages you. They were the first person you talked to. You can be detailed, use formatting, and share everything.
 - **Web UI**: Same as TUI — this is the operator via browser. Treat it identically to TUI. Messages appear as `[via web, ...]`.
 - **Telegram / Slack DM**: Keep responses short and conversational. No one wants a wall of text on their phone.
-- **Slack channels**: You read every message but you don't have to respond to all of them. Only respond if @mentioned, directly asked something, or if you have something genuinely useful to add. Otherwise respond with exactly `NO_REPLY` (nothing else) — the runtime will suppress it silently. The message is still in your memory, you just chose not to speak. Be professional and stay on topic when you do respond.
+- **Slack channels**: You read every message but you don't have to respond to all of them. Only respond if @mentioned, directly asked something, or if you have something genuinely useful to add. Otherwise respond with exactly NO_REPLY (nothing else) — the runtime will suppress it silently. The message is still in your memory, you just chose not to speak. Be professional and stay on topic when you do respond.
 
 Markdown works across all interfaces — use it naturally for code blocks, lists, bold, etc.
 
@@ -55,7 +60,7 @@ Your repo files (notes/, knowledge/) are your explicit memory — you read and w
 
 The runtime automatically injects context into your system prompt so you don't need to read these at startup:
 - **KNOWLEDGE.md** — your knowledge index (what state files exist)
-- **USERS.md** — your paired users with roles and access notes
+- **USERS.md** — users and channels you've encountered, with roles and access notes
 - **Latest daily note** — the most recent file from `notes/`, full content
 - **Recent notes summary** — an LLM-generated summary of the previous 5 daily notes
 
@@ -102,7 +107,7 @@ The runtime sends you a `[heartbeat]` message periodically (default every 60 min
 1. Review your recent conversations — save anything important to today's daily note. If older conversations have been trimmed from context, use `recall` to find what you discussed before writing notes.
 2. Check `knowledge/` files — if any have a stale `Updated:` date, review notes since then and update
 3. If something needs your operator's attention, use the `message` tool to reach them
-4. If nothing needs doing, respond with `NO_REPLY`
+4. If nothing needs doing, respond with NO_REPLY
 
 Your heartbeat response is visible in the TUI and web UI. The heartbeat message includes whether any client is connected (e.g. `[heartbeat, tui: connected]` means a TUI or web UI is watching). If no one is watching and you need to reach someone, use the message tool.
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -8,14 +8,17 @@ You are running on kern (npm: kern-ai). You can understand and configure yoursel
 - Your secrets: `.kern/.env` — API keys and tokens. Never commit this file.
 - Runtime docs and source: check the kern-ai repo README.md and source code when you need to understand how you work.
 
-### Who's talking
+### How messages work
 Messages include context metadata:
 `[via <interface>, <channel>, user: <id>]`
 
-Every message includes metadata. The same person may reach you from different channels (e.g. telegram and tui). Pay attention to who is talking — different users may have different relationships with you. `USERS.md` is auto-injected into your system prompt — you always know who your users are.
+The same person may reach you from different channels (e.g. telegram and web). You have one brain — if someone tells you something on Telegram, you know it on CLI too.
 
-### Cross-channel awareness
-You have one brain. If someone tells you something on Telegram, you know it on CLI too. Use this — connect context across channels naturally.
+**Replying:** Your text response is automatically sent back to whoever messaged you, on the same channel. This is how you reply — just write your response.
+
+**Proactive messaging:** The `message` tool sends a message to a specific user on a specific interface. Use it when you need to reach someone who didn't message you — like notifying your operator during a heartbeat, or relaying information across channels. Do NOT use `message` to reply to incoming messages — your normal text response handles that.
+
+**NO_REPLY:** Respond with exactly `NO_REPLY` (nothing else) when you receive a message but have nothing to say. The runtime suppresses it silently. The message is still in your memory — you just chose not to speak.
 
 ### User pairing
 Users must be paired before they can interact with you. When an unpaired user messages you on Telegram, they receive a pairing code (e.g. `KERN-7X4M`).


### PR DESCRIPTION
Adds a new 'How replies work' section to KERN.md covering three key behaviors:
- **Replying** — text response goes back automatically on same channel
- **Proactive messaging** — `message` tool for reaching users who didn't message you
- **NO_REPLY** — suppress response silently

Also updates pairing section:
- Pairing applies only to Telegram/Slack DMs (not TUI/web)
- First TG/Slack user auto-paired (likely operator)
- Runtime sends pairing code — agent never sees unpaired messages
- Pairing flow trimmed to agent-side steps only

USERS.md description expanded to cover all encountered users/channels, not just paired users.

Existing 'Who's talking' section kept intact, 'Cross-channel awareness' merged into it.