### PR TITLE
docs: migration section + agent connection info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
 ### Improvements
 - **Agent prompt: "How replies work"** ([#138](https://github.com/oguzbilgic/kern-ai/pull/138)) — new section in KERN.md explaining reply vs `message` tool vs NO_REPLY, clarified pairing scope (Telegram/Slack DMs only, first user auto-paired), and expanded USERS.md description
 
+### Migration
+- **Web UI now connects directly to agents** — add agents via the sidebar `+` button with their URL (`http://<host>:<port>`) and `KERN_AUTH_TOKEN` from `.kern/.env`
+  - `kern proxy` is no longer required for single-agent setups
+  - If you still need multi-agent proxy, use the new `kern proxy` command — `kern web` no longer proxies or requires auth
+- Rename `KERN_WEB_TOKEN` to `KERN_PROXY_TOKEN` in `~/.kern/.env` (old name still works as fallback)
+- Agents now bind `0.0.0.0` by default — set `host: "127.0.0.1"` in agent config if you want localhost only
+
 ## v0.24.1
 
 ### Fixes

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -6,7 +6,6 @@ You are running inside kern, an agent runtime with a single persistent session s
 You are running on kern (npm: kern-ai). You can understand and configure yourself:
 - Your config: `.kern/config.json` — read or modify it. Changes require a restart to take effect.
 - Your secrets: `.kern/.env` — API keys and tokens. Never commit this file.
-- Runtime docs and source: check the kern-ai repo README.md and source code when you need to understand how you work.
 
 ### Who's talking
 Messages include context metadata:
@@ -114,6 +113,7 @@ Your heartbeat response is visible in the TUI and web UI. The heartbeat message 
 ### Slash commands
 Users can type slash commands in any channel (TUI, web, Telegram, Slack). These are intercepted by the runtime — you never see them and cannot trigger them yourself. Available commands: `/status`, `/restart`, `/help`. If you need a restart (e.g. after config changes), ask your operator to type `/restart`.
 
-### Documentation
-For detailed docs on configuration, tools, pairing, interfaces, and commands:
-https://github.com/oguzbilgic/kern-ai/tree/master/docs
+
+For detailed docs on configuration, tools, pairing, interfaces, and commands: https://github.com/oguzbilgic/kern-ai/tree/master/docs
+
+For updates, changelog, and migration notes: https://github.com/oguzbilgic/kern-ai/blob/master/CHANGELOG.md


### PR DESCRIPTION
Two small additions:

**KERN.md** — new bullet in Self-awareness: agents can share their URL, port, and token via `kern({ action: "status" })` when operators need to connect.

**CHANGELOG.md** — Migration section for next release:
- Direct agent connections replace proxy for single-agent setups
- `KERN_WEB_TOKEN` → `KERN_PROXY_TOKEN` rename
- Agents bind `0.0.0.0` by default