### PR TITLE
feat: Zustand store for unified localStorage management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,20 @@
 
 ## next
 
+### Features
+- **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
+
+### Improvements
+- **Zustand store** ([#148](https://github.com/oguzbilgic/kern-ai/pull/148)) — replaced ~12 fragmented localStorage keys with a single persisted Zustand store; automatic migration from legacy keys on first load
+- **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
+
 ### Fixes
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab
 
+## desktop-next
+
 ### Improvements
-- **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
-- **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
+- **Simplified connect screen** — removed token input; just enter the kern web URL. Agents are added with tokens through the web UI sidebar.
 
 ## v0.25.0
 
@@ -115,11 +123,6 @@
 - Scroll-to-bottom button overlapping multi-line input ([#72](https://github.com/oguzbilgic/kern-ai/issues/72)) — repositions dynamically above input pill; chat re-anchors on window resize
 - Chat loses scroll position on window resize ([#73](https://github.com/oguzbilgic/kern-ai/issues/73))
 - URL auto-linking capturing trailing punctuation
-
-## desktop-next
-
-### Improvements
-- **Simplified connect screen** — removed token input; just enter the kern web URL. Agents are added with tokens through the web UI sidebar.
 
 ## desktop-v0.1.1
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, type DragEvent } from "react";
+import { useState, useCallback, useEffect, useMemo, type DragEvent } from "react";
 import { useAgents, agentKey } from "../hooks/useAgents";
 import { useAgent } from "../hooks/useAgent";
 import { Sidebar } from "../components/Sidebar";
@@ -39,7 +39,7 @@ export default function Home() {
   const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true });
   const pinnedArray = useStore((s) => s.ui.pinnedStats);
   const togglePin = useStore((s) => s.togglePin);
-  const pinned = new Set(pinnedArray);
+  const pinned = useMemo(() => new Set(pinnedArray), [pinnedArray]);
 
   // KernBridge — stable API for desktop app (Tauri) and Android WebView
   useEffect(() => {
@@ -157,7 +157,7 @@ export default function Home() {
             <PinnedStats status={status} pinned={pinned} />
           </div>
           <div className="ml-auto flex items-center gap-1">
-            <ThemePicker prefs={prefs} onPrefsChange={setPrefs} />
+            <ThemePicker />
             {/* Plugin header buttons */}
             {activeAgent && renderPluginHeaders({
               agentName: activeAgent.name,

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,20 +7,22 @@ import { Sidebar } from "../components/Sidebar";
 import { Chat } from "../components/Chat";
 import { Input, fileToAttachment } from "../components/Input";
 import { InfoPanel, PinnedStats } from "../components/InfoPanel";
-import { ThemePicker, usePreferences } from "../components/ThemePicker";
+import { ThemePicker } from "../components/ThemePicker";
 import { ThinkingDots } from "../components/ThinkingDots";
 import { SurfaceModal, SurfacePanel, panelMinChatWidth } from "../components/SurfaceManager";
 import { useSurfaces } from "../lib/surfaces";
 import { useMemorySurfaces, MEMORY_SURFACE_ID } from "../components/inspector";
 import { renderPluginHeaders } from "../plugins/registry";
 import { usePluginInit } from "../plugins";
+import { useStore } from "../lib/store";
 import type { Attachment } from "../lib/types";
 
 export default function Home() {
   const { agents, activeAgent, active, setActive, addServer, removeServer, addDirectAgent, removeDirectAgent, reorder } = useAgents();
   const [dragOver, setDragOver] = useState(false);
   const [externalAttachments, setExternalAttachments] = useState<Attachment[]>([]);
-  const { prefs, setPrefs } = usePreferences();
+  const prefs = useStore((s) => s.prefs);
+  const setPrefs = useStore((s) => s.setPrefs);
   const [modalSurface, setModalSurface] = useState<string | null>(null);
   const [infoOpen, setInfoOpen] = useState(false);
   const { hasPanels: showPanel } = useSurfaces();
@@ -35,22 +37,9 @@ export default function Home() {
   });
 
   const { messages, streamParts, thinking, activity, activityDetail, connected, status, send, loadMore, hasMore, loadingMore } = useAgent(activeAgent, { withHistory: true });
-  const [pinned, setPinned] = useState<Set<string>>(() => {
-    if (typeof window === "undefined") return new Set();
-    try {
-      const saved = localStorage.getItem("kern-pinned-stats");
-      return saved ? new Set(JSON.parse(saved)) : new Set();
-    } catch { return new Set(); }
-  });
-
-  const togglePin = useCallback((key: string) => {
-    setPinned((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key); else next.add(key);
-      localStorage.setItem("kern-pinned-stats", JSON.stringify([...next]));
-      return next;
-    });
-  }, []);
+  const pinnedArray = useStore((s) => s.ui.pinnedStats);
+  const togglePin = useStore((s) => s.togglePin);
+  const pinned = new Set(pinnedArray);
 
   // KernBridge — stable API for desktop app (Tauri) and Android WebView
   useEffect(() => {

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -108,23 +108,22 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onAddServer,
   // Mini/full state from store
   const mini = useStore((s) => s.ui.sidebarMini);
   const setSidebarMini = useStore((s) => s.setSidebarMini);
-  const setMini = setSidebarMini;
   const [userSet, setUserSet] = useState(false); // track manual toggle
 
   // Manual toggle wrapper
   function toggleMini() {
     setUserSet(true);
-    setMini(!mini);
+    setSidebarMini(!mini);
   }
 
   // Auto-collapse on narrow, auto-expand on wide — unless user manually toggled
   useEffect(() => {
     function check() {
       if (window.innerWidth < 768) {
-        setMini(true);
+        setSidebarMini(true);
         setUserSet(false); // reset so widening will auto-expand
       } else if (window.innerWidth >= 1024 && !userSet) {
-        setMini(false);
+        setSidebarMini(false);
       }
     }
     window.addEventListener("resize", check);

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useAgent } from "../hooks/useAgent";
 import { agentKey } from "../hooks/useAgents";
 import { renderPluginSidebars } from "../plugins/registry";
 import { avatarColor } from "../lib/colors";
+import { useStore } from "../lib/store";
 
 function AgentRow({
   agent,
@@ -104,21 +105,16 @@ export function Sidebar({ agents, active, activeThinking, onSelect, onAddServer,
   const [dropIndex, setDropIndex] = useState<number | null>(null);
 
 
-  // Mini/full state persisted in localStorage
-  const [mini, setMini] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return localStorage.getItem("kern-sidebar-mini") === "true";
-  });
+  // Mini/full state from store
+  const mini = useStore((s) => s.ui.sidebarMini);
+  const setSidebarMini = useStore((s) => s.setSidebarMini);
+  const setMini = setSidebarMini;
   const [userSet, setUserSet] = useState(false); // track manual toggle
-
-  useEffect(() => {
-    localStorage.setItem("kern-sidebar-mini", String(mini));
-  }, [mini]);
 
   // Manual toggle wrapper
   function toggleMini() {
     setUserSet(true);
-    setMini((m) => !m);
+    setMini(!mini);
   }
 
   // Auto-collapse on narrow, auto-expand on wide — unless user manually toggled

--- a/web/components/ThemePicker.tsx
+++ b/web/components/ThemePicker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { useStore, type Preferences } from "../lib/store";
+import { useStore } from "../lib/store";
 
 const THEMES = [
   "github-dark-dimmed",
@@ -31,16 +31,16 @@ function loadTheme(theme: string) {
   link.href = `${CDN}/${theme}.min.css`;
 }
 
-export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPrefsChange: (p: Partial<Preferences>) => void }) {
+export function ThemePicker() {
   const [open, setOpen] = useState(false);
-  const syntaxTheme = useStore((s) => s.prefs.syntaxTheme);
+  const prefs = useStore((s) => s.prefs);
   const setPrefs = useStore((s) => s.setPrefs);
   const ref = useRef<HTMLDivElement>(null);
 
   // Load syntax theme CSS on mount and when it changes
   useEffect(() => {
-    loadTheme(syntaxTheme);
-  }, [syntaxTheme]);
+    loadTheme(prefs.syntaxTheme);
+  }, [prefs.syntaxTheme]);
 
   useEffect(() => {
     if (!open) return;
@@ -50,11 +50,6 @@ export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPr
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
-
-  const selectTheme = (theme: string) => {
-    setPrefs({ syntaxTheme: theme });
-    setOpen(false);
-  };
 
   return (
     <div className="relative" ref={ref}>
@@ -73,7 +68,7 @@ export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPr
           {([["bubble", "Bubble"], ["flat", "Flat"]] as const).map(([key, label]) => (
             <button
               key={key}
-              onClick={() => onPrefsChange({ chatLayout: key })}
+              onClick={() => setPrefs({ chatLayout: key })}
               className={`w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--border)] transition-colors cursor-pointer ${
                 key === prefs.chatLayout ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
               }`}
@@ -86,19 +81,19 @@ export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPr
             Tools
           </div>
           <button
-            onClick={() => onPrefsChange({ showTools: !prefs.showTools })}
+            onClick={() => setPrefs({ showTools: !prefs.showTools })}
             className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--border)] transition-colors cursor-pointer text-[var(--text-dim)]"
           >
             {prefs.showTools ? "●" : "○"} Show tool calls
           </button>
           <button
-            onClick={() => onPrefsChange({ coloredTools: !prefs.coloredTools })}
+            onClick={() => setPrefs({ coloredTools: !prefs.coloredTools })}
             className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--border)] transition-colors cursor-pointer text-[var(--text-dim)]"
           >
             {prefs.coloredTools ? "●" : "○"} Colored tool names
           </button>
           <button
-            onClick={() => onPrefsChange({ peekLastTool: !prefs.peekLastTool })}
+            onClick={() => setPrefs({ peekLastTool: !prefs.peekLastTool })}
             className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--border)] transition-colors cursor-pointer text-[var(--text-dim)]"
           >
             {prefs.peekLastTool ? "●" : "○"} Peek last tool output
@@ -110,12 +105,12 @@ export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPr
           {THEMES.map((t) => (
             <button
               key={t}
-              onClick={() => selectTheme(t)}
+              onClick={() => { setPrefs({ syntaxTheme: t }); setOpen(false); }}
               className={`w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--border)] transition-colors cursor-pointer ${
-                t === syntaxTheme ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
+                t === prefs.syntaxTheme ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
               }`}
             >
-              {t === syntaxTheme && "● "}{t}
+              {t === prefs.syntaxTheme && "● "}{t}
             </button>
           ))}
         </div>

--- a/web/components/ThemePicker.tsx
+++ b/web/components/ThemePicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { useStore, type Preferences } from "../lib/store";
 
 const THEMES = [
   "github-dark-dimmed",
@@ -17,8 +18,6 @@ const THEMES = [
 ];
 
 const CDN = "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles";
-const STORAGE_KEY = "kern-hljs-theme";
-const DEFAULT_THEME = "github-dark-dimmed";
 
 function loadTheme(theme: string) {
   const id = "hljs-theme";
@@ -32,50 +31,16 @@ function loadTheme(theme: string) {
   link.href = `${CDN}/${theme}.min.css`;
 }
 
-export type ChatLayout = "bubble" | "flat";
-
-export interface Preferences {
-  chatLayout: ChatLayout;
-  coloredTools: boolean;
-  peekLastTool: boolean;
-  showTools: boolean;
-}
-
-const PREFS_DEFAULTS: Preferences = {
-  chatLayout: "flat",
-  coloredTools: true,
-  peekLastTool: false,
-  showTools: false,
-};
-
-export function usePreferences() {
-  const [prefs, setPrefsState] = useState<Preferences>(PREFS_DEFAULTS);
-  useEffect(() => {
-    const saved = localStorage.getItem("kern-prefs");
-    if (saved) {
-      try { setPrefsState({ ...PREFS_DEFAULTS, ...JSON.parse(saved) }); } catch {}
-    }
-  }, []);
-  const setPrefs = (partial: Partial<Preferences>) => {
-    setPrefsState((prev) => {
-      const next = { ...prev, ...partial };
-      localStorage.setItem("kern-prefs", JSON.stringify(next));
-      return next;
-    });
-  };
-  return { prefs, setPrefs };
-}
-
 export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPrefsChange: (p: Partial<Preferences>) => void }) {
   const [open, setOpen] = useState(false);
-  const [current, setCurrent] = useState(DEFAULT_THEME);
+  const syntaxTheme = useStore((s) => s.prefs.syntaxTheme);
+  const setPrefs = useStore((s) => s.setPrefs);
   const ref = useRef<HTMLDivElement>(null);
 
+  // Load syntax theme CSS on mount and when it changes
   useEffect(() => {
-    const saved = localStorage.getItem(STORAGE_KEY) || DEFAULT_THEME;
-    setCurrent(saved);
-    loadTheme(saved);
-  }, []);
+    loadTheme(syntaxTheme);
+  }, [syntaxTheme]);
 
   useEffect(() => {
     if (!open) return;
@@ -86,10 +51,8 @@ export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPr
     return () => document.removeEventListener("mousedown", handler);
   }, [open]);
 
-  const select = (theme: string) => {
-    setCurrent(theme);
-    localStorage.setItem(STORAGE_KEY, theme);
-    loadTheme(theme);
+  const selectTheme = (theme: string) => {
+    setPrefs({ syntaxTheme: theme });
     setOpen(false);
   };
 
@@ -147,12 +110,12 @@ export function ThemePicker({ prefs, onPrefsChange }: { prefs: Preferences; onPr
           {THEMES.map((t) => (
             <button
               key={t}
-              onClick={() => select(t)}
+              onClick={() => selectTheme(t)}
               className={`w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--border)] transition-colors cursor-pointer ${
-                t === current ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
+                t === syntaxTheme ? "text-[var(--accent)]" : "text-[var(--text-dim)]"
               }`}
             >
-              {t === current && "● "}{t}
+              {t === syntaxTheme && "● "}{t}
             </button>
           ))}
         </div>

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -1,31 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { AgentInfo, ServerConfig, DirectAgent } from "../lib/types";
+import type { AgentInfo } from "../lib/types";
+import { useStore } from "../lib/store";
 import * as api from "../lib/api";
-
-/** Apply saved order from localStorage, appending any new agents at the end */
-function applyOrder(agents: AgentInfo[]): AgentInfo[] {
-  try {
-    const stored = localStorage.getItem("kern-agent-order");
-    if (!stored) return agents;
-    const order: string[] = JSON.parse(stored);
-    const map = new Map(agents.map((a) => [a.baseUrl, a]));
-    const ordered: AgentInfo[] = [];
-    for (const url of order) {
-      const agent = map.get(url);
-      if (agent) {
-        ordered.push(agent);
-        map.delete(url);
-      }
-    }
-    // Append agents not in saved order
-    for (const agent of map.values()) ordered.push(agent);
-    return ordered;
-  } catch {
-    return agents;
-  }
-}
 
 export function useAgents() {
   const [agents, setAgents] = useState<AgentInfo[]>([]);
@@ -33,29 +11,19 @@ export function useAgents() {
   const activeRef = useRef<string | null>(null);
   activeRef.current = active;
 
-  // Get proxy servers from localStorage
-  const getServers = useCallback((): ServerConfig[] => {
-    try {
-      const stored = localStorage.getItem("kern-servers");
-      if (stored) return JSON.parse(stored);
-    } catch { /* ignore */ }
-    return [];
-  }, []);
-
-  // Get direct agents from localStorage
-  const getDirectAgents = useCallback((): DirectAgent[] => {
-    try {
-      const stored = localStorage.getItem("kern-agents");
-      if (stored) return JSON.parse(stored);
-    } catch { /* ignore */ }
-    return [];
-  }, []);
+  // Read connections from store
+  const servers = useStore((s) => s.connections.servers);
+  const directs = useStore((s) => s.connections.agents);
+  const storeAddServer = useStore((s) => s.addServer);
+  const storeRemoveServer = useStore((s) => s.removeServer);
+  const storeAddAgent = useStore((s) => s.addAgent);
+  const storeRemoveAgent = useStore((s) => s.removeAgent);
+  const storeReorder = useStore((s) => s.reorderAgents);
 
   const discover = useCallback(async () => {
     const proxyAgents: AgentInfo[] = [];
 
     // Discover from proxy servers
-    const servers = getServers();
     for (const server of servers) {
       try {
         const raw = await api.fetchAgents(server.url, server.token);
@@ -70,9 +38,8 @@ export function useAgents() {
       } catch { /* ignore unreachable servers */ }
     }
 
-    // Discover direct agents
+    // Discover direct agents (order preserved from store array)
     const directList: AgentInfo[] = [];
-    const directs = getDirectAgents();
     for (const d of directs) {
       const status = await api.pingAgent(d.url, d.token);
       directList.push({
@@ -83,8 +50,8 @@ export function useAgents() {
       });
     }
 
-    // Order: direct agents → proxy servers, then apply saved order
-    const all = applyOrder([...directList, ...proxyAgents]);
+    // Order: direct agents → proxy servers
+    const all = [...directList, ...proxyAgents];
     setAgents(all);
 
     // Auto-select first running agent if none active
@@ -97,7 +64,7 @@ export function useAgents() {
         if (first) setActiveState(first.baseUrl);
       }
     }
-  }, [getServers, getDirectAgents]);
+  }, [servers, directs]);
 
   // Discover on mount and periodically
   useEffect(() => {
@@ -111,45 +78,37 @@ export function useAgents() {
     sessionStorage.setItem("kern_active_agent", key);
   }, []);
 
-  // Server management (proxy)
-  const addServer = useCallback((url: string, serverToken: string) => {
-    const servers = getServers();
-    if (servers.some((s) => s.url === url)) return;
-    servers.push({ url, token: serverToken });
-    localStorage.setItem("kern-servers", JSON.stringify(servers));
-    discover();
-  }, [getServers, discover]);
+  // Server management
+  const addServer = useCallback((url: string, token: string) => {
+    storeAddServer(url, token);
+  }, [storeAddServer]);
 
   const removeServer = useCallback((url: string) => {
-    const servers = getServers().filter((s) => s.url !== url);
-    localStorage.setItem("kern-servers", JSON.stringify(servers));
+    storeRemoveServer(url);
     setAgents((prev) => prev.filter((a) => !a.baseUrl.startsWith(url)));
-  }, [getServers]);
+  }, [storeRemoveServer]);
 
   // Direct agent management
-  const addDirectAgent = useCallback((url: string, agentToken: string) => {
-    const directs = getDirectAgents();
-    if (directs.some((d) => d.url === url)) return;
-    directs.push({ url, token: agentToken });
-    localStorage.setItem("kern-agents", JSON.stringify(directs));
-    discover();
-  }, [getDirectAgents, discover]);
+  const addDirectAgent = useCallback((url: string, token: string) => {
+    storeAddAgent(url, token);
+  }, [storeAddAgent]);
 
   const removeDirectAgent = useCallback((url: string) => {
-    const directs = getDirectAgents().filter((d) => d.url !== url);
-    localStorage.setItem("kern-agents", JSON.stringify(directs));
+    storeRemoveAgent(url);
     setAgents((prev) => prev.filter((a) => a.baseUrl !== url));
-  }, [getDirectAgents]);
+  }, [storeRemoveAgent]);
 
   const reorder = useCallback((fromIndex: number, toIndex: number) => {
+    // Reorder in store (persistent)
+    storeReorder(fromIndex, toIndex);
+    // Reorder in local state (immediate UI update)
     setAgents((prev) => {
       const next = [...prev];
       const [moved] = next.splice(fromIndex, 1);
       next.splice(toIndex, 0, moved);
-      localStorage.setItem("kern-agent-order", JSON.stringify(next.map((a) => a.baseUrl)));
       return next;
     });
-  }, []);
+  }, [storeReorder]);
 
   const activeAgent = agents.find((a) => a.baseUrl === active) ?? null;
 

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
 import type { AgentInfo } from "../lib/types";
 import { useStore } from "../lib/store";
 import * as api from "../lib/api";
@@ -11,9 +12,9 @@ export function useAgents() {
   const activeRef = useRef<string | null>(null);
   activeRef.current = active;
 
-  // Read connections from store
-  const servers = useStore((s) => s.connections.servers);
-  const directs = useStore((s) => s.connections.agents);
+  // Read connections from store with shallow equality to avoid spurious rerenders
+  const servers = useStore(useShallow((s) => s.connections.servers));
+  const directs = useStore(useShallow((s) => s.connections.agents));
   const storeAddServer = useStore((s) => s.addServer);
   const storeRemoveServer = useStore((s) => s.removeServer);
   const storeAddAgent = useStore((s) => s.addAgent);
@@ -78,20 +79,22 @@ export function useAgents() {
     sessionStorage.setItem("kern_active_agent", key);
   }, []);
 
-  // Server management
+  // Server management — trigger discover after store update
   const addServer = useCallback((url: string, token: string) => {
     storeAddServer(url, token);
-  }, [storeAddServer]);
+    setTimeout(discover, 100);
+  }, [storeAddServer, discover]);
 
   const removeServer = useCallback((url: string) => {
     storeRemoveServer(url);
     setAgents((prev) => prev.filter((a) => !a.baseUrl.startsWith(url)));
   }, [storeRemoveServer]);
 
-  // Direct agent management
+  // Direct agent management — trigger discover after store update
   const addDirectAgent = useCallback((url: string, token: string) => {
     storeAddAgent(url, token);
-  }, [storeAddAgent]);
+    setTimeout(discover, 100);
+  }, [storeAddAgent, discover]);
 
   const removeDirectAgent = useCallback((url: string) => {
     storeRemoveAgent(url);

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -79,22 +79,20 @@ export function useAgents() {
     sessionStorage.setItem("kern_active_agent", key);
   }, []);
 
-  // Server management — trigger discover after store update
+  // Server management — store update triggers discover via useEffect deps
   const addServer = useCallback((url: string, token: string) => {
     storeAddServer(url, token);
-    setTimeout(discover, 100);
-  }, [storeAddServer, discover]);
+  }, [storeAddServer]);
 
   const removeServer = useCallback((url: string) => {
     storeRemoveServer(url);
     setAgents((prev) => prev.filter((a) => !a.baseUrl.startsWith(url)));
   }, [storeRemoveServer]);
 
-  // Direct agent management — trigger discover after store update
+  // Direct agent management — store update triggers discover via useEffect deps
   const addDirectAgent = useCallback((url: string, token: string) => {
     storeAddAgent(url, token);
-    setTimeout(discover, 100);
-  }, [storeAddAgent, discover]);
+  }, [storeAddAgent]);
 
   const removeDirectAgent = useCallback((url: string) => {
     storeRemoveAgent(url);

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -1,0 +1,163 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ChatLayout = "bubble" | "flat";
+
+export interface Preferences {
+  chatLayout: ChatLayout;
+  coloredTools: boolean;
+  peekLastTool: boolean;
+  showTools: boolean;
+  syntaxTheme: string;
+}
+
+export interface ConnectionEntry {
+  url: string;
+  token: string;
+}
+
+interface UIState {
+  sidebarMini: boolean;
+  pinnedStats: string[];
+  activeDashboard: string | null;
+}
+
+export interface KernStore {
+  // Preferences
+  prefs: Preferences;
+  setPrefs: (partial: Partial<Preferences>) => void;
+
+  // Connections
+  connections: {
+    servers: ConnectionEntry[];
+    agents: ConnectionEntry[];
+  };
+  addServer: (url: string, token: string) => void;
+  removeServer: (url: string) => void;
+  addAgent: (url: string, token: string) => void;
+  removeAgent: (url: string) => void;
+  reorderAgents: (from: number, to: number) => void;
+
+  // UI state
+  ui: UIState;
+  setSidebarMini: (mini: boolean) => void;
+  togglePin: (key: string) => void;
+  setActiveDashboard: (name: string | null) => void;
+}
+
+const PREFS_DEFAULTS: Preferences = {
+  chatLayout: "flat",
+  coloredTools: true,
+  peekLastTool: false,
+  showTools: false,
+  syntaxTheme: "github-dark-dimmed",
+};
+
+export const useStore = create<KernStore>()(
+  persist(
+    (set) => ({
+      // Preferences
+      prefs: { ...PREFS_DEFAULTS },
+      setPrefs: (partial) =>
+        set((s) => ({ prefs: { ...s.prefs, ...partial } })),
+
+      // Connections
+      connections: { servers: [], agents: [] },
+      addServer: (url, token) =>
+        set((s) => {
+          if (s.connections.servers.some((sv) => sv.url === url)) return s;
+          return { connections: { ...s.connections, servers: [...s.connections.servers, { url, token }] } };
+        }),
+      removeServer: (url) =>
+        set((s) => ({
+          connections: { ...s.connections, servers: s.connections.servers.filter((sv) => sv.url !== url) },
+        })),
+      addAgent: (url, token) =>
+        set((s) => {
+          if (s.connections.agents.some((a) => a.url === url)) return s;
+          return { connections: { ...s.connections, agents: [...s.connections.agents, { url, token }] } };
+        }),
+      removeAgent: (url) =>
+        set((s) => ({
+          connections: { ...s.connections, agents: s.connections.agents.filter((a) => a.url !== url) },
+        })),
+      reorderAgents: (from, to) =>
+        set((s) => {
+          const next = [...s.connections.agents];
+          const [moved] = next.splice(from, 1);
+          next.splice(to, 0, moved);
+          return { connections: { ...s.connections, agents: next } };
+        }),
+
+      // UI state
+      ui: { sidebarMini: false, pinnedStats: [], activeDashboard: null },
+      setSidebarMini: (mini) =>
+        set((s) => ({ ui: { ...s.ui, sidebarMini: mini } })),
+      togglePin: (key) =>
+        set((s) => {
+          const pins = new Set(s.ui.pinnedStats);
+          if (pins.has(key)) pins.delete(key);
+          else pins.add(key);
+          return { ui: { ...s.ui, pinnedStats: [...pins] } };
+        }),
+      setActiveDashboard: (name) =>
+        set((s) => ({ ui: { ...s.ui, activeDashboard: name } })),
+    }),
+    {
+      name: "kern",
+      version: 1,
+      migrate: (persisted: unknown, version: number) => {
+        const state = persisted as Record<string, unknown>;
+        if (version === 0) {
+          // Read legacy fragmented keys
+          try {
+            const oldPrefs = JSON.parse(localStorage.getItem("kern-prefs") || "{}");
+            const oldTheme = localStorage.getItem("kern-hljs-theme");
+            const oldServers = JSON.parse(localStorage.getItem("kern-servers") || "[]");
+            const oldAgents = JSON.parse(localStorage.getItem("kern-agents") || "[]");
+            const oldMini = localStorage.getItem("kern-sidebar-mini") === "true";
+            const oldPinned = JSON.parse(localStorage.getItem("kern-pinned-stats") || "[]");
+            const oldDashboard = localStorage.getItem("kern-active-dashboard");
+
+            // Apply saved order to direct agents
+            let agents: ConnectionEntry[] = oldAgents;
+            try {
+              const order: string[] = JSON.parse(localStorage.getItem("kern-agent-order") || "[]");
+              if (order.length) {
+                const map = new Map<string, ConnectionEntry>(agents.map((a) => [a.url, a]));
+                const ordered: ConnectionEntry[] = [];
+                for (const url of order) {
+                  const agent = map.get(url);
+                  if (agent) { ordered.push(agent); map.delete(url); }
+                }
+                for (const agent of map.values()) ordered.push(agent);
+                agents = ordered;
+              }
+            } catch { /* ignore */ }
+
+            state.prefs = { ...PREFS_DEFAULTS, ...oldPrefs };
+            if (oldTheme) (state.prefs as Preferences).syntaxTheme = oldTheme;
+
+            state.connections = { servers: oldServers, agents };
+            state.ui = { sidebarMini: oldMini, pinnedStats: oldPinned, activeDashboard: oldDashboard };
+
+            // Clean up legacy keys
+            const legacyKeys = [
+              "kern-prefs", "kern-hljs-theme", "kern-servers", "kern-agents",
+              "kern-agent-order", "kern-sidebar-mini", "kern-pinned-stats", "kern-active-dashboard",
+            ];
+            for (const k of legacyKeys) localStorage.removeItem(k);
+          } catch { /* ignore migration errors — defaults will apply */ }
+        }
+        return state as unknown as KernStore;
+      },
+      partialize: (state) => ({
+        prefs: state.prefs,
+        connections: state.connections,
+        ui: state.ui,
+      }),
+    },
+  ),
+);

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -55,6 +55,59 @@ const PREFS_DEFAULTS: Preferences = {
   syntaxTheme: "github-dark-dimmed",
 };
 
+// Migrate legacy localStorage keys → single 'kern' key before Zustand loads.
+// Runs once on module import. If 'kern' already exists, skip.
+if (typeof window !== "undefined" && !localStorage.getItem("kern")) {
+  try {
+    const hasLegacy = localStorage.getItem("kern-prefs") || localStorage.getItem("kern-agents") || localStorage.getItem("kern-servers");
+    if (hasLegacy) {
+      const oldPrefs = JSON.parse(localStorage.getItem("kern-prefs") || "{}");
+      const oldTheme = localStorage.getItem("kern-hljs-theme");
+      const oldServers: ConnectionEntry[] = JSON.parse(localStorage.getItem("kern-servers") || "[]");
+      const oldAgents: ConnectionEntry[] = JSON.parse(localStorage.getItem("kern-agents") || "[]");
+      const oldMini = localStorage.getItem("kern-sidebar-mini") === "true";
+      const oldPinned: string[] = JSON.parse(localStorage.getItem("kern-pinned-stats") || "[]");
+      const oldDashboard = localStorage.getItem("kern-active-dashboard") || null;
+
+      // Apply saved order to direct agents
+      let agents: ConnectionEntry[] = oldAgents;
+      try {
+        const order: string[] = JSON.parse(localStorage.getItem("kern-agent-order") || "[]");
+        if (order.length) {
+          const map = new Map<string, ConnectionEntry>(agents.map((a) => [a.url, a]));
+          const ordered: ConnectionEntry[] = [];
+          for (const url of order) {
+            const agent = map.get(url);
+            if (agent) { ordered.push(agent); map.delete(url); }
+          }
+          for (const agent of map.values()) ordered.push(agent);
+          agents = ordered;
+        }
+      } catch { /* ignore */ }
+
+      const prefs = { ...PREFS_DEFAULTS, ...oldPrefs };
+      if (oldTheme) prefs.syntaxTheme = oldTheme;
+
+      const migrated = {
+        state: {
+          prefs,
+          connections: { servers: oldServers, agents },
+          ui: { sidebarMini: oldMini, pinnedStats: oldPinned, activeDashboard: oldDashboard },
+        },
+        version: 1,
+      };
+      localStorage.setItem("kern", JSON.stringify(migrated));
+
+      // Clean up legacy keys
+      const legacyKeys = [
+        "kern-prefs", "kern-hljs-theme", "kern-servers", "kern-agents",
+        "kern-agent-order", "kern-sidebar-mini", "kern-pinned-stats", "kern-active-dashboard",
+      ];
+      for (const k of legacyKeys) localStorage.removeItem(k);
+    }
+  } catch { /* ignore migration errors */ }
+}
+
 export const useStore = create<KernStore>()(
   persist(
     (set) => ({
@@ -108,105 +161,11 @@ export const useStore = create<KernStore>()(
     {
       name: "kern",
       version: 1,
-      migrate: (persisted: unknown, version: number) => {
-        const state = persisted as Record<string, unknown>;
-        if (version === 0) {
-          // Read legacy fragmented keys
-          try {
-            const oldPrefs = JSON.parse(localStorage.getItem("kern-prefs") || "{}");
-            const oldTheme = localStorage.getItem("kern-hljs-theme");
-            const oldServers = JSON.parse(localStorage.getItem("kern-servers") || "[]");
-            const oldAgents = JSON.parse(localStorage.getItem("kern-agents") || "[]");
-            const oldMini = localStorage.getItem("kern-sidebar-mini") === "true";
-            const oldPinned = JSON.parse(localStorage.getItem("kern-pinned-stats") || "[]");
-            const oldDashboard = localStorage.getItem("kern-active-dashboard");
-
-            // Apply saved order to direct agents
-            let agents: ConnectionEntry[] = oldAgents;
-            try {
-              const order: string[] = JSON.parse(localStorage.getItem("kern-agent-order") || "[]");
-              if (order.length) {
-                const map = new Map<string, ConnectionEntry>(agents.map((a) => [a.url, a]));
-                const ordered: ConnectionEntry[] = [];
-                for (const url of order) {
-                  const agent = map.get(url);
-                  if (agent) { ordered.push(agent); map.delete(url); }
-                }
-                for (const agent of map.values()) ordered.push(agent);
-                agents = ordered;
-              }
-            } catch { /* ignore */ }
-
-            state.prefs = { ...PREFS_DEFAULTS, ...oldPrefs };
-            if (oldTheme) (state.prefs as Preferences).syntaxTheme = oldTheme;
-
-            state.connections = { servers: oldServers, agents };
-            state.ui = { sidebarMini: oldMini, pinnedStats: oldPinned, activeDashboard: oldDashboard };
-
-            // Clean up legacy keys
-            const legacyKeys = [
-              "kern-prefs", "kern-hljs-theme", "kern-servers", "kern-agents",
-              "kern-agent-order", "kern-sidebar-mini", "kern-pinned-stats", "kern-active-dashboard",
-            ];
-            for (const k of legacyKeys) localStorage.removeItem(k);
-          } catch { /* ignore migration errors — defaults will apply */ }
-        }
-        return state as unknown as KernStore;
-      },
       partialize: (state) => ({
         prefs: state.prefs,
         connections: state.connections,
         ui: state.ui,
       }),
-      onRehydrateStorage: () => (state) => {
-        // Zustand skips migrate() when no prior persisted key exists.
-        // Check for legacy keys and import them on first hydration.
-        if (!state) return;
-        try {
-          const hasLegacy = localStorage.getItem("kern-prefs") || localStorage.getItem("kern-agents") || localStorage.getItem("kern-servers");
-          if (!hasLegacy) return;
-
-          const oldPrefs = JSON.parse(localStorage.getItem("kern-prefs") || "{}");
-          const oldTheme = localStorage.getItem("kern-hljs-theme");
-          const oldServers: ConnectionEntry[] = JSON.parse(localStorage.getItem("kern-servers") || "[]");
-          const oldAgents: ConnectionEntry[] = JSON.parse(localStorage.getItem("kern-agents") || "[]");
-          const oldMini = localStorage.getItem("kern-sidebar-mini") === "true";
-          const oldPinned: string[] = JSON.parse(localStorage.getItem("kern-pinned-stats") || "[]");
-          const oldDashboard = localStorage.getItem("kern-active-dashboard") || null;
-
-          // Apply saved order to direct agents
-          let agents = oldAgents;
-          try {
-            const order: string[] = JSON.parse(localStorage.getItem("kern-agent-order") || "[]");
-            if (order.length) {
-              const map = new Map<string, ConnectionEntry>(agents.map((a) => [a.url, a]));
-              const ordered: ConnectionEntry[] = [];
-              for (const url of order) {
-                const agent = map.get(url);
-                if (agent) { ordered.push(agent); map.delete(url); }
-              }
-              for (const agent of map.values()) ordered.push(agent);
-              agents = ordered;
-            }
-          } catch { /* ignore */ }
-
-          const prefs = { ...PREFS_DEFAULTS, ...oldPrefs };
-          if (oldTheme) prefs.syntaxTheme = oldTheme;
-
-          useStore.setState({
-            prefs,
-            connections: { servers: oldServers, agents },
-            ui: { sidebarMini: oldMini, pinnedStats: oldPinned, activeDashboard: oldDashboard },
-          });
-
-          // Clean up legacy keys
-          const legacyKeys = [
-            "kern-prefs", "kern-hljs-theme", "kern-servers", "kern-agents",
-            "kern-agent-order", "kern-sidebar-mini", "kern-pinned-stats", "kern-active-dashboard",
-          ];
-          for (const k of legacyKeys) localStorage.removeItem(k);
-        } catch { /* ignore migration errors */ }
-      },
     },
   ),
 );

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -102,6 +102,9 @@ if (typeof window !== "undefined" && !localStorage.getItem("kern")) {
       const legacyKeys = [
         "kern-prefs", "kern-hljs-theme", "kern-servers", "kern-agents",
         "kern-agent-order", "kern-sidebar-mini", "kern-pinned-stats", "kern-active-dashboard",
+        "kern-chat-layout", "kern-token",
+        "kern_filters", "kern_pinned_stats", "kern_servers", "kern_sidebar_prev",
+        "kern_sidebar_state", "kern_web_token",
       ];
       for (const k of legacyKeys) localStorage.removeItem(k);
     }

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -158,6 +158,55 @@ export const useStore = create<KernStore>()(
         connections: state.connections,
         ui: state.ui,
       }),
+      onRehydrateStorage: () => (state) => {
+        // Zustand skips migrate() when no prior persisted key exists.
+        // Check for legacy keys and import them on first hydration.
+        if (!state) return;
+        try {
+          const hasLegacy = localStorage.getItem("kern-prefs") || localStorage.getItem("kern-agents") || localStorage.getItem("kern-servers");
+          if (!hasLegacy) return;
+
+          const oldPrefs = JSON.parse(localStorage.getItem("kern-prefs") || "{}");
+          const oldTheme = localStorage.getItem("kern-hljs-theme");
+          const oldServers: ConnectionEntry[] = JSON.parse(localStorage.getItem("kern-servers") || "[]");
+          const oldAgents: ConnectionEntry[] = JSON.parse(localStorage.getItem("kern-agents") || "[]");
+          const oldMini = localStorage.getItem("kern-sidebar-mini") === "true";
+          const oldPinned: string[] = JSON.parse(localStorage.getItem("kern-pinned-stats") || "[]");
+          const oldDashboard = localStorage.getItem("kern-active-dashboard") || null;
+
+          // Apply saved order to direct agents
+          let agents = oldAgents;
+          try {
+            const order: string[] = JSON.parse(localStorage.getItem("kern-agent-order") || "[]");
+            if (order.length) {
+              const map = new Map<string, ConnectionEntry>(agents.map((a) => [a.url, a]));
+              const ordered: ConnectionEntry[] = [];
+              for (const url of order) {
+                const agent = map.get(url);
+                if (agent) { ordered.push(agent); map.delete(url); }
+              }
+              for (const agent of map.values()) ordered.push(agent);
+              agents = ordered;
+            }
+          } catch { /* ignore */ }
+
+          const prefs = { ...PREFS_DEFAULTS, ...oldPrefs };
+          if (oldTheme) prefs.syntaxTheme = oldTheme;
+
+          useStore.setState({
+            prefs,
+            connections: { servers: oldServers, agents },
+            ui: { sidebarMini: oldMini, pinnedStats: oldPinned, activeDashboard: oldDashboard },
+          });
+
+          // Clean up legacy keys
+          const legacyKeys = [
+            "kern-prefs", "kern-hljs-theme", "kern-servers", "kern-agents",
+            "kern-agent-order", "kern-sidebar-mini", "kern-pinned-stats", "kern-active-dashboard",
+          ];
+          for (const k of legacyKeys) localStorage.removeItem(k);
+        } catch { /* ignore migration errors */ }
+      },
     },
   ),
 );

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,8 @@
         "marked-highlight": "^2.2.4",
         "next": "16.2.2",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1562,7 +1563,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2661,7 +2662,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6599,6 +6600,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "marked-highlight": "^2.2.4",
     "next": "16.2.2",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/web/plugins/dashboard/useDashboards.ts
+++ b/web/plugins/dashboard/useDashboards.ts
@@ -6,6 +6,7 @@ import type { AgentInfo } from "../../lib/types";
 import type { DashboardInfo } from "./index";
 import { fetchDashboards, loadDashboardHtml } from "./index";
 import { registerSurface, unregisterSurface } from "../../lib/surfaces";
+import { useStore } from "../../lib/store";
 import { DashboardIframe } from "./components";
 
 interface DashboardStore {
@@ -35,9 +36,12 @@ const SURFACE_ID = "dashboard:panel";
 export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null): DashboardStore {
   const [panelHtml, setPanelHtml] = useState<{ html: string; title: string; dashboard?: string } | null>(null);
   const [allDashboards, setAllDashboards] = useState<DashboardInfo[]>([]);
-  const [activeDashboard, setActiveDashboard] = useState<string | null>(null);
+  const [activeDashboard, setActiveDashboardLocal] = useState<string | null>(null);
   const panelRef = useRef(panelHtml);
   panelRef.current = panelHtml;
+
+  const storeActiveDashboard = useStore((s) => s.ui.activeDashboard);
+  const storeSetActiveDashboard = useStore((s) => s.setActiveDashboard);
 
   // Fetch dashboards from all running agents
   useEffect(() => {
@@ -52,28 +56,31 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
 
   const openPanel = useCallback((html: string, title: string, dashboard?: string) => {
     setPanelHtml({ html, title, dashboard });
-    if (dashboard) { setActiveDashboard(dashboard); localStorage.setItem("kern-active-dashboard", dashboard); }
-  }, []);
+    if (dashboard) {
+      setActiveDashboardLocal(dashboard);
+      storeSetActiveDashboard(dashboard);
+    }
+  }, [storeSetActiveDashboard]);
 
   const closePanel = useCallback(() => {
     setPanelHtml(null);
-    setActiveDashboard(null);
-    localStorage.removeItem("kern-active-dashboard");
+    setActiveDashboardLocal(null);
+    storeSetActiveDashboard(null);
     unregisterSurface(SURFACE_ID);
-  }, []);
+  }, [storeSetActiveDashboard]);
 
   const loadAndOpen = useCallback((name: string, baseUrl: string, token: string) => {
     loadDashboardHtml(name, baseUrl, token)
       .then(html => {
         if (html) {
           setPanelHtml({ html, title: name, dashboard: name });
-          setActiveDashboard(name);
-          localStorage.setItem("kern-active-dashboard", name);
+          setActiveDashboardLocal(name);
+          storeSetActiveDashboard(name);
         } else {
           closePanel();
         }
       });
-  }, [closePanel]);
+  }, [closePanel, storeSetActiveDashboard]);
 
   // Stable render function that reads from ref to avoid re-registration loops
   const renderPanel = useCallback(() => createElement(DashboardIframe, { html: panelRef.current?.html || "" }), []);
@@ -96,11 +103,10 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
     }
   }, [panelHtml, renderPanel, onClosePanel]);
 
