### PR TITLE
Fix dashboard iframe links not opening in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## next
+
+### Fixes
+- **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab
+
+### Improvements
+- **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
+
 ## v0.25.0
 
 ### Features

--- a/web/plugins/dashboard/components.tsx
+++ b/web/plugins/dashboard/components.tsx
@@ -82,7 +82,7 @@ export function RenderBlock({ msg, onOpenPanel }: { msg: ChatMessage; onOpenPane
         <pre className="px-3 py-2 text-xs overflow-auto rounded-b-lg font-mono"
           style={{ background: "#161616", color: "var(--text-dim)", maxHeight: 400 }}>{html}</pre>
       ) : (
-        <iframe ref={iframeRef} srcDoc={wrappedHtml} sandbox="allow-scripts"
+        <iframe ref={iframeRef} srcDoc={wrappedHtml} sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           className="w-full border-0 rounded-b-lg" style={{ height, background: "transparent" }} />
       )}
     </div>
@@ -113,7 +113,7 @@ export function DashboardIframe({ html }: { html: string }) {
   return (
     <iframe
       srcDoc={wrappedHtml}
-      sandbox="allow-scripts"
+      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
       className="w-full h-full border-0"
       style={{ background: "transparent" }}
     />


### PR DESCRIPTION
Adds `allow-popups allow-popups-to-escape-sandbox` to iframe sandbox attributes on both inline render blocks and panel dashboard iframes.

Without these, `target="_blank"` links inside dashboards silently fail to open.

Closes #141