### PR TITLE
feat: kern run --init-if-needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## next
 
 ### Features
-- **Env var config overrides** ([#192](https://github.com/oguzbilgic/kern-ai/issues/192)) — `KERN_NAME`, `KERN_PORT`, and `KERN_MODEL` environment variables override matching config fields. Env vars take priority over `config.json`. Designed for Docker deployments where config is passed via environment.
+- **Env var config overrides** ([#192](https://github.com/oguzbilgic/kern-ai/issues/192)) — `KERN_NAME`, `KERN_PORT`, `KERN_MODEL`, and `KERN_PROVIDER` environment variables override matching config fields. Env vars take priority over `config.json`. Designed for Docker deployments where config is passed via environment.
+- **`kern run --init-if-needed`** ([#193](https://github.com/oguzbilgic/kern-ai/issues/193)) — auto-scaffolds agent directory on first start if `.kern/config.json` is missing. Uses `KERN_*` env vars for config, no interactive prompts. Enables zero-config Docker container startup on empty volumes.
 
 ## v0.26.0
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -228,3 +228,18 @@ List available slash commands with descriptions.
 ## kern run \<name|path\>
 
 Run an agent in the foreground (for development/debugging). Starts all interfaces (Telegram, Slack) in-process.
+
+### --init-if-needed
+
+Auto-scaffolds the agent directory on first start if `.kern/config.json` is missing. Reads `KERN_*` environment variables for configuration — no interactive prompts. Designed for Docker containers starting on empty volumes.
+
+```bash
+kern run --init-if-needed /home/kern/agent
+```
+
+Environment variables used during scaffold:
+- `KERN_NAME` — agent name (default: directory basename)
+- `KERN_MODEL` — model identifier (default: `anthropic/claude-opus-4.6`)
+- `KERN_PROVIDER` — provider name (default: `openrouter`)
+- `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OLLAMA_BASE_URL` — written to `.kern/.env`
+- `TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` — written to `.kern/.env` if set

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node --no-deprecation
 
-import { resolve } from "path";
+import { resolve, basename } from "path";
 import { existsSync } from "fs";
 import { startApp } from "./app.js";
 import { runInit } from "./init.js";
@@ -362,8 +362,18 @@ async function main() {
     const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
 
     if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
-      const { initMinimal } = await import("./init.js");
-      await initMinimal(agentDir);
+      const { scaffoldAgent, API_KEY_ENV } = await import("./init.js");
+      const name = process.env.KERN_NAME || basename(agentDir);
+      const provider = process.env.KERN_PROVIDER || "openrouter";
+      const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
+      await scaffoldAgent({
+        name, dir: agentDir, provider, envVar, skipStart: true,
+        model: process.env.KERN_MODEL || "anthropic/claude-opus-4.6",
+        apiKey: process.env[envVar] || "",
+        telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
+        slackBotToken: process.env.SLACK_BOT_TOKEN || "",
+        slackAppToken: process.env.SLACK_APP_TOKEN || "",
+      });
     }
 
     await startApp(agentDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,7 +357,15 @@ async function main() {
   }
 
   if (cmd === "run") {
-    const agentDir = await resolveAgentDir(args[1]);
+    const initIfNeeded = args.includes("--init-if-needed");
+    const dirArg = args.filter((a: string) => a !== "--init-if-needed")[1];
+    const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
+
+    if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
+      const { initMinimal } = await import("./init.js");
+      await initMinimal(agentDir);
+    }
+
     await startApp(agentDir);
     return;
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -136,7 +136,7 @@ const PROVIDERS = [
   { name: "Ollama (local)", value: "ollama", keyLabel: "Ollama server URL" },
 ];
 
-const API_KEY_ENV: Record<string, string> = {
+export const API_KEY_ENV: Record<string, string> = {
   openrouter: "OPENROUTER_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
   openai: "OPENAI_API_KEY",
@@ -397,7 +397,7 @@ export async function runInit(targetArg?: string, flags?: Record<string, string>
   });
 }
 
-interface ScaffoldOpts {
+export interface ScaffoldOpts {
   name: string;
   dir: string;
   provider: string;
@@ -410,7 +410,7 @@ interface ScaffoldOpts {
   skipStart?: boolean;
 }
 
-async function scaffoldAgent(opts: ScaffoldOpts): Promise<void> {
+export async function scaffoldAgent(opts: ScaffoldOpts): Promise<void> {
   const { name, dir, provider, model, apiKey, envVar, telegramToken, slackBotToken, slackAppToken, skipStart } = opts;
 
   const dirExists = existsSync(dir);
@@ -558,26 +558,3 @@ node_modules/
   }
 }
 
-/**
- * Minimal non-interactive init for Docker / --init-if-needed.
- * Calls scaffoldAgent with defaults from env vars, no prompts, no auto-start.
- */
-export async function initMinimal(dir: string): Promise<void> {
-  const name = process.env.KERN_NAME || basename(dir);
-  const provider = process.env.KERN_PROVIDER || "openrouter";
-  const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
-
-  await scaffoldAgent({
-    name,
-    dir: resolve(dir),
-    provider,
-    model: process.env.KERN_MODEL || "anthropic/claude-opus-4.6",
-    apiKey: process.env[envVar] || "",
-    envVar,
-    telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
-    slackBotToken: process.env.SLACK_BOT_TOKEN || "",
-    slackAppToken: process.env.SLACK_APP_TOKEN || "",
-    skipStart: true,
-  });
-  log("init", `initialized ${name} at ${dir}`);
-}

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,10 +1,11 @@
 import { mkdir, writeFile, readFile } from "fs/promises";
-import { join, resolve } from "path";
+import { join, resolve, basename } from "path";
 import { existsSync } from "fs";
 import { input, select, password } from "@inquirer/prompts";
 import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "./registry.js";
 import { startAgent } from "./daemon.js";
 import type { KernConfig } from "./config.js";
+import { log } from "./log.js";
 
 // Fallback models used when live fetch fails (e.g. no network, bad key)
 const FALLBACK_MODELS: Record<string, { name: string; value: string }[]> = {
@@ -551,4 +552,58 @@ node_modules/
   print(`    \x1b[36mkern web start\x1b[0m      browser chat`);
   print(`    \x1b[36mkern install ${name}\x1b[0m     auto-restart + boot persistence (systemd)`);
   print("");
+}
+
+/**
+ * Minimal non-interactive init for Docker / --init-if-needed.
+ * Creates .kern/config.json, .kern/.env, and scaffold files if missing.
+ * Uses KERN_* env vars and config defaults — no prompts.
+ */
+export async function initMinimal(dir: string): Promise<void> {
+  log("init", `initializing ${dir}`);
+
+  // Create directories
+  await mkdir(dir, { recursive: true });
+  await mkdir(join(dir, "knowledge"), { recursive: true });
+  await mkdir(join(dir, "notes"), { recursive: true });
+  await mkdir(join(dir, ".kern", "sessions"), { recursive: true });
+
+  const name = process.env.KERN_NAME || basename(dir);
+
+  // .kern/config.json
+  const config: Partial<KernConfig> = {
+    name,
+    model: process.env.KERN_MODEL || "anthropic/claude-opus-4.6",
+    provider: process.env.KERN_PROVIDER || "openrouter",
+    toolScope: "full",
+    port: await assignPort(),
+  };
+  await writeFile(join(dir, ".kern", "config.json"), JSON.stringify(config, null, 2) + "\n");
+
+  // .kern/.env — empty, secrets come from environment
+  if (!existsSync(join(dir, ".kern", ".env"))) {
+    await writeFile(join(dir, ".kern", ".env"), "");
+  }
+
+  // Scaffold markdown files if missing
+  if (!existsSync(join(dir, "AGENTS.md"))) {
+    const agentsMd = await readFile(join(import.meta.dirname, "..", "templates", "AGENTS.md"), "utf-8");
+    await writeFile(join(dir, "AGENTS.md"), agentsMd);
+  }
+  if (!existsSync(join(dir, "IDENTITY.md"))) {
+    const cap = name.charAt(0).toUpperCase() + name.slice(1);
+    await writeFile(join(dir, "IDENTITY.md"), `# Identity\n\nYou are ${cap}. Ask your human to define your role and responsibilities.\n\n## Home\n- Repo: this directory\n`);
+  }
+  if (!existsSync(join(dir, "KNOWLEDGE.md"))) {
+    await writeFile(join(dir, "KNOWLEDGE.md"), `# Knowledge Index\n\nNo knowledge files yet. Create files in \`knowledge/\` as you learn about your domain.\n`);
+  }
+  if (!existsSync(join(dir, "USERS.md"))) {
+    await writeFile(join(dir, "USERS.md"), `# Users\n\nNo paired users yet. Users pair via Telegram with a pairing code.\n`);
+  }
+  if (!existsSync(join(dir, ".gitignore"))) {
+    await writeFile(join(dir, ".gitignore"), `.kern/.env\n.kern/sessions/\n.kern/recall.db\n.kern/media/\n.kern/logs/\nnode_modules/\n`);
+  }
+
+  await registerAgent(dir);
+  log("init", `initialized ${name}`);
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -407,14 +407,16 @@ interface ScaffoldOpts {
   telegramToken: string;
   slackBotToken: string;
   slackAppToken: string;
+  quiet?: boolean;
 }
 
 async function scaffoldAgent(opts: ScaffoldOpts): Promise<void> {
-  const { name, dir, provider, model, apiKey, envVar, telegramToken, slackBotToken, slackAppToken } = opts;
+  const { name, dir, provider, model, apiKey, envVar, telegramToken, slackBotToken, slackAppToken, quiet } = opts;
+  const out = quiet ? () => {} : print;
 
   const dirExists = existsSync(dir);
-  print("");
-  print(dirExists ? `  Adding kern to ${dir}/...` : `  Creating ${dir}/...`);
+  out("");
+  out(dirExists ? `  Adding kern to ${dir}/...` : `  Creating ${dir}/...`);
 
   // Create directories
   await mkdir(dir, { recursive: true });
@@ -485,44 +487,44 @@ node_modules/
   // Write files — only create if they don't exist (except .kern/ which always gets written)
   if (!existsSync(join(dir, "AGENTS.md"))) {
     await writeFile(join(dir, "AGENTS.md"), agentsMd);
-    print("  + AGENTS.md");
+    out("  + AGENTS.md");
   } else {
-    print("  ○ AGENTS.md (exists)");
+    out("  ○ AGENTS.md (exists)");
   }
 
   if (!existsSync(join(dir, "IDENTITY.md"))) {
     await writeFile(join(dir, "IDENTITY.md"), identityMd);
-    print(`  + IDENTITY.md (${capitalName})`);
+    out(`  + IDENTITY.md (${capitalName})`);
   } else {
-    print("  ○ IDENTITY.md (exists)");
+    out("  ○ IDENTITY.md (exists)");
   }
 
   if (!existsSync(join(dir, "KNOWLEDGE.md"))) {
     await writeFile(join(dir, "KNOWLEDGE.md"), knowledgeMd);
-    print("  + KNOWLEDGE.md");
+    out("  + KNOWLEDGE.md");
   } else {
-    print("  ○ KNOWLEDGE.md (exists)");
+    out("  ○ KNOWLEDGE.md (exists)");
   }
 
   if (!existsSync(join(dir, "USERS.md"))) {
     await writeFile(join(dir, "USERS.md"), `# Users\n\nNo paired users yet. Users pair via Telegram with a pairing code.\n`);
-    print("  + USERS.md");
+    out("  + USERS.md");
   } else {
-    print("  ○ USERS.md (exists)");
+    out("  ○ USERS.md (exists)");
   }
 
   // .kern/ config always written (new agent or adopt)
   await writeFile(join(dir, ".kern", "config.json"), JSON.stringify(config, null, 2) + "\n");
-  print("  + .kern/config.json");
+  out("  + .kern/config.json");
 
   await writeFile(join(dir, ".kern", ".env"), envLines.join("\n") + "\n");
-  print("  + .kern/.env");
+  out("  + .kern/.env");
 
   if (!existsSync(join(dir, ".gitignore"))) {
     await writeFile(join(dir, ".gitignore"), gitignore);
-    print("  + .gitignore");
+    out("  + .gitignore");
   } else {
-    print("  ○ .gitignore (exists)");
+    out("  ○ .gitignore (exists)");
   }
 
   // Git init only for new repos
@@ -532,78 +534,51 @@ node_modules/
       execSync("git init", { cwd: dir, stdio: "ignore" });
       execSync("git add -A", { cwd: dir, stdio: "ignore" });
       execSync('git commit -m "initial agent setup"', { cwd: dir, stdio: "ignore" });
-      print("  + git init + first commit");
+      out("  + git init + first commit");
     } catch {
-      print("  (git init skipped)");
+      out("  (git init skipped)");
     }
   } else {
-    print("  ○ git repo (exists)");
+    out("  ○ git repo (exists)");
   }
 
-  // Register and start
+  // Register
   await registerAgent(dir);
-  print("");
-  print("  ✓ Starting...");
-  print("");
-  await startAgent(name);
-  print("");
-  print("  Next steps:");
-  print(`    \x1b[36mkern tui\x1b[0m            terminal chat`);
-  print(`    \x1b[36mkern web start\x1b[0m      browser chat`);
-  print(`    \x1b[36mkern install ${name}\x1b[0m     auto-restart + boot persistence (systemd)`);
-  print("");
+
+  if (!quiet) {
+    print("");
+    print("  ✓ Starting...");
+    print("");
+    await startAgent(name);
+    print("");
+    print("  Next steps:");
+    print(`    \x1b[36mkern tui\x1b[0m            terminal chat`);
+    print(`    \x1b[36mkern web start\x1b[0m      browser chat`);
+    print(`    \x1b[36mkern install ${name}\x1b[0m     auto-restart + boot persistence (systemd)`);
+    print("");
+  }
 }
 
 /**
  * Minimal non-interactive init for Docker / --init-if-needed.
- * Creates .kern/config.json, .kern/.env, and scaffold files if missing.
- * Uses KERN_* env vars and config defaults — no prompts.
+ * Calls scaffoldAgent with defaults from env vars, no prompts, no auto-start.
  */
 export async function initMinimal(dir: string): Promise<void> {
-  log("init", `initializing ${dir}`);
-
-  // Create directories
-  await mkdir(dir, { recursive: true });
-  await mkdir(join(dir, "knowledge"), { recursive: true });
-  await mkdir(join(dir, "notes"), { recursive: true });
-  await mkdir(join(dir, ".kern", "sessions"), { recursive: true });
-
   const name = process.env.KERN_NAME || basename(dir);
+  const provider = process.env.KERN_PROVIDER || "openrouter";
+  const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
 
-  // .kern/config.json
-  const config: Partial<KernConfig> = {
+  await scaffoldAgent({
     name,
+    dir: resolve(dir),
+    provider,
     model: process.env.KERN_MODEL || "anthropic/claude-opus-4.6",
-    provider: process.env.KERN_PROVIDER || "openrouter",
-    toolScope: "full",
-    port: await assignPort(),
-  };
-  await writeFile(join(dir, ".kern", "config.json"), JSON.stringify(config, null, 2) + "\n");
-
-  // .kern/.env — empty, secrets come from environment
-  if (!existsSync(join(dir, ".kern", ".env"))) {
-    await writeFile(join(dir, ".kern", ".env"), "");
-  }
-
-  // Scaffold markdown files if missing
-  if (!existsSync(join(dir, "AGENTS.md"))) {
-    const agentsMd = await readFile(join(import.meta.dirname, "..", "templates", "AGENTS.md"), "utf-8");
-    await writeFile(join(dir, "AGENTS.md"), agentsMd);
-  }
-  if (!existsSync(join(dir, "IDENTITY.md"))) {
-    const cap = name.charAt(0).toUpperCase() + name.slice(1);
-    await writeFile(join(dir, "IDENTITY.md"), `# Identity\n\nYou are ${cap}. Ask your human to define your role and responsibilities.\n\n## Home\n- Repo: this directory\n`);
-  }
-  if (!existsSync(join(dir, "KNOWLEDGE.md"))) {
-    await writeFile(join(dir, "KNOWLEDGE.md"), `# Knowledge Index\n\nNo knowledge files yet. Create files in \`knowledge/\` as you learn about your domain.\n`);
-  }
-  if (!existsSync(join(dir, "USERS.md"))) {
-    await writeFile(join(dir, "USERS.md"), `# Users\n\nNo paired users yet. Users pair via Telegram with a pairing code.\n`);
-  }
-  if (!existsSync(join(dir, ".gitignore"))) {
-    await writeFile(join(dir, ".gitignore"), `.kern/.env\n.kern/sessions/\n.kern/recall.db\n.kern/media/\n.kern/logs/\nnode_modules/\n`);
-  }
-
-  await registerAgent(dir);
-  log("init", `initialized ${name}`);
+    apiKey: process.env[envVar] || "",
+    envVar,
+    telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
+    slackBotToken: process.env.SLACK_BOT_TOKEN || "",
+    slackAppToken: process.env.SLACK_APP_TOKEN || "",
+    quiet: true,
+  });
+  log("init", `initialized ${name} at ${dir}`);
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -407,16 +407,15 @@ interface ScaffoldOpts {
   telegramToken: string;
   slackBotToken: string;
   slackAppToken: string;
-  quiet?: boolean;
+  skipStart?: boolean;
 }
 
 async function scaffoldAgent(opts: ScaffoldOpts): Promise<void> {
-  const { name, dir, provider, model, apiKey, envVar, telegramToken, slackBotToken, slackAppToken, quiet } = opts;
-  const out = quiet ? () => {} : print;
+  const { name, dir, provider, model, apiKey, envVar, telegramToken, slackBotToken, slackAppToken, skipStart } = opts;
 
   const dirExists = existsSync(dir);
-  out("");
-  out(dirExists ? `  Adding kern to ${dir}/...` : `  Creating ${dir}/...`);
+  print("");
+  print(dirExists ? `  Adding kern to ${dir}/...` : `  Creating ${dir}/...`);
 
   // Create directories
   await mkdir(dir, { recursive: true });
@@ -487,44 +486,44 @@ node_modules/
   // Write files — only create if they don't exist (except .kern/ which always gets written)
   if (!existsSync(join(dir, "AGENTS.md"))) {
     await writeFile(join(dir, "AGENTS.md"), agentsMd);
-    out("  + AGENTS.md");
+    print("  + AGENTS.md");
   } else {
-    out("  ○ AGENTS.md (exists)");
+    print("  ○ AGENTS.md (exists)");
   }
 
   if (!existsSync(join(dir, "IDENTITY.md"))) {
     await writeFile(join(dir, "IDENTITY.md"), identityMd);
-    out(`  + IDENTITY.md (${capitalName})`);
+    print(`  + IDENTITY.md (${capitalName})`);
   } else {
-    out("  ○ IDENTITY.md (exists)");
+    print("  ○ IDENTITY.md (exists)");
   }
 
   if (!existsSync(join(dir, "KNOWLEDGE.md"))) {
     await writeFile(join(dir, "KNOWLEDGE.md"), knowledgeMd);
-    out("  + KNOWLEDGE.md");
+    print("  + KNOWLEDGE.md");
   } else {
-    out("  ○ KNOWLEDGE.md (exists)");
+    print("  ○ KNOWLEDGE.md (exists)");
   }
 
   if (!existsSync(join(dir, "USERS.md"))) {
     await writeFile(join(dir, "USERS.md"), `# Users\n\nNo paired users yet. Users pair via Telegram with a pairing code.\n`);
-    out("  + USERS.md");
+    print("  + USERS.md");
   } else {
-    out("  ○ USERS.md (exists)");
+    print("  ○ USERS.md (exists)");
   }
 
   // .kern/ config always written (new agent or adopt)
   await writeFile(join(dir, ".kern", "config.json"), JSON.stringify(config, null, 2) + "\n");
-  out("  + .kern/config.json");
+  print("  + .kern/config.json");
 
   await writeFile(join(dir, ".kern", ".env"), envLines.join("\n") + "\n");
-  out("  + .kern/.env");
+  print("  + .kern/.env");
 
   if (!existsSync(join(dir, ".gitignore"))) {
     await writeFile(join(dir, ".gitignore"), gitignore);
-    out("  + .gitignore");
+    print("  + .gitignore");
   } else {
-    out("  ○ .gitignore (exists)");
+    print("  ○ .gitignore (exists)");
   }
 
   // Git init only for new repos
@@ -534,18 +533,18 @@ node_modules/
       execSync("git init", { cwd: dir, stdio: "ignore" });
       execSync("git add -A", { cwd: dir, stdio: "ignore" });
       execSync('git commit -m "initial agent setup"', { cwd: dir, stdio: "ignore" });
-      out("  + git init + first commit");
+      print("  + git init + first commit");
     } catch {
-      out("  (git init skipped)");
+      print("  (git init skipped)");
     }
   } else {
-    out("  ○ git repo (exists)");
+    print("  ○ git repo (exists)");
   }
 
-  // Register
+  // Register and start
   await registerAgent(dir);
 
-  if (!quiet) {
+  if (!skipStart) {
     print("");
     print("  ✓ Starting...");
     print("");
@@ -578,7 +577,7 @@ export async function initMinimal(dir: string): Promise<void> {
     telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
     slackBotToken: process.env.SLACK_BOT_TOKEN || "",
     slackAppToken: process.env.SLACK_APP_TOKEN || "",
-    quiet: true,
+    skipStart: true,
   });
   log("init", `initialized ${name} at ${dir}`);
 }


### PR DESCRIPTION
Auto-scaffolds agent directory on first start if `.kern/config.json` is missing.

### Behavior
- `kern run --init-if-needed` checks for `.kern/config.json` in the working directory
- If missing: creates `.kern/`, scaffold files (AGENTS.md, IDENTITY.md, etc.), config from env vars, registers agent
- If exists: starts normally (flag is a no-op)

### Config sources
Uses `KERN_*` env vars (#192) with sensible defaults:
- `KERN_NAME` → agent name (default: directory basename)
- `KERN_MODEL` → model (default: `anthropic/claude-opus-4.6`)
- `KERN_PROVIDER` → provider (default: `openrouter`)
- Port auto-assigned from 4100-4999

### Docker usage
```bash
docker run -v agent:/home/kern/agent -p 4100:4100 \
  -e KERN_NAME=vega \
  -e KERN_MODEL=anthropic/claude-opus-4.6 \
  -e OPENROUTER_API_KEY=sk-or-... \
  kern-agent
```

First run scaffolds, subsequent runs reuse existing config from volume.

Closes #193. Part of #157.