### PR TITLE
fix: don't render remove button in mini sidebar (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - **Offline agent names** ([#166](https://github.com/oguzbilgic/kern-ai/issues/166)) — offline direct agents now show their cached name instead of repeating the hostname
+- **Mini sidebar remove button** ([#159](https://github.com/oguzbilgic/kern-ai/issues/159)) — remove button no longer renders in mini mode, preventing accidental agent removal
 - **Dashboard panel resize** ([#121](https://github.com/oguzbilgic/kern-ai/issues/121)) — panel width now clamps on window resize; auto-closes when window is too narrow
 - **Panel resize text selection** ([#122](https://github.com/oguzbilgic/kern-ai/issues/122)) — dragging the panel resize handle no longer selects text in the chat area
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -68,11 +68,11 @@ function AgentRow({
           <span className="truncate whitespace-nowrap">{agent.name}</span>
         </div>
       </button>
-      {/* Remove button for direct agents */}
-      {onRemove && (
+      {/* Remove button for direct agents — hidden in mini mode */}
+      {onRemove && !mini && (
         <button
           onClick={(e) => { e.stopPropagation(); onRemove(); }}
-          className={`absolute right-1.5 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center rounded text-[var(--text-muted)] hover:text-red-400 hover:bg-[var(--bg-hover)] opacity-0 group-hover:opacity-100 transition-opacity text-xs ${mini ? "right-0.5 w-4 h-4" : ""}`}
+          className="absolute right-1.5 top-1/2 -translate-y-1/2 w-5 h-5 flex items-center justify-center rounded text-[var(--text-muted)] hover:text-red-400 hover:bg-[var(--bg-hover)] opacity-0 group-hover:opacity-100 transition-opacity text-xs"
           title="Remove agent"
         >
           ✕


### PR DESCRIPTION
The remove button (✕) for direct agents was hidden via CSS opacity in mini mode but still received click events, causing accidental agent removal when clicking near the avatar.

Fix: don't render the button at all when sidebar is in mini mode.

Closes #159