### PR TITLE
Fix: dashboard panel close button hidden on narrow windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
 
 ### Fixes
+- **Dashboard panel resize** ([#121](https://github.com/oguzbilgic/kern-ai/issues/121)) — panel width now clamps on window resize; auto-closes when window is too narrow
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab
 
 ## desktop-v0.2.0

--- a/web/components/SurfaceManager.tsx
+++ b/web/components/SurfaceManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { getSurfaces, getSurfaceGroups, getSurfacesByGroup, onSurfaceChange, type Surface } from "../lib/surfaces";
+import { useStore } from "../lib/store";
 
 const accent = "#e5b567";
 
@@ -177,7 +178,23 @@ export function SurfacePanel() {
     const onResize = () => {
       const maxW = getMaxWidth();
       if (maxW < 280) {
-        // Not enough room — close all panel surfaces
+        // Try collapsing sidebar to mini first
+        const { ui, setSidebarMini } = useStore.getState();
+        if (!ui.sidebarMini) {
+          setSidebarMini(true);
+          // Recheck after sidebar collapses (200→75 = +125px)
+          requestAnimationFrame(() => {
+            const newMaxW = getMaxWidth();
+            if (newMaxW < 280) {
+              const panelSurfaces = getSurfaces().filter(s => s.mode === "panel");
+              panelSurfaces.forEach(s => s.onClose?.());
+            } else {
+              setWidth(prev => Math.max(280, Math.min(prev, newMaxW)));
+            }
+          });
+          return;
+        }
+        // Already mini — close panel
         const panelSurfaces = getSurfaces().filter(s => s.mode === "panel");
         panelSurfaces.forEach(s => s.onClose?.());
         return;

--- a/web/components/SurfaceManager.tsx
+++ b/web/components/SurfaceManager.tsx
@@ -158,13 +158,15 @@ export function SurfacePanel() {
   }, []);
 
   useEffect(() => {
+    const getMaxWidth = () => {
+      const sidebarEl = document.querySelector('[data-sidebar]') as HTMLElement | null;
+      const sidebarW = sidebarEl?.offsetWidth ?? 0;
+      return window.innerWidth - sidebarW - 360;
+    };
     const onMove = (e: MouseEvent) => {
       if (!dragging.current) return;
       const delta = startX.current - e.clientX;
-      const sidebarEl = document.querySelector('[data-sidebar]') as HTMLElement | null;
-      const sidebarW = sidebarEl?.offsetWidth ?? 0;
-      const maxW = window.innerWidth - sidebarW - 360;
-      setWidth(Math.max(280, Math.min(startW.current + delta, maxW)));
+      setWidth(Math.max(280, Math.min(startW.current + delta, getMaxWidth())));
     };
     const onUp = () => {
       dragging.current = false;
@@ -172,11 +174,16 @@ export function SurfacePanel() {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     };
+    const onResize = () => {
+      setWidth(prev => Math.max(280, Math.min(prev, getMaxWidth())));
+    };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
+    window.addEventListener("resize", onResize);
     return () => {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
+      window.removeEventListener("resize", onResize);
     };
   }, []);
 

--- a/web/components/SurfaceManager.tsx
+++ b/web/components/SurfaceManager.tsx
@@ -175,7 +175,14 @@ export function SurfacePanel() {
       document.body.style.userSelect = "";
     };
     const onResize = () => {
-      setWidth(prev => Math.max(280, Math.min(prev, getMaxWidth())));
+      const maxW = getMaxWidth();
+      if (maxW < 280) {
+        // Not enough room — close all panel surfaces
+        const panelSurfaces = getSurfaces().filter(s => s.mode === "panel");
+        panelSurfaces.forEach(s => s.onClose?.());
+        return;
+      }
+      setWidth(prev => Math.max(280, Math.min(prev, maxW)));
     };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);

--- a/web/components/SurfaceManager.tsx
+++ b/web/components/SurfaceManager.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { getSurfaces, getSurfaceGroups, getSurfacesByGroup, onSurfaceChange, type Surface } from "../lib/surfaces";
-import { useStore } from "../lib/store";
 
 const accent = "#e5b567";
 
@@ -178,23 +177,7 @@ export function SurfacePanel() {
     const onResize = () => {
       const maxW = getMaxWidth();
       if (maxW < 280) {
-        // Try collapsing sidebar to mini first
-        const { ui, setSidebarMini } = useStore.getState();
-        if (!ui.sidebarMini) {
-          setSidebarMini(true);
-          // Recheck after sidebar collapses (200→75 = +125px)
-          requestAnimationFrame(() => {
-            const newMaxW = getMaxWidth();
-            if (newMaxW < 280) {
-              const panelSurfaces = getSurfaces().filter(s => s.mode === "panel");
-              panelSurfaces.forEach(s => s.onClose?.());
-            } else {
-              setWidth(prev => Math.max(280, Math.min(prev, newMaxW)));
-            }
-          });
-          return;
-        }
-        // Already mini — close panel
+        // Not enough room — close all panel surfaces
         const panelSurfaces = getSurfaces().filter(s => s.mode === "panel");
         panelSurfaces.forEach(s => s.onClose?.());
         return;


### PR DESCRIPTION
Fixes #121. Adds resize event listener to clamp panel width when browser window shrinks. Previously panel could overflow viewport, hiding the close button.