### PR TITLE
feat: SearXNG websearch provider with fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - **SearXNG websearch provider** ([#177](https://github.com/oguzbilgic/kern-ai/issues/177)) — `websearch` tool now supports a provider fallback chain: SearXNG (if `SEARXNG_URL` set) → DuckDuckGo. SearXNG results formatted as markdown (top 10), DDG falls back to HTML scraping. Each provider has a 5s timeout; failures log and fall through
-- **Markdown tool output** — `websearch` and `webfetch` tool results now render as styled markdown in the web UI instead of plain monospace text
+- **Markdown search output** — `websearch` and `webfetch` tool results render as styled markdown in the web UI instead of plain monospace text
 - **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
 - **Agent connection info** ([#164](https://github.com/oguzbilgic/kern-ai/issues/164)) — info panel shows agent URL and masked token with copy buttons; both pinnable to header
 - **Code block copy button** ([#156](https://github.com/oguzbilgic/kern-ai/issues/156)) — fenced code blocks show a copy-to-clipboard button on hover with language label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## next
 
 ### Features
-- **SearXNG websearch provider** ([#177](https://github.com/oguzbilgic/kern-ai/issues/177)) — `websearch` tool now supports a provider fallback chain: SearXNG (if `SEARXNG_URL` set) → DuckDuckGo. Each provider has a 5s timeout; failures log warnings and fall through to the next provider
+- **SearXNG websearch provider** ([#177](https://github.com/oguzbilgic/kern-ai/issues/177)) — `websearch` tool now supports a provider fallback chain: SearXNG (if `SEARXNG_URL` set) → DuckDuckGo. SearXNG results formatted as markdown (top 10), DDG falls back to HTML scraping. Each provider has a 5s timeout; failures log and fall through
+- **Markdown tool output** — `websearch` and `webfetch` tool results now render as styled markdown in the web UI instead of plain monospace text
 - **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
 - **Agent connection info** ([#164](https://github.com/oguzbilgic/kern-ai/issues/164)) — info panel shows agent URL and masked token with copy buttons; both pinnable to header
 - **Code block copy button** ([#156](https://github.com/oguzbilgic/kern-ai/issues/156)) — fenced code blocks show a copy-to-clipboard button on hover with language label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 ### Features
+- **SearXNG websearch provider** ([#177](https://github.com/oguzbilgic/kern-ai/issues/177)) — `websearch` tool now supports a provider fallback chain: SearXNG (if `SEARXNG_URL` set) → DuckDuckGo. Each provider has a 5s timeout; failures log warnings and fall through to the next provider
 - **Sidebar agent reordering** ([#145](https://github.com/oguzbilgic/kern-ai/issues/145)) — drag-and-drop to reorder direct agents in the sidebar; order persisted across sessions; Cmd/Ctrl+1..9 shortcuts follow sidebar order
 - **Agent connection info** ([#164](https://github.com/oguzbilgic/kern-ai/issues/164)) — info panel shows agent URL and masked token with copy buttons; both pinnable to header
 - **Code block copy button** ([#156](https://github.com/oguzbilgic/kern-ai/issues/156)) — fenced code blocks show a copy-to-clipboard button on hover with language label

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,6 +53,7 @@ Secrets. Gitignored. Never committed.
 ```
 OPENROUTER_API_KEY=sk-or-...
 OLLAMA_BASE_URL=http://localhost:11434
+SEARXNG_URL=http://searxng:8080
 TELEGRAM_BOT_TOKEN=...
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_APP_TOKEN=xapp-...
@@ -60,6 +61,8 @@ KERN_AUTH_TOKEN=...
 ```
 
 Only set the API keys for providers/interfaces you use.
+
+**`SEARXNG_URL`** — URL of a self-hosted [SearXNG](https://github.com/searxng/searxng) instance with JSON API enabled. When set, `websearch` tool uses SearXNG as primary search provider with DuckDuckGo as fallback.
 
 ### Auth tokens
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -95,7 +95,7 @@ Truncates responses over 50000 chars.
 
 ## websearch
 
-Search the web using DuckDuckGo. Returns results as markdown with titles, links, and snippets.
+Search the web. Returns results as markdown with titles, URLs, and snippets. Uses a provider fallback chain: SearXNG (if `SEARXNG_URL` set) → DuckDuckGo.
 
 ```
 websearch({ query: "node.js html to markdown library" })

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -25,7 +25,10 @@ const searxng: SearchProvider = {
       clearTimeout(timer);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      return JSON.stringify(data.results ?? data, null, 2);
+      const results = (data.results ?? []).slice(0, 10);
+      return results
+        .map((r: any) => `## ${r.title}\n${r.url}\n${r.content || ""}`)
+        .join("\n\n");
     } catch (e) {
       clearTimeout(timer);
       throw e;
@@ -74,7 +77,7 @@ const providers: SearchProvider[] = [searxng, ddg];
 
 export const websearchTool = tool({
   description:
-    "Search the web using DuckDuckGo. Returns search results as markdown with titles, URLs, and snippets.",
+    "Search the web. Returns search results as markdown with titles, URLs, and snippets.",
   inputSchema: z.object({
     query: z.string().describe("The search query"),
   }),

--- a/src/tools/websearch.ts
+++ b/src/tools/websearch.ts
@@ -1,21 +1,48 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { htmlToMarkdown } from "../util.js";
+import { log } from "../log.js";
 
-export const websearchTool = tool({
-  description:
-    "Search the web using DuckDuckGo. Returns search results as markdown with titles, URLs, and snippets.",
-  inputSchema: z.object({
-    query: z.string().describe("The search query"),
-  }),
-  execute: async ({ query }) => {
-    const timeout = 30000;
+const TIMEOUT = 5000;
+
+type SearchProvider = {
+  name: string;
+  enabled: () => boolean;
+  search: (query: string) => Promise<string>;
+};
+
+const searxng: SearchProvider = {
+  name: "searxng",
+  enabled: () => !!process.env.SEARXNG_URL,
+  search: async (query) => {
+    const base = process.env.SEARXNG_URL!.replace(/\/$/, "");
+    const url = `${base}/search?q=${encodeURIComponent(query)}&format=json`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT);
+
     try {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeout);
+      const res = await fetch(url, { signal: controller.signal });
+      clearTimeout(timer);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      return JSON.stringify(data.results ?? data, null, 2);
+    } catch (e) {
+      clearTimeout(timer);
+      throw e;
+    }
+  },
+};
 
+const ddg: SearchProvider = {
+  name: "ddg",
+  enabled: () => true,
+  search: async (query) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), TIMEOUT);
+
+    try {
       const url = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
-      const response = await fetch(url, {
+      const res = await fetch(url, {
         method: "POST",
         signal: controller.signal,
         headers: {
@@ -25,37 +52,46 @@ export const websearchTool = tool({
       });
 
       clearTimeout(timer);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
-      if (!response.ok) {
-        return `Error: HTTP ${response.status} ${response.statusText}`;
-      }
-
-      let html = await response.text();
-
-      // Strip DDG chrome — keep only the results section
+      let html = await res.text();
       const resultsStart = html.indexOf('<div class="serp__results">');
-      if (resultsStart !== -1) {
-        html = html.slice(resultsStart);
-      }
+      if (resultsStart !== -1) html = html.slice(resultsStart);
 
       const result = htmlToMarkdown(html);
-
-      // Truncate very large responses
       if (result.length > 50000) {
-        return (
-          result.slice(0, 50000) +
-          "\n...(truncated, " +
-          result.length +
-          " chars total)"
-        );
+        return result.slice(0, 50000) + "\n...(truncated, " + result.length + " chars total)";
       }
-
       return result;
-    } catch (e: any) {
-      if (e.name === "AbortError") {
-        return `Error: request timed out after ${timeout}ms`;
-      }
-      return `Error: ${e.message}`;
+    } catch (e) {
+      clearTimeout(timer);
+      throw e;
     }
+  },
+};
+
+const providers: SearchProvider[] = [searxng, ddg];
+
+export const websearchTool = tool({
+  description:
+    "Search the web using DuckDuckGo. Returns search results as markdown with titles, URLs, and snippets.",
+  inputSchema: z.object({
+    query: z.string().describe("The search query"),
+  }),
+  execute: async ({ query }) => {
+    const active = providers.filter((p) => p.enabled());
+
+    for (const provider of active) {
+      try {
+        const result = await provider.search(query);
+        log.debug("tools", `websearch: ${provider.name} succeeded for "${query}"`);
+        return result;
+      } catch (e: any) {
+        const reason = e.name === "AbortError" ? "timeout" : e.message;
+        log.warn("tools", `websearch: ${provider.name} failed for "${query}": ${reason}`);
+      }
+    }
+
+    return "Error: all search providers failed. Try again later or use webfetch with a direct URL.";
   },
 });

--- a/web/components/ToolCall.tsx
+++ b/web/components/ToolCall.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import type { ChatMessage } from "../lib/types";
+import { renderMarkdown } from "../lib/markdown";
 import hljs from "highlight.js/lib/core";
 import bash from "highlight.js/lib/languages/bash";
 import javascript from "highlight.js/lib/languages/javascript";
@@ -297,6 +298,13 @@ function WriteOutput({ path, input, output }: { path: string; input: Record<stri
   return <PlainOutput output={output} />;
 }
 
+function MarkdownOutput({ output }: { output: string }) {
+  return (
+    <div className="markdown-body text-[12px]"
+      dangerouslySetInnerHTML={{ __html: renderMarkdown(output) }} />
+  );
+}
+
 function renderToolOutput(msg: ChatMessage) {
   const name = msg.toolName || "";
   const input = msg.toolInput || {};
@@ -315,7 +323,7 @@ function renderToolOutput(msg: ChatMessage) {
       return <GrepOutput output={output} />;
     case "webfetch":
     case "websearch":
-      return <PlainOutput output={output} maxLen={1500} />;
+      return <MarkdownOutput output={output} />;
     default:
       return <PlainOutput output={output} />;
   }


### PR DESCRIPTION
Closes #177

Refactors `websearch` tool to use a provider fallback chain:

1. **SearXNG** — top 10 results formatted as markdown (title, URL, snippet). Enabled when `SEARXNG_URL` env var is set.
2. **DuckDuckGo** — existing HTML scraping, always last in chain.

Each provider gets a 5s timeout. On failure, logs a warning and tries next. If all fail, returns error string.

Also renders `websearch` and `webfetch` tool output as styled markdown in the web UI instead of plain monospace.

### Changes
- `src/tools/websearch.ts` — provider chain with SearXNG + DDG, markdown formatting
- `web/components/ToolCall.tsx` — `MarkdownOutput` for websearch/webfetch results
- `docs/config.md` — document `SEARXNG_URL` env var
- `CHANGELOG.md` — two new features

No new dependencies.