### PR TITLE
Desktop: simplify connect screen to URL only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,11 @@
 - Chat loses scroll position on window resize ([#73](https://github.com/oguzbilgic/kern-ai/issues/73))
 - URL auto-linking capturing trailing punctuation
 
+## desktop-next
+
+### Improvements
+- **Simplified connect screen** — removed token input; just enter the kern web URL. Agents are added with tokens through the web UI sidebar.
+
 ## desktop-v0.1.1
 
 ### Features

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -212,7 +212,7 @@
         // Just check if the URL is reachable by fetching the root page
         let res;
         try {
-          res = await fetch(url + '/', { method: 'HEAD' });
+          res = await fetch(url + '/');
         } catch (networkErr) {
           throw new Error(`Could not reach ${url}\n\n${networkErr?.message || 'Network request failed'}`);
         }

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -129,20 +129,17 @@
 <body>
   <div class="connect-card">
     <div class="logo">kern<span>.</span></div>
-    <div class="subtitle">Connect to your agent server</div>
+    <div class="subtitle">Connect to your web server</div>
 
-    <label>Server URL</label>
+    <label>URL</label>
     <input type="url" id="url" placeholder="http://100.115.98.30:8080" autocomplete="off" spellcheck="false">
-
-    <label>Access Token</label>
-    <input type="password" id="token" placeholder="paste your web token">
 
     <div class="error" id="error"></div>
     <div class="hint" id="hint"></div>
     <button id="connect" onclick="connect()">Connect</button>
 
     <div class="saved-servers" id="saved" style="display:none">
-      <h3>Saved Servers</h3>
+      <h3>Recent</h3>
       <div id="server-list"></div>
     </div>
   </div>
@@ -155,9 +152,9 @@
       catch { return []; }
     }
 
-    function saveServer(url, token) {
+    function saveServer(url) {
       const servers = getSavedServers().filter(s => s.url !== url);
-      servers.unshift({ url, token });
+      servers.unshift({ url });
       localStorage.setItem(STORAGE_KEY, JSON.stringify(servers.slice(0, 10)));
     }
 
@@ -174,7 +171,7 @@
       if (!servers.length) { container.style.display = 'none'; return; }
       container.style.display = 'block';
       list.innerHTML = servers.map(s => `
-        <div class="server-item" onclick="connectTo('${s.url}', '${s.token}')">
+        <div class="server-item" onclick="connectTo('${s.url}')">
           <span class="url">${s.url}</span>
           <button class="remove" onclick="event.stopPropagation(); removeServer('${s.url}')">&times;</button>
         </div>
@@ -198,12 +195,11 @@
     async function connect() {
       let url = document.getElementById('url').value.replace(/\/+$/, '');
       if (url && !/^https?:\/\//i.test(url)) url = 'http://' + url;
-      const token = document.getElementById('token').value;
       const error = document.getElementById('error');
       const hint = document.getElementById('hint');
       const btn = document.getElementById('connect');
 
-      if (!url) { showError('Enter a server URL'); return; }
+      if (!url) { showError('Enter a URL'); return; }
 
       btn.disabled = true;
       btn.textContent = 'Connecting…';
@@ -213,48 +209,36 @@
       document.querySelector('.connect-card').style.opacity = '0.85';
 
       try {
+        // Just check if the URL is reachable by fetching the root page
         let res;
         try {
-          res = await fetch(url + '/api/agents', {
-            headers: token ? { 'Authorization': 'Bearer ' + token } : {}
-          });
+          res = await fetch(url + '/', { method: 'HEAD' });
         } catch (networkErr) {
           throw new Error(`Could not reach ${url}\n\n${networkErr?.message || 'Network request failed'}`);
         }
 
-        if (!res.ok) {
-          if (res.status === 401) {
-            throw new Error('Invalid token for this server');
-          }
-          if (res.status === 404) {
-            throw new Error('This URL is reachable, but it does not look like a kern web server');
-          }
-          const text = await res.text().catch(() => '');
-          throw new Error(`Server returned ${res.status} ${res.statusText}${text ? `\n\n${text.slice(0, 300)}` : ''}`);
+        if (!res.ok && res.status !== 401) {
+          throw new Error(`Server returned ${res.status} ${res.statusText}`);
         }
 
-        saveServer(url, token);
-        const targetUrl = url + '?token=' + encodeURIComponent(token);
-        console.log('[desktop] navigating to:', targetUrl);
-
-        // Navigate — Tauri's on_navigation(|_| true) allows external URLs
-        window.location.replace(targetUrl);
+        saveServer(url);
+        console.log('[desktop] navigating to:', url);
+        window.location.replace(url);
       } catch (e) {
         showError(
-          e.message || 'Load failed',
-          'Check that the URL points to <code>kern web</code>, the token is correct, and the server opens in your browser first.'
+          e.message || 'Connection failed',
+          'Make sure <code>kern web</code> is running and the URL opens in your browser.'
         );
         btn.disabled = false;
         btn.textContent = 'Connect';
         document.body.style.pointerEvents = '';
         document.querySelector('.connect-card').style.opacity = '1';
-        throw e; // Re-throw so auto-reconnect can detect failure
+        throw e;
       }
     }
 
-    function connectTo(url, token) {
+    function connectTo(url) {
       document.getElementById('url').value = url;
-      document.getElementById('token').value = token;
       connect();
     }
 
@@ -263,7 +247,6 @@
     // Auto-reconnect: if we have a saved server, try connecting immediately
     (function autoReconnect() {
       const params = new URLSearchParams(window.location.search);
-      // Skip auto-reconnect if coming from logout
       if (params.get('logout')) {
         history.replaceState(null, '', 'index.html');
         return;
@@ -273,7 +256,6 @@
       const s = servers[0];
       console.log('[desktop] auto-reconnecting to', s.url);
       document.getElementById('url').value = s.url;
-      document.getElementById('token').value = s.token;
       setTimeout(() => connect().catch(() => {}), 200);
     })();
 


### PR DESCRIPTION
Removes token input from desktop connect screen. Agents are added with their own tokens via the web UI's Add Agent modal after connecting.

- Removed token input field
- Validation: simple HEAD reachability check instead of /api/agents auth
- Saved servers store URL only, no tokens
- Hint text updated for kern web

Fixes desktop validation failures after v0.25.0 proxy split.