### PR TITLE
fix(desktop): open external links in system browser

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -76,14 +76,21 @@ fn main() {
                     let _ = w.eval(&format!("window.location.replace('{}');", url));
                 }
 
-                // Intercept _blank links for on_navigation handling
+                // Intercept external links — open in system browser
                 w.eval(r#"
                     document.addEventListener('click', function(e) {
-                        var a = e.target.closest('a[target="_blank"]');
-                        if (a && a.href) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            window.location.href = a.href;
+                        var a = e.target.closest('a[href]');
+                        if (!a) return;
+                        var href = a.href;
+                        if (!href || href.startsWith('javascript:')) return;
+                        var url = new URL(href, window.location.href);
+                        // Same origin = let WebView handle it
+                        if (url.origin === window.location.origin) return;
+                        // External link = open in system browser
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (window.__TAURI_INTERNALS__) {
+                            window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: href });
                         }
                     }, true);
                 "#).ok();


### PR DESCRIPTION
External links (different origin) were navigating inside the WebView, breaking the app. Now intercepts all `<a href>` clicks, compares origin, and opens external URLs in the system browser via Tauri opener plugin. Same-origin links still handled by WebView.

Fixes clicking on docs links, GitHub links, blog links etc. inside the desktop app.