-  // Restore active dashboard on load
+  // Restore active dashboard on load from store
   useEffect(() => {
     if (!activeAgent) return;
-    const saved = localStorage.getItem("kern-active-dashboard");
-    if (saved) loadAndOpen(saved, activeAgent.baseUrl, activeAgent.token || "");
+    if (storeActiveDashboard) loadAndOpen(storeActiveDashboard, activeAgent.baseUrl, activeAgent.token || "");
   }, [activeAgent]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Close panel if active dashboard no longer exists

--- a/web/plugins/dashboard/useDashboards.ts
+++ b/web/plugins/dashboard/useDashboards.ts
@@ -36,12 +36,11 @@ const SURFACE_ID = "dashboard:panel";
 export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null): DashboardStore {
   const [panelHtml, setPanelHtml] = useState<{ html: string; title: string; dashboard?: string } | null>(null);
   const [allDashboards, setAllDashboards] = useState<DashboardInfo[]>([]);
-  const [activeDashboard, setActiveDashboardLocal] = useState<string | null>(null);
   const panelRef = useRef(panelHtml);
   panelRef.current = panelHtml;
 
-  const storeActiveDashboard = useStore((s) => s.ui.activeDashboard);
-  const storeSetActiveDashboard = useStore((s) => s.setActiveDashboard);
+  const activeDashboard = useStore((s) => s.ui.activeDashboard);
+  const setActiveDashboard = useStore((s) => s.setActiveDashboard);
 
   // Fetch dashboards from all running agents
   useEffect(() => {
@@ -56,31 +55,26 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
 
   const openPanel = useCallback((html: string, title: string, dashboard?: string) => {
     setPanelHtml({ html, title, dashboard });
-    if (dashboard) {
-      setActiveDashboardLocal(dashboard);
-      storeSetActiveDashboard(dashboard);
-    }
-  }, [storeSetActiveDashboard]);
+    if (dashboard) setActiveDashboard(dashboard);
+  }, [setActiveDashboard]);
 
   const closePanel = useCallback(() => {
     setPanelHtml(null);
-    setActiveDashboardLocal(null);
-    storeSetActiveDashboard(null);
+    setActiveDashboard(null);
     unregisterSurface(SURFACE_ID);
-  }, [storeSetActiveDashboard]);
+  }, [setActiveDashboard]);
 
   const loadAndOpen = useCallback((name: string, baseUrl: string, token: string) => {
     loadDashboardHtml(name, baseUrl, token)
       .then(html => {
         if (html) {
           setPanelHtml({ html, title: name, dashboard: name });
-          setActiveDashboardLocal(name);
-          storeSetActiveDashboard(name);
+          setActiveDashboard(name);
         } else {
           closePanel();
         }
       });
-  }, [closePanel, storeSetActiveDashboard]);
+  }, [closePanel, setActiveDashboard]);
 
   // Stable render function that reads from ref to avoid re-registration loops
   const renderPanel = useCallback(() => createElement(DashboardIframe, { html: panelRef.current?.html || "" }), []);
