### PR TITLE
fix(desktop): open external links in system browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 - **Dashboard links** ([#141](https://github.com/oguzbilgic/kern-ai/issues/141)) — external links inside dashboard iframes now open in a new tab
 - **Recall tool in-context filtering** ([#58](https://github.com/oguzbilgic/kern-ai/issues/58)) — Recall tool no longer returns chunks already in the context window
 
+## desktop-next
+
+### Fixes
+- **External links open in system browser** ([#190](https://github.com/oguzbilgic/kern-ai/pull/190)) — links to external sites (docs, GitHub, etc.) now open in the default browser instead of navigating inside the WebView
+
 ## desktop-v0.3.1
 
 ### Fixes

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,9 @@
+{
+  "identifier": "default",
+  "description": "Default capabilities for the main window",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "opener:default"
+  ]
+}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -81,23 +81,24 @@ fn main() {
                     let _ = w.eval(&format!("window.location.replace('{}');", url));
                 }
 
-                // Intercept external links — open in system browser
+                // Intercept external links — open in system browser (deduplicated)
                 w.eval(r#"
-                    document.addEventListener('click', function(e) {
-                        var a = e.target.closest('a[href]');
-                        if (!a) return;
-                        var href = a.href;
-                        if (!href || href.startsWith('javascript:')) return;
-                        var url = new URL(href, window.location.href);
-                        // Same origin = let WebView handle it
-                        if (url.origin === window.location.origin) return;
-                        // External link = open in system browser
-                        e.preventDefault();
-                        e.stopPropagation();
-                        if (window.__TAURI_INTERNALS__) {
-                            window.__TAURI_INTERNALS__.invoke('open_external', { url: href });
-                        }
-                    }, true);
+                    if (!window.__kern_link_handler) {
+                        window.__kern_link_handler = true;
+                        document.addEventListener('click', function(e) {
+                            var a = e.target.closest('a[href]');
+                            if (!a) return;
+                            var href = a.href;
+                            if (!href || href.startsWith('javascript:')) return;
+                            var url = new URL(href, window.location.href);
+                            if (url.origin === window.location.origin) return;
+                            e.preventDefault();
+                            e.stopPropagation();
+                            if (window.__TAURI_INTERNALS__) {
+                                window.__TAURI_INTERNALS__.invoke('open_external', { url: href });
+                            }
+                        }, true);
+                    }
                 "#).ok();
             })
             .disable_drag_drop_handler()

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -12,6 +12,11 @@ use tauri_plugin_opener::OpenerExt;
 const DEFAULT_URL: &str = "https://app.kern-ai.com";
 
 #[tauri::command]
+fn open_external(app: tauri::AppHandle, url: String) {
+    let _ = app.opener().open_url(&url, None::<&str>);
+}
+
+#[tauri::command]
 fn set_custom_url(app: tauri::AppHandle, url: String) {
     let u = if url.is_empty() { None } else { Some(url.as_str()) };
     write_custom_url(&app, u);
@@ -46,7 +51,7 @@ fn get_start_url(app: &tauri::AppHandle) -> String {
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![set_custom_url])
+        .invoke_handler(tauri::generate_handler![set_custom_url, open_external])
         .setup(|app| {
             let start_url = get_start_url(app.handle());
             let handle = app.handle().clone();
@@ -90,7 +95,7 @@ fn main() {
                         e.preventDefault();
                         e.stopPropagation();
                         if (window.__TAURI_INTERNALS__) {
-                            window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: href });
+                            window.__TAURI_INTERNALS__.invoke('open_external', { url: href });
                         }
                     }, true);
                 "#).ok();
@@ -234,7 +239,7 @@ fn main() {
                 "open_browser" => {
                     if let Some(w) = window {
                         let _ = w.eval(
-                            "window.__TAURI_INTERNALS__?.invoke('plugin:opener|open_url', { url: window.location.href });",
+                            "window.__TAURI_INTERNALS__?.invoke('open_external', { url: window.location.href });",
                         );
                     }
                 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -76,14 +76,21 @@ fn main() {
                     let _ = w.eval(&format!("window.location.replace('{}');", url));
                 }
 
-                // Intercept _blank links for on_navigation handling
+                // Intercept external links — open in system browser
                 w.eval(r#"
                     document.addEventListener('click', function(e) {
-                        var a = e.target.closest('a[target="_blank"]');
-                        if (a && a.href) {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            window.location.href = a.href;
+                        var a = e.target.closest('a[href]');
+                        if (!a) return;
+                        var href = a.href;
+                        if (!href || href.startsWith('javascript:')) return;
+                        var url = new URL(href, window.location.href);
+                        // Same origin = let WebView handle it
+                        if (url.origin === window.location.origin) return;
+                        // External link = open in system browser
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (window.__TAURI_INTERNALS__) {
+                            window.__TAURI_INTERNALS__.invoke('plugin:opener|open_url', { url: href });
                         }
                     }, true);
                 "#).ok();


### PR DESCRIPTION
External links (different origin) were navigating inside the WebView, breaking the app. Now intercepts all `<a href>` clicks, compares origin, and opens external URLs in the system browser via Tauri opener plugin. Same-origin links still handled by WebView.