### PR TITLE
fix(desktop): load local page first to preserve iframe permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 - **Panel resize text selection** ([#122](https://github.com/oguzbilgic/kern-ai/issues/122)) — dragging the panel resize handle no longer selects text in the chat area
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab
 
+## desktop-next
+
+### Fixes
+- **Dashboard iframe rendering** — fixed iframes not rendering in desktop app caused by overly strict navigation filter blocking iframe sub-resource loads
+
 ## desktop-v0.3.0
 
 ### Features

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -54,25 +54,29 @@ fn main() {
             let window = WebviewWindowBuilder::new(
                 app,
                 "main",
-                WebviewUrl::External(start_url.parse().unwrap()),
+                WebviewUrl::App("index.html".into()),
             )
             .title("kern")
             .inner_size(1000.0, 700.0)
             .min_inner_size(600.0, 400.0)
-            .on_navigation(move |url| {
-                let scheme = url.scheme();
-                // Allow http (local agents) and the default app URL
-                if scheme == "http" || scheme == "tauri" {
-                    true
-                } else if scheme == "https" && url.host_str() == Some("app.kern-ai.com") {
-                    true
-                } else {
-                    // Open external https links in system browser
-                    let _ = handle.opener().open_url(url.as_str(), None::<&str>);
-                    false
-                }
+            .on_navigation(move |_url| {
+                // Allow all navigations in WebView — external link interception
+                // is handled by the click listener in on_page_load instead
+                true
             })
-            .on_page_load(|w, _payload| {
+            .on_page_load(move |w, _payload| {
+                // Redirect local page to target server URL
+                let url = if let Some(custom) = read_custom_url(w.app_handle()) {
+                    custom
+                } else {
+                    DEFAULT_URL.to_string()
+                };
+                let current_url = w.url().map(|u| u.to_string()).unwrap_or_default();
+                if current_url.starts_with("tauri://") {
+                    let _ = w.eval(&format!("window.location.replace('{}');", url));
+                }
+
+                // Intercept _blank links for on_navigation handling
                 w.eval(r#"
                     document.addEventListener('click', function(e) {
                         var a = e.target.closest('a[target="_blank"]');


### PR DESCRIPTION
Fixes dashboard iframes not rendering in desktop app after v0.3.0.

**Root cause:** v0.3.0 changed from `WebviewUrl::App` to `WebviewUrl::External`, which makes WKWebView treat the page as an external origin. This breaks `srcDoc` sandboxed iframes (dashboards).

**Fix:** Load bundled `index.html` first (`tauri://localhost` origin), then immediately redirect to target URL via `on_page_load`. The redirect only fires once when current URL is `tauri://`. All other navigation (Custom Server, Reset, menu actions) continues to work as before.

One file changed, ~16 lines.