### PR TITLE
fix: show cached name for offline agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
 
 ### Fixes
+- **Offline agent names** ([#166](https://github.com/oguzbilgic/kern-ai/issues/166)) — offline direct agents now show their cached name instead of repeating the hostname
 - **Dashboard panel resize** ([#121](https://github.com/oguzbilgic/kern-ai/issues/121)) — panel width now clamps on window resize; auto-closes when window is too narrow
 - **Panel resize text selection** ([#122](https://github.com/oguzbilgic/kern-ai/issues/122)) — dragging the panel resize handle no longer selects text in the chat area
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -20,6 +20,7 @@ export function useAgents() {
   const storeAddAgent = useStore((s) => s.addAgent);
   const storeRemoveAgent = useStore((s) => s.removeAgent);
   const storeReorder = useStore((s) => s.reorderAgents);
+  const storeUpdateName = useStore((s) => s.updateAgentName);
 
   const discover = useCallback(async () => {
     const proxyAgents: AgentInfo[] = [];
@@ -43,8 +44,17 @@ export function useAgents() {
     const directList: AgentInfo[] = [];
     for (const d of directs) {
       const status = await api.pingAgent(d.url, d.token);
+      let name: string;
+      if (status?.name) {
+        name = status.name;
+        // Cache name in store for offline fallback
+        if (name !== d.name) storeUpdateName(d.url, name);
+      } else {
+        // Offline — use cached name or fall back to hostname
+        name = d.name || new URL(d.url).hostname;
+      }
       directList.push({
-        name: status?.name || new URL(d.url).hostname,
+        name,
         running: status !== null,
         token: d.token,
         baseUrl: d.url,

--- a/web/lib/store.ts
+++ b/web/lib/store.ts
@@ -16,6 +16,7 @@ export interface Preferences {
 export interface ConnectionEntry {
   url: string;
   token: string;
+  name?: string;
 }
 
 interface UIState {
@@ -39,6 +40,7 @@ export interface KernStore {
   addAgent: (url: string, token: string) => void;
   removeAgent: (url: string) => void;
   reorderAgents: (from: number, to: number) => void;
+  updateAgentName: (url: string, name: string) => void;
 
   // UI state
   ui: UIState;
@@ -146,6 +148,15 @@ export const useStore = create<KernStore>()(
           next.splice(to, 0, moved);
           return { connections: { ...s.connections, agents: next } };
         }),
+      updateAgentName: (url, name) =>
+        set((s) => ({
+          connections: {
+            ...s.connections,
+            agents: s.connections.agents.map((a) =>
+              a.url === url ? { ...a, name } : a
+            ),
+          },
+        })),
 
       // UI state
       ui: { sidebarMini: false, pinnedStats: [], activeDashboard: null },


### PR DESCRIPTION
When a direct agent goes offline, the sidebar fell back to showing the hostname from the URL — often repeating the same IP for all offline agents.

Now we cache the agent name in the Zustand store on every successful ping and use the cached name when the agent is unreachable.

Fixes sidebar showing wrong/duplicate names for offline agents.