### PR TITLE
Show agent connection info in info panel (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Features
 - **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
+- **Agent connection info** ([#164](https://github.com/oguzbilgic/kern-ai/issues/164)) — info panel shows agent URL and masked token with copy buttons; both pinnable to header
+- **Code block copy button** ([#156](https://github.com/oguzbilgic/kern-ai/issues/156)) — fenced code blocks show a copy-to-clipboard button on hover with language label
 
 ### Improvements
-- **Code block copy button** ([#156](https://github.com/oguzbilgic/kern-ai/issues/156)) — fenced code blocks show a copy-to-clipboard button on hover with language label
 - **Zustand store** ([#148](https://github.com/oguzbilgic/kern-ai/pull/148)) — replaced ~12 fragmented localStorage keys with a single persisted Zustand store; automatic migration from legacy keys on first load
 - **OpenRouter attribution** — updated app title to "Kern Agent" and added `X-OpenRouter-Title` header alongside legacy `X-Title`
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -154,7 +154,7 @@ export default function Home() {
                 {activeAgent?.name || "no agent"}
               </span>
             </button>
-            <PinnedStats status={status} pinned={pinned} />
+            <PinnedStats status={status} pinned={pinned} baseUrl={activeAgent?.baseUrl} token={activeAgent?.token} />
           </div>
           <div className="ml-auto flex items-center gap-1">
             <ThemePicker />
@@ -176,7 +176,7 @@ export default function Home() {
 
         {/* Info panel */}
         {infoOpen && (
-          <InfoPanel status={status} connected={connected} pinned={pinned} onTogglePin={togglePin} onClose={() => setInfoOpen(false)} />
+          <InfoPanel status={status} connected={connected} pinned={pinned} onTogglePin={togglePin} onClose={() => setInfoOpen(false)} baseUrl={activeAgent?.baseUrl} token={activeAgent?.token} />
         )}
 
         <Chat

--- a/web/components/InfoPanel.tsx
+++ b/web/components/InfoPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { StatusData } from "../lib/types";
 
 interface InfoPanelProps {
@@ -6,6 +7,8 @@ interface InfoPanelProps {
   pinned: Set<string>;
   onTogglePin: (key: string) => void;
   onClose: () => void;
+  baseUrl?: string;
+  token?: string;
 }
 
 function getRows(status: StatusData): [string, string][] {
@@ -30,10 +33,14 @@ function getRows(status: StatusData): [string, string][] {
   ].filter((r): r is [string, string] => !!r[1]);
 }
 
-export function PinnedStats({ status, pinned }: { status: StatusData | null; pinned: Set<string> }) {
-  if (!status || pinned.size === 0) return null;
-  const rows = getRows(status);
-  const items = rows.filter(([label]) => pinned.has(label));
+export function PinnedStats({ status, pinned, baseUrl, token }: { status: StatusData | null; pinned: Set<string>; baseUrl?: string; token?: string }) {
+  if (pinned.size === 0) return null;
+  const rows = status ? getRows(status) : [];
+  const connectionRows: [string, string][] = [];
+  if (baseUrl) connectionRows.push(["URL", baseUrl]);
+  if (token) connectionRows.push(["Token", maskToken(token)]);
+  const allRows = [...rows, ...connectionRows];
+  const items = allRows.filter(([label]) => pinned.has(label));
   if (items.length === 0) return null;
 
   return (
@@ -45,7 +52,33 @@ export function PinnedStats({ status, pinned }: { status: StatusData | null; pin
   );
 }
 
-export function InfoPanel({ status, connected, pinned, onTogglePin, onClose }: InfoPanelProps) {
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.style.cssText = "position:fixed;opacity:0";
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    document.body.removeChild(ta);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button onClick={copy} className="ml-2 text-[10px] text-[var(--text-muted)] hover:text-[var(--text-dim)] transition-colors">
+      {copied ? "✓" : "copy"}
+    </button>
+  );
+}
+
+function maskToken(token: string): string {
+  if (token.length <= 8) return "••••••••";
+  return "••••••••" + token.slice(-4);
+}
+
+export function InfoPanel({ status, connected, pinned, onTogglePin, onClose, baseUrl, token }: InfoPanelProps) {
   if (!status) return null;
 
   const rows = getRows(status);
@@ -72,6 +105,37 @@ export function InfoPanel({ status, connected, pinned, onTogglePin, onClose }: I
               <td className="text-[var(--text-dim)] font-mono py-[2px]">{value}</td>
             </tr>
           ))}
+          {(baseUrl || token) && (
+            <>
+
+              {baseUrl && (
+                <tr className="cursor-pointer" onClick={() => onTogglePin("URL")}>
+                  <td className="pr-1 py-[2px] align-top">
+                    <span className={`text-[10px] ${pinned.has("URL") ? "text-[var(--text-dim)]" : "text-[var(--border)]"}`}>
+                      {pinned.has("URL") ? "●" : "○"}
+                    </span>
+                  </td>
+                  <td className="text-[var(--text-muted)] pr-4 py-[2px] align-top whitespace-nowrap">URL</td>
+                  <td className="text-[var(--text-dim)] font-mono py-[2px]">
+                    {baseUrl}<CopyButton text={baseUrl} />
+                  </td>
+                </tr>
+              )}
+              {token && (
+                <tr className="cursor-pointer" onClick={() => onTogglePin("Token")}>
+                  <td className="pr-1 py-[2px] align-top">
+                    <span className={`text-[10px] ${pinned.has("Token") ? "text-[var(--text-dim)]" : "text-[var(--border)]"}`}>
+                      {pinned.has("Token") ? "●" : "○"}
+                    </span>
+                  </td>
+                  <td className="text-[var(--text-muted)] pr-4 py-[2px] align-top whitespace-nowrap">Token</td>
+                  <td className="text-[var(--text-dim)] font-mono py-[2px]">
+                    {maskToken(token)}<CopyButton text={token} />
+                  </td>
+                </tr>
+              )}
+            </>
+          )}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Adds URL and masked token to the agent info panel with copy buttons.

- **URL**: full base URL, copyable, pinnable to header
- **Token**: masked (`••••••••xxxx`, last 4 chars visible), copy button copies full token, pinnable
- Both rows are pinnable like all other stats
- No backend changes

Closes #164