### PR TITLE
feat: code block copy button (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
 
 ### Improvements
+- **Code block copy button** ([#156](https://github.com/oguzbilgic/kern-ai/issues/156)) — fenced code blocks show a copy-to-clipboard button on hover with language label
 - **Zustand store** ([#148](https://github.com/oguzbilgic/kern-ai/pull/148)) — replaced ~12 fragmented localStorage keys with a single persisted Zustand store; automatic migration from legacy keys on first load
 - **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -33,6 +33,56 @@ body {
 .markdown-body {
   line-height: 1.6;
 }
+.markdown-body .code-block-wrapper {
+  position: relative;
+  margin: 8px 0;
+}
+.markdown-body .code-block-wrapper pre {
+  margin: 0;
+}
+.markdown-body .code-lang {
+  position: absolute;
+  top: 6px;
+  right: 52px;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  pointer-events: none;
+}
+.markdown-body .code-copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.markdown-body .code-copy-btn .copy-icon,
+.markdown-body .code-copy-btn .check-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+.markdown-body .code-copy-btn .check-icon {
+  display: none;
+}
+.markdown-body .code-copy-btn.copied .copy-icon { display: none; }
+.markdown-body .code-copy-btn.copied .check-icon { display: inline; }
+.markdown-body .code-block-wrapper:hover .code-copy-btn {
+  opacity: 1;
+}
+.markdown-body .code-copy-btn:hover {
+  color: var(--text-dim);
+  border-color: var(--text-muted);
+}
 .markdown-body pre {
   background: #161616;
   border: 1px solid var(--border);

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -55,6 +55,11 @@ const marked = new Marked(
     gfm: true,
     breaks: true,
     renderer: {
+      code({ text, lang }) {
+        const langClass = lang ? `hljs language-${lang}` : "hljs";
+        const langLabel = lang ? `<span class="code-lang">${lang}</span>` : "";
+        return `<div class="code-block-wrapper">${langLabel}<button class="code-copy-btn" title="Copy" onclick="var t=this.closest('.code-block-wrapper').querySelector('code').textContent||'',a=document.createElement('textarea');a.value=t;a.style.cssText='position:fixed;opacity:0';document.body.appendChild(a);a.select();document.execCommand('copy');document.body.removeChild(a);this.classList.add('copied');var b=this;setTimeout(function(){b.classList.remove('copied')},1500)"><span class="copy-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg></span><span class="check-icon" style="color:#3fb950"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"></polyline></svg></span></button><pre><code class="${langClass}">${text}</code></pre></div>`;
+      },
       link({ href, text }) {
         // Block javascript: URLs
         if (/^javascript:/i.test(href)) return text;


### PR DESCRIPTION
Adds a copy-to-clipboard button on fenced code blocks in chat messages.

- Button appears on hover, top-right corner
- Shows language label next to button
- Checkmark confirmation after copy
- Styled to match dark theme

Closes #156