@@ -106,7 +100,7 @@ export function useDashboards(agents: AgentInfo[], activeAgent: AgentInfo | null
   // Restore active dashboard on load from store
   useEffect(() => {
     if (!activeAgent) return;
-    if (storeActiveDashboard) loadAndOpen(storeActiveDashboard, activeAgent.baseUrl, activeAgent.token || "");
+    if (activeDashboard) loadAndOpen(activeDashboard, activeAgent.baseUrl, activeAgent.token || "");
   }, [activeAgent]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Close panel if active dashboard no longer exists


### PR DESCRIPTION
Replaces ~10 fragmented localStorage keys with a single Zustand persist store.

## Changes

**New: `web/lib/store.ts`**
- Single `kern` localStorage key with all UI state
- Versioned migrations via Zustand persist middleware
- v0→v1 migration reads all legacy keys (prefs, theme, servers, agents, order, sidebar, pins, dashboard) and cleans them up

**Removed**
- `usePreferences` hook and `PREFS_DEFAULTS` from ThemePicker
- All direct `localStorage.getItem/setItem` calls across components

**Updated consumers**
- `page.tsx` — prefs and pinned stats from store
- `Sidebar.tsx` — mini/full state from store
- `ThemePicker.tsx` — syntax theme from store, removed local state
- `useAgents.ts` — connections (servers, direct agents, reorder) from store
- `useDashboards.ts` — active dashboard from store

## Store shape
```ts
{
  prefs: { chatLayout, coloredTools, peekLastTool, showTools, syntaxTheme },
  connections: { servers: [{url, token}], agents: [{url, token}] },
  ui: { sidebarMini, pinnedStats, activeDashboard }
}
```

Closes #147