### PR TITLE
feat: KERN_* env var config overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## next
+
+### Features
+- **Env var config overrides** ([#192](https://github.com/oguzbilgic/kern-ai/issues/192)) — `KERN_NAME`, `KERN_PORT`, and `KERN_MODEL` environment variables override matching config fields. Env vars take priority over `config.json`. Designed for Docker deployments where config is passed via environment.
+
 ## v0.26.0
 
 ### Features

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,19 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 - **openai** — OpenAI or Azure. Model IDs like `gpt-4o`.
 - **ollama** — local Ollama server. Model IDs match Ollama model names like `gemma4:31b`. Set `OLLAMA_BASE_URL` in `.env` for remote servers (default: `http://localhost:11434`).
 
+## Environment variable overrides
+
+Environment variables override matching `config.json` fields. Useful for Docker deployments where config is passed via environment.
+
+| Env var | Config field | Type |
+|---------|-------------|------|
+| `KERN_NAME` | `name` | string |
+| `KERN_PORT` | `port` | number |
+| `KERN_MODEL` | `model` | string |
+| `KERN_PROVIDER` | `provider` | string |
+
+Env vars take priority over `config.json`. Overrides are logged on startup.
+
 ## Per-agent: .kern/.env
 
 Secrets. Gitignored. Never committed.

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,10 +125,39 @@ export async function loadConfig(agentDir: string): Promise<KernConfig> {
       }
     }
 
-    return { ...configDefaults, ...cleaned };
+    return applyEnvOverrides({ ...configDefaults, ...cleaned });
   } catch {
-    return configDefaults;
+    return applyEnvOverrides(configDefaults);
   }
+}
+
+/**
+ * Apply KERN_* environment variable overrides to config.
+ * Only a small explicit set of fields are supported.
+ */
+const ENV_CONFIG_MAP: Record<string, { key: keyof KernConfig; type: "string" | "number" }> = {
+  KERN_NAME:  { key: "name",  type: "string" },
+  KERN_PORT:  { key: "port",  type: "number" },
+  KERN_MODEL: { key: "model", type: "string" },
+};
+
+function applyEnvOverrides(config: KernConfig): KernConfig {
+  for (const [envKey, { key, type }] of Object.entries(ENV_CONFIG_MAP)) {
+    const val = process.env[envKey];
+    if (val === undefined) continue;
+
+    if (type === "number") {
+      const num = Number(val);
+      if (!isNaN(num)) {
+        (config as any)[key] = num;
+        log("config", `${envKey} → ${key}=${num}`);
+      }
+    } else {
+      (config as any)[key] = val;
+      log("config", `${envKey} → ${key}=${val}`);
+    }
+  }
+  return config;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -136,9 +136,10 @@ export async function loadConfig(agentDir: string): Promise<KernConfig> {
  * Only a small explicit set of fields are supported.
  */
 const ENV_CONFIG_MAP: Record<string, { key: keyof KernConfig; type: "string" | "number" }> = {
-  KERN_NAME:  { key: "name",  type: "string" },
-  KERN_PORT:  { key: "port",  type: "number" },
-  KERN_MODEL: { key: "model", type: "string" },
+  KERN_NAME:     { key: "name",     type: "string" },
+  KERN_PORT:     { key: "port",     type: "number" },
+  KERN_MODEL:    { key: "model",    type: "string" },
+  KERN_PROVIDER: { key: "provider", type: "string" },
 };
 
 function applyEnvOverrides(config: KernConfig): KernConfig {


### PR DESCRIPTION
Adds environment variable overrides for agent config fields. Env vars take priority over `config.json`.

### Supported vars

| Env var | Config field | Type |
|---------|-------------|------|
| `KERN_NAME` | `name` | string |
| `KERN_PORT` | `port` | number |
| `KERN_MODEL` | `model` | string |

Secrets (`KERN_AUTH_TOKEN`, `OPENROUTER_API_KEY`, etc.) stay in `.kern/.env` as before.

Designed for Docker deployments:
```bash
docker run -v home:/home/kern -p 4100:4100 \
  -e KERN_NAME=vega \
  -e KERN_PORT=4100 \
  -e KERN_MODEL=anthropic/claude-sonnet-4 \
  -e KERN_AUTH_TOKEN=secret \
  kern-agent
```

Closes #192. Part of #157.