### PR TITLE
Fix: text selection while dragging panel resize handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - **Dashboard panel resize** ([#121](https://github.com/oguzbilgic/kern-ai/issues/121)) — panel width now clamps on window resize; auto-closes when window is too narrow
+- **Panel resize text selection** ([#122](https://github.com/oguzbilgic/kern-ai/issues/122)) — dragging the panel resize handle no longer selects text in the chat area
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab
 
 ## desktop-v0.2.0

--- a/web/components/SurfaceManager.tsx
+++ b/web/components/SurfaceManager.tsx
@@ -209,8 +209,8 @@ export function SurfacePanel() {
 
   return (
     <div className="flex flex-col flex-shrink-0 relative" style={{ width }}>
-      {/* Drag overlay — blocks iframe from stealing mouse events */}
-      {isDragging && <div className="absolute inset-0 z-20" />}
+      {/* Drag overlay — covers entire viewport to block text selection and iframe mouse capture */}
+      {isDragging && <div className="fixed inset-0 z-[9999] cursor-col-resize" />}
       {/* Resize handle — wide invisible hit area with thin visible line */}
       <div
         onMouseDown={onDragStart}


### PR DESCRIPTION
Fixes #122. Replaced panel-local drag overlay with a full-viewport fixed overlay during resize drag, preventing text selection in the chat area and maintaining col-resize cursor everywhere.