### PR TITLE
AgentSkills: core plugin and tool (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@
   - Standalone `skill` tool with `list`, `activate`, `deactivate` actions
   - Active skill instructions injected into system prompt — durable, never trimmed
   - API endpoints: `GET /skills`, `GET /skills/:name`
-  - Bundled `create-skill` builtin — helps agents write new skills following the standard
-  - `/skills` slash command shows catalog with active state
+  - Bundled `create-skill` builtin — helps agents write new skills following the standard ([#218](https://github.com/oguzbilgic/kern-ai/pull/218))
+  - `/skills` slash command shows catalog with active state ([#219](https://github.com/oguzbilgic/kern-ai/pull/219))
 ### Improvements
-- **Plugin status in `/status`** — plugins report status via `onStatus` hook, aggregated and shown in `/status` output (e.g. `skills: 2 active / 3 total`)
-- **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
+- **Plugin status in `/status`** ([#224](https://github.com/oguzbilgic/kern-ai/pull/224)) — plugins report status via `onStatus` hook, aggregated and shown in `/status` output (e.g. `skills: 2 active / 3 total`)
+- **Plugin slash commands** ([#219](https://github.com/oguzbilgic/kern-ai/pull/219)) — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
   - Web UI fetches available commands from `GET /commands` endpoint; plugin commands appear in autocomplete automatically
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,9 @@
   - API endpoints: `GET /skills`, `GET /skills/:name`
   - Bundled `create-skill` builtin — helps agents write new skills following the standard
   - `/skills` slash command shows catalog with active state
+### Improvements
 - **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
 - **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
-
-### Improvements
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.
 
 ## v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
   - Bundled `create-skill` builtin — helps agents write new skills following the standard
   - `/skills` slash command shows catalog with active state
 ### Improvements
+- **Plugin status in `/status`** — plugins report status via `onStatus` hook, aggregated and shown in `/status` output (e.g. `skills: 2 active / 3 total`)
 - **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
-- **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
+  - Web UI fetches available commands from `GET /commands` endpoint; plugin commands appear in autocomplete automatically
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.
 
 ## v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
   - Compact skill catalog always present in system prompt (~tokens per skill)
   - Standalone `skill` tool with `list`, `activate`, `deactivate` actions
   - Active skill instructions injected into system prompt — durable, never trimmed
-  - Active skills persisted to `.kern/active-skills.json` for restart recovery
   - API endpoints: `GET /skills`, `GET /skills/:name`
 
 ## v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - Active skill instructions injected into system prompt — durable, never trimmed
   - API endpoints: `GET /skills`, `GET /skills/:name`
 
+### Improvements
+- **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.
+
 ## v0.27.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## next
+
+### Features
+- **AgentSkills support** ([#213](https://github.com/oguzbilgic/kern-ai/issues/213)) — progressive disclosure skill system following the [AgentSkills](https://agentskills.io/) open standard
+  - Scans `skills/` (agent-created) and `.agents/skills/` (installed) for `SKILL.md` files
+  - Compact skill catalog always present in system prompt (~tokens per skill)
+  - Standalone `skill` tool with `list`, `activate`, `deactivate` actions
+  - Active skill instructions injected into system prompt — durable, never trimmed
+  - Active skills persisted to `.kern/active-skills.json` for restart recovery
+  - API endpoints: `GET /skills`, `GET /skills/:name`
+
 ## v0.27.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## next
 
 ### Features
-- **AgentSkills support** ([#213](https://github.com/oguzbilgic/kern-ai/issues/213)) — progressive disclosure skill system following the [AgentSkills](https://agentskills.io/) open standard
+- **AgentSkills support** ([#213](https://github.com/oguzbilgic/kern-ai/issues/213)) — progressive disclosure skill system following the [AgentSkills](https://agentskills.io/) universal spec, part of the [skills.sh](https://skills.sh) ecosystem
   - Scans `skills/` (agent-created) and `.agents/skills/` (installed) for `SKILL.md` files
   - Compact skill catalog always present in system prompt (~tokens per skill)
   - Standalone `skill` tool with `list`, `activate`, `deactivate` actions
@@ -11,6 +11,7 @@
   - API endpoints: `GET /skills`, `GET /skills/:name`
   - Bundled `create-skill` builtin — helps agents write new skills following the standard ([#218](https://github.com/oguzbilgic/kern-ai/pull/218))
   - `/skills` slash command shows catalog with active state ([#219](https://github.com/oguzbilgic/kern-ai/pull/219))
+  - Install community skills with `npx skills -a universal` or `npx clawhub --dir .agents/skills`
 ### Improvements
 - **Plugin status in `/status`** ([#224](https://github.com/oguzbilgic/kern-ai/pull/224)) — plugins report status via `onStatus` hook, aggregated and shown in `/status` output (e.g. `skills: 2 active / 3 total`)
 - **Plugin slash commands** ([#219](https://github.com/oguzbilgic/kern-ai/pull/219)) — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Standalone `skill` tool with `list`, `activate`, `deactivate` actions
   - Active skill instructions injected into system prompt — durable, never trimmed
   - API endpoints: `GET /skills`, `GET /skills/:name`
+  - Bundled `create-skill` builtin — helps agents write new skills following the standard
+  - `/skills` slash command shows catalog with active state
+- **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
+- **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
 
 ### Improvements
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Models can be mixed per role: `model` for chat, `embeddingModel` for recall, `su
 - [Dashboards](docs/dashboards.md)
 - [Context & segments](docs/context.md)
 - [Prompt caching](docs/caching.md)
+- [Skills](docs/skills.md)
 - [Media](docs/media.md)
 - [Tools](docs/tools.md)
 - [Interfaces](docs/interfaces.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,8 @@ These are internal — the web proxy forwards to them, TUI connects directly.
 | `/context/segments` | GET | Segments currently in context |
 | `/sessions` | GET | Session list with current session ID |
 | `/recall/stats` | GET | Recall index stats |
+| `/commands` | GET | Available slash commands (builtins + plugins) |
+| `/skills` | GET | Skill catalog with active status |
 
 ### Auth
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,6 +49,7 @@ These are internal — the web proxy forwards to them, TUI connects directly.
 | `/recall/stats` | GET | Recall index stats |
 | `/commands` | GET | Available slash commands (builtins + plugins) |
 | `/skills` | GET | Skill catalog with active status |
+| `/skills/:name` | GET | Skill detail including full body |
 
 ### Auth
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -34,7 +34,7 @@ Browser-based chat served by `kern web`. See [Interfaces](interfaces.md#web-ui) 
 - Mid-turn messaging — send follow-ups injected between tool steps
 - Full history on connect, including tool call results
 - Switching agents mid-stream preserves the partial assistant response instead of dropping the in-progress text
-- Slash commands — `/status`, `/restart`, `/help` with autocomplete popup
+- Slash commands with dynamic autocomplete — fetches available commands from agent, including plugin commands
 - Markdown rendering — headers, lists, code blocks, tables, bold, italic, links
 - Syntax highlighting in code blocks and tool output
 - Dark theme, mobile-friendly

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,9 +223,17 @@ Restart the agent daemon.
 - The agent cannot restart itself — it must ask the operator to type `/restart`
 - Web UI auto-reconnects after restart (re-discovers the new agent port)
 
+### /skills
+
+List all available skills with active/inactive status. Provided by the skills plugin.
+
 ### /help
 
-List available slash commands with descriptions.
+List available slash commands with descriptions. Includes commands registered by plugins.
+
+### API: GET /commands
+
+Returns all available slash commands (builtins + plugins) as a JSON object mapping command names to descriptions. Used by the web UI for dynamic autocomplete.
 
 ## kern run \<name|path\>
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -105,6 +105,6 @@ Bundled skills live inside the kern npm package and cannot be edited. To overrid
 
 ## Installing skills
 
-Skills from external registries are installed into `.agents/skills/`. This directory follows the [AgentSkills](https://agentskills.io/) convention shared across agent frameworks.
+Skills from external registries are installed into `.agents/skills/`. This directory follows the [AgentSkills](https://agentskills.io/) universal spec, part of the [skills.sh](https://skills.sh) ecosystem.
 
-Registry search and install commands are planned for a future release.
+Use `npx skills` with `-a universal` or `npx clawhub` with `--dir .agents/skills` to search, install, and manage community skills. Prefer official or widely-used skills over obscure ones.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,12 +4,15 @@ Skills are reusable instruction packages that extend an agent's capabilities. Ea
 
 ## Directories
 
-Skills are loaded from two directories:
+Skills are loaded from three directories, in priority order:
 
 | Directory | Purpose | Version controlled |
 |---|---|---|
 | `skills/` | Agent-created skills | Yes |
 | `.agents/skills/` | Installed from registries | No |
+| *(bundled)* | Ships with kern package | No |
+
+If a local skill has the same name as a bundled or installed skill, the local one takes priority.
 
 ## SKILL.md format
 
@@ -91,6 +94,14 @@ The `skill` tool has three actions:
    ```
 
 3. The skill appears in the catalog on the next turn — no restart needed.
+
+## Bundled skills
+
+kern ships with built-in skills that appear automatically in every agent's catalog. Currently bundled:
+
+- **create-skill** — helps agents write new skills following the AgentSkills format
+
+Bundled skills live inside the kern npm package and cannot be edited. To override a bundled skill, create a local skill with the same name in `skills/`.
 
 ## Installing skills
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -60,6 +60,10 @@ The `skill` tool has three actions:
 | `activate` | Load a skill's full instructions into system prompt |
 | `deactivate` | Unload a skill to free token budget |
 
+## Slash command
+
+`/skills` lists all available skills with active/inactive status icons. This command is registered by the skills plugin and appears in web UI autocomplete automatically.
+
 ## API
 
 | Endpoint | Description |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,95 @@
+# Skills
+
+Skills are reusable instruction packages that extend an agent's capabilities. Each skill is a folder containing a `SKILL.md` file with frontmatter metadata and markdown instructions.
+
+## Directories
+
+Skills are loaded from two directories:
+
+| Directory | Purpose | Version controlled |
+|---|---|---|
+| `skills/` | Agent-created skills | Yes |
+| `.agents/skills/` | Installed from registries | No |
+
+## SKILL.md format
+
+```markdown
+---
+name: deploy-lxc
+description: Create and configure Debian 12 LXC containers on Proxmox
+---
+
+# Deploy LXC
+
+Step-by-step instructions, commands, checklists, etc.
+```
+
+The frontmatter `name` and `description` are optional — if omitted, the folder name is used and description is empty.
+
+## How it works
+
+### Catalog injection
+
+A compact catalog of all available skills is always present in the agent's system prompt:
+
+```
+# Available Skills
+- deploy-lxc: Create and configure Debian 12 LXC containers on Proxmox
+- backup-db: Backup PostgreSQL databases to S3
+```
+
+This costs ~50-100 tokens per skill and lets the agent know what's available without loading full instructions.
+
+### Activation
+
+When the agent activates a skill, the full `SKILL.md` body is injected into the system prompt. This persists across turns until explicitly deactivated. Active skills are never subject to conversation trimming.
+
+Skills are in-memory only — they reset on agent restart.
+
+### Rescanning
+
+Skill directories are rescanned every turn. If the agent creates a new `skills/foo/SKILL.md` mid-session, it appears in the catalog immediately on the next turn.
+
+## Skill tool
+
+The `skill` tool has three actions:
+
+| Action | Description |
+|---|---|
+| `list` | Show all skills with active/inactive status |
+| `activate` | Load a skill's full instructions into system prompt |
+| `deactivate` | Unload a skill to free token budget |
+
+## API
+
+| Endpoint | Description |
+|---|---|
+| `GET /skills` | List all skills with name, description, source, active status |
+| `GET /skills/:name` | Skill detail including full body |
+
+## Creating a skill
+
+1. Create a folder in `skills/`:
+   ```
+   skills/my-skill/SKILL.md
+   ```
+
+2. Add frontmatter and instructions:
+   ```markdown
+   ---
+   name: my-skill
+   description: What this skill does
+   ---
+
+   # My Skill
+
+   Instructions the agent follows when this skill is active.
+   ```
+
+3. The skill appears in the catalog on the next turn — no restart needed.
+
+## Installing skills
+
+Skills from external registries are installed into `.agents/skills/`. This directory follows the [AgentSkills](https://agentskills.io/) convention shared across agent frameworks.
+
+Registry search and install commands are planned for a future release.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "templates",
+    "skills",
     "docs",
     "web/out"
   ],

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: create-skill
+description: Create a new skill following the AgentSkills format
+---
+
+# Create Skill
+
+Create well-structured skill files for yourself or other agents.
+
+## Skill format
+
+A skill is a folder containing `SKILL.md` with optional supporting files:
+
+```
+my-skill/
+├── SKILL.md          # Required: YAML frontmatter + instructions
+├── scripts/          # Optional: executable scripts
+├── references/       # Optional: docs, examples
+└── assets/           # Optional: templates, data
+```
+
+## SKILL.md structure
+
+```markdown
+---
+name: my-skill
+description: One-line description of what this skill does
+---
+
+# Skill Title
+
+Instructions the agent follows when this skill is activated.
+Include context, steps, commands, and examples.
+Reference files in this directory using the absolute path shown in the skill catalog.
+```
+
+## Guidelines
+
+- **Name**: lowercase, hyphenated (e.g. `deploy-app`, `run-tests`)
+- **Description**: one line, starts with a verb (e.g. "Deploy applications to production")
+- **Body**: actionable instructions, not documentation. Write for an agent, not a human.
+- **Scripts**: include executable scripts the agent can run via bash tool
+- **References**: include docs the agent can read on demand — don't put everything in SKILL.md
+
+## Where to create skills
+
+- `skills/` in the agent's repo for agent-specific skills
+- `.agents/skills/` for skills installed from registries
+
+## Example
+
+```markdown
+---
+name: check-health
+description: Run health checks on all homelab services
+---
+
+# Check Health
+
+Run health checks across all services and report status.
+
+## Steps
+
+1. Read the service list from `knowledge/services.md`
+2. For each service, run the check script:
+   ```bash
+   bash scripts/check.sh <service-name>
+   ```
+3. Collect results and report summary
+4. If any service is down, notify operator via message tool
+```

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,9 @@ import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusF
 import { plugins, type PluginContext } from "./plugins/index.js";
 import { log } from "./log.js";
 
-async function handleSlashCommand(cmd: string, userId: string, iface: string, agentName: string): Promise<string | null> {
+let _pluginCtx: PluginContext | null = null;
+
+async function handleSlashCommand(cmd: string, userId: string, iface: string, agentName: string, agentDir: string): Promise<string | null> {
   switch (cmd) {
     case "/restart": {
       log("kern", `restart requested by ${userId} via ${iface}`);
@@ -47,15 +49,25 @@ async function handleSlashCommand(cmd: string, userId: string, iface: string, ag
       return formatStatus(getStatusDataFn());
     }
 
-    case "/help":
-      return [
+    case "/help": {
+      const builtins = [
         "/status   — show agent status, uptime, token usage",
         "/restart  — restart the agent process",
-        "/help     — show this help",
-      ].join("\n");
+      ];
+      const pluginCmds = plugins.collectCommandDescriptions();
+      for (const [cmd, desc] of Object.entries(pluginCmds)) {
+        builtins.push(`${cmd.padEnd(10)} — ${desc}`);
+      }
+      builtins.push("/help     — show this help");
+      return builtins.join("\n");
+    }
 
-    default:
-      return null; // unknown command — fall through to LLM
+    default: {
+      // Check plugin commands before falling through to LLM
+      const pluginCmd = plugins.getCommand(cmd);
+      if (pluginCmd) return pluginCmd.handler(_pluginCtx!);
+      return null;
+    }
   }
 }
 
@@ -146,6 +158,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     db: memoryDB,
     sessionId: () => runtime.getSessionId(),
   };
+  _pluginCtx = pluginCtx;
   const loadedPlugins = await plugins.load(pluginCtx);
 
   // Register plugin tools and descriptions with runtime
@@ -237,7 +250,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     // Slash commands bypass the queue — instant response even if queue is busy
     const cmd = text.trim();
     if (cmd.startsWith("/")) {
-      const result = await handleSlashCommand(cmd, userId, iface, agentName);
+      const result = await handleSlashCommand(cmd, userId, iface, agentName, agentDir);
       if (result !== null) {
         server.broadcast({
           type: "command-result" as any,
@@ -252,6 +265,19 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
 
   server.setStatusFn(() => {
     return getStatusDataFn();
+  });
+
+  server.setCommandsFn(() => {
+    const cmds: Record<string, string> = {
+      "/status": "show agent status, uptime, token usage",
+      "/restart": "restart the agent process",
+    };
+    const pluginCmds = plugins.collectCommandDescriptions();
+    for (const [cmd, desc] of Object.entries(pluginCmds)) {
+      cmds[cmd] = desc;
+    }
+    cmds["/help"] = "show this help";
+    return cmds;
   });
 
   server.setMessageHandler(async (text, userId, iface, channel, attachments) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -270,10 +270,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   });
 
   server.setSystemPromptFn(async () => {
-    const latestSystem = await runtime.getSystemPrompt();
-    const built = runtime.buildPromptContext();
-    const systemText = typeof built.system === "string" ? built.system : built.system?.content;
-    return { system: systemText || latestSystem };
+    return { system: await runtime.getSystemPrompt() };
   });
 
   server.setContextSegmentsFn(() => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -273,8 +273,8 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     return { system: await runtime.getSystemPrompt() };
   });
 
-  server.setContextSegmentsFn(() => {
-    const built = runtime.buildPromptContext();
+  server.setContextSegmentsFn(async () => {
+    const built = await runtime.buildPromptContext();
     return {
       tokenCount: built.stats.summaryTokens,
       segments: built.stats.summarySegments,

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import { setMessageSender } from "./tools/message.js";
 import { SegmentIndex } from "./segments.js";
 import { MemoryDB } from "./memory.js";
 import { MessageQueue } from "./queue.js";
-import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusFn, setSegmentStatsFn, type InterfaceStatus } from "./tools/kern.js";
+import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusFn, setSegmentStatsFn, setPluginStatusFn, type InterfaceStatus } from "./tools/kern.js";
 import { plugins, type PluginContext } from "./plugins/index.js";
 import { log } from "./log.js";
 
@@ -160,6 +160,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   };
   _pluginCtx = pluginCtx;
   const loadedPlugins = await plugins.load(pluginCtx);
+  setPluginStatusFn(() => plugins.collectStatus(pluginCtx));
 
   // Register plugin tools and descriptions with runtime
   const pluginTools = plugins.collectTools();

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -121,6 +121,27 @@ export const plugins = {
     }
   },
 
+  /** Look up a slash command handler from plugins. */
+  getCommand(cmd: string): { description: string; handler: (ctx: PluginContext) => Promise<string> } | null {
+    for (const plugin of activePlugins) {
+      if (plugin.commands?.[cmd]) return plugin.commands[cmd];
+    }
+    return null;
+  },
+
+  /** Collect all plugin command descriptions for /help. */
+  collectCommandDescriptions(): Record<string, string> {
+    const cmds: Record<string, string> = {};
+    for (const plugin of activePlugins) {
+      if (plugin.commands) {
+        for (const [cmd, { description }] of Object.entries(plugin.commands)) {
+          cmds[cmd] = description;
+        }
+      }
+    }
+    return cmds;
+  },
+
   /** Process attachments — first plugin that returns a message wins. */
   async dispatchProcessAttachments(
     attachments: import("../interfaces/types.js").Attachment[],

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -84,7 +84,13 @@ export const plugins = {
       if (plugin.onBeforeContext) {
         try {
           const result = await plugin.onBeforeContext(info, ctx);
-          if (result) injections.push(result);
+          if (result) {
+            if (Array.isArray(result)) {
+              injections.push(...result);
+            } else {
+              injections.push(result);
+            }
+          }
         } catch (err: any) {
           log.error("plugin", `onBeforeContext error in ${plugin.name}: ${err.message}`);
         }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -3,6 +3,7 @@ import { dashboardPlugin } from "./dashboard/plugin.js";
 import { notesPlugin } from "./notes/plugin.js";
 import { recallPlugin } from "./recall/plugin.js";
 import { mediaPlugin } from "./media/plugin.js";
+import { skillsPlugin } from "./skills/plugin.js";
 import { log } from "../log.js";
 
 export type { KernPlugin, PluginContext, RouteHandler, ContextInjection, BeforeContextInfo } from "./types.js";
@@ -16,6 +17,7 @@ const availablePlugins: KernPlugin[] = [
   recallPlugin,
   mediaPlugin,
   dashboardPlugin,
+  skillsPlugin,
 ];
 
 /** Active plugin instances after loading */

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -142,6 +142,21 @@ export const plugins = {
     return cmds;
   },
 
+  /** Collect status info from all plugins. */
+  collectStatus(ctx: PluginContext): Record<string, any> {
+    const status: Record<string, any> = {};
+    for (const plugin of activePlugins) {
+      if (plugin.onStatus) {
+        try {
+          Object.assign(status, plugin.onStatus(ctx));
+        } catch (err: any) {
+          log.error("plugin", `onStatus error in ${plugin.name}: ${err.message}`);
+        }
+      }
+    }
+    return status;
+  },
+
   /** Process attachments — first plugin that returns a message wins. */
   async dispatchProcessAttachments(
     attachments: import("../interfaces/types.js").Attachment[],

--- a/src/plugins/notes/plugin.ts
+++ b/src/plugins/notes/plugin.ts
@@ -72,7 +72,7 @@ export const notesPlugin: KernPlugin = {
     }
   },
 
-  async onBeforeContext(_info: BeforeContextInfo, ctx: PluginContext): Promise<ContextInjection | null> {
+  async onBeforeContext(_info: BeforeContextInfo, ctx: PluginContext): Promise<ContextInjection[] | null> {
     // Refresh notes context each time (handles background regeneration)
     try {
       cachedNotes = await loadNotesContext(ctx.agentDir, ctx.config, ctx.db);
@@ -80,21 +80,23 @@ export const notesPlugin: KernPlugin = {
       log.error("notes", `failed to refresh notes context: ${err.message}`);
     }
 
-    const parts: string[] = [];
+    const injections: ContextInjection[] = [];
 
     if (cachedNotes.summary) {
-      parts.push(wrapNotesSummary(cachedNotes.summary));
+      injections.push({
+        label: "notes",
+        content: wrapNotesSummary(cachedNotes.summary),
+        placement: "system",
+      });
     }
     if (cachedNotes.latest && cachedNotes.latestFile) {
-      parts.push(wrapDocument(`notes/${cachedNotes.latestFile}`, cachedNotes.latest));
+      injections.push({
+        label: "",
+        content: wrapDocument(`notes/${cachedNotes.latestFile}`, cachedNotes.latest),
+        placement: "system",
+      });
     }
 
-    if (parts.length === 0) return null;
-
-    return {
-      label: "notes",
-      content: parts.join("\n\n"),
-      placement: "system",
-    };
+    return injections.length > 0 ? injections : null;
   },
 };

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -1,5 +1,5 @@
 import type { KernPlugin, PluginContext, RouteHandler, BeforeContextInfo, ContextInjection } from "../types.js";
-import { scanSkills, type SkillInfo } from "./scanner.js";
+import { scanSkills, loadSkillBody, type SkillInfo } from "./scanner.js";
 import { isActive, getActiveSkills } from "./state.js";
 import { skillTool, setCatalog } from "./tool.js";
 import { log } from "../../log.js";
@@ -21,58 +21,55 @@ export const skillsPlugin: KernPlugin = {
     skill: skillTool,
   },
 
-  routes: (() => {
-    let _ctx: PluginContext | null = null;
-
-    const routes: RouteHandler[] = [
-      {
-        method: "GET",
-        path: "/skills",
-        handler: (_req, res) => {
-          const active = getActiveSkills();
-          const result = catalog.map((s) => ({
-            name: s.name,
-            description: s.description,
-            path: s.path,
-            source: s.source,
-            active: active.has(s.name),
-          }));
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(result));
-        },
+  routes: [
+    {
+      method: "GET",
+      path: "/skills",
+      handler: (_req, res) => {
+        const active = getActiveSkills();
+        const result = catalog.map((s) => ({
+          name: s.name,
+          description: s.description,
+          path: s.displayPath,
+          source: s.source,
+          active: active.has(s.name),
+        }));
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
       },
-      {
-        method: "GET",
-        path: /^\/skills\/([^/]+)$/,
-        handler: (_req, res, match) => {
-          const name = match?.[1];
-          const skill = catalog.find((s) => s.name === name);
-          if (!skill) {
-            res.writeHead(404, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "Skill not found" }));
-            return;
-          }
+    },
+    {
+      method: "GET",
+      path: /^\/skills\/([^/]+)$/,
+      handler: async (_req, res, match) => {
+        const name = match?.[1];
+        const skill = catalog.find((s) => s.name === name);
+        if (!skill) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Skill not found" }));
+          return;
+        }
+        try {
           const active = getActiveSkills();
+          const body = await loadSkillBody(skill);
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({
             name: skill.name,
             description: skill.description,
-            path: skill.path,
+            path: skill.displayPath,
             source: skill.source,
             active: active.has(skill.name),
-            body: skill.body,
+            body,
           }));
-        },
+        } catch {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Failed to load skill body" }));
+        }
       },
-    ];
-
-    (routes as any)._setCtx = (ctx: PluginContext) => { _ctx = ctx; };
-    return routes;
-  })(),
+    },
+  ] as RouteHandler[],
 
   async onStartup(ctx) {
-    (this.routes as any)?._setCtx(ctx);
-
     // Scan skill directories
     catalog = await scanSkills(ctx.agentDir);
     setCatalog(catalog);
@@ -92,11 +89,10 @@ export const skillsPlugin: KernPlugin = {
 
     const injections: ContextInjection[] = [];
 
-    // Compact catalog with absolute paths and active state
+    // Compact catalog with logical paths and active state
     const catalogLines = catalog.map((s) => {
       const state = isActive(s.name) ? "active" : "available";
-      const skillPath = `${s.path}/SKILL.md`;
-      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${skillPath}`;
+      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${s.displayPath}`;
     });
     injections.push({
       label: "skills",
@@ -104,15 +100,19 @@ export const skillsPlugin: KernPlugin = {
       placement: "system",
     });
 
-    // Active skills: injected as <document> blocks (no label — content is pre-wrapped)
+    // Active skills: load body lazily and inject as <document> blocks
     for (const skill of catalog) {
       if (!isActive(skill.name)) continue;
-      const skillPath = `${skill.path}/SKILL.md`.replace(/"/g, '&quot;');
-      injections.push({
-        label: "",
-        content: `<document path="${skillPath}">\n${skill.body}\n</document>`,
-        placement: "system",
-      });
+      try {
+        const body = await loadSkillBody(skill);
+        injections.push({
+          label: "",
+          content: `<document path="${skill.displayPath}">\n${body}\n</document>`,
+          placement: "system",
+        });
+      } catch (err: any) {
+        log.warn("skills", `failed to load active skill ${skill.name}: ${err.message}`);
+      }
     }
 
     return injections;

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -118,6 +118,21 @@ export const skillsPlugin: KernPlugin = {
     return injections;
   },
 
+  commands: {
+    "/skills": {
+      description: "list available skills",
+      handler: async () => {
+        if (catalog.length === 0) return "No skills found.";
+        const active = getActiveSkills();
+        const lines = catalog.map((s) => {
+          const icon = active.has(s.name) ? "✦" : "○";
+          return `  ${icon} ${s.name} — ${s.description || "(no description)"}`;
+        });
+        return `Skills (${catalog.length} available, ${active.size} active)\n\n${lines.join("\n")}`;
+      },
+    },
+  },
+
   onStatus(_ctx) {
     return {
       skills: `${getActiveSkills().size} active / ${catalog.length} total`,

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -1,0 +1,118 @@
+import type { KernPlugin, PluginContext, RouteHandler, BeforeContextInfo, ContextInjection } from "../types.js";
+import { scanSkills, type SkillInfo } from "./scanner.js";
+import { initState, loadActiveSkills, isActive, getActiveSkills } from "./state.js";
+import { skillTool, setCatalog } from "./tool.js";
+import { log } from "../../log.js";
+
+/** Cached skill catalog */
+let catalog: SkillInfo[] = [];
+
+/**
+ * Skills plugin — progressive disclosure skill system.
+ *
+ * Scans skills/ (agent-created) and .agents/skills/ (installed) directories.
+ * Injects compact catalog into system prompt. Full skill content injected
+ * only when agent explicitly activates a skill.
+ */
+export const skillsPlugin: KernPlugin = {
+  name: "skills",
+
+  tools: {
+    skill: skillTool,
+  },
+
+  routes: (() => {
+    let _ctx: PluginContext | null = null;
+
+    const routes: RouteHandler[] = [
+      {
+        method: "GET",
+        path: "/skills",
+        handler: (_req, res) => {
+          const active = getActiveSkills();
+          const result = catalog.map((s) => ({
+            name: s.name,
+            description: s.description,
+            source: s.source,
+            active: active.has(s.name),
+          }));
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(result));
+        },
+      },
+      {
+        method: "GET",
+        path: /^\/skills\/([^/]+)$/,
+        handler: (_req, res, match) => {
+          const name = match?.[1];
+          const skill = catalog.find((s) => s.name === name);
+          if (!skill) {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: "Skill not found" }));
+            return;
+          }
+          const active = getActiveSkills();
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            name: skill.name,
+            description: skill.description,
+            source: skill.source,
+            active: active.has(skill.name),
+            body: skill.body,
+          }));
+        },
+      },
+    ];
+
+    (routes as any)._setCtx = (ctx: PluginContext) => { _ctx = ctx; };
+    return routes;
+  })(),
+
+  async onStartup(ctx) {
+    (this.routes as any)?._setCtx(ctx);
+
+    // Initialize state persistence
+    initState(ctx.agentDir);
+    await loadActiveSkills();
+
+    // Scan skill directories
+    catalog = await scanSkills(ctx.agentDir);
+    setCatalog(catalog);
+
+    if (catalog.length > 0) {
+      const active = getActiveSkills();
+      log("skills", `found ${catalog.length} skill(s), ${active.size} active`);
+    }
+  },
+
+  async onBeforeContext(_info: BeforeContextInfo, _ctx: PluginContext): Promise<ContextInjection | null> {
+    if (catalog.length === 0) return null;
+
+    const parts: string[] = [];
+
+    // Always: compact catalog
+    const catalogLines = catalog.map((s) => {
+      const marker = isActive(s.name) ? "✦" : "-";
+      return `${marker} ${s.name}: ${s.description || "(no description)"}`;
+    });
+    parts.push("# Available Skills\n" + catalogLines.join("\n"));
+
+    // Active skills: full content
+    for (const skill of catalog) {
+      if (!isActive(skill.name)) continue;
+      parts.push(`# Active Skill: ${skill.name}\n\n${skill.body}`);
+    }
+
+    return {
+      label: "skills",
+      content: parts.join("\n\n"),
+      placement: "system",
+    };
+  },
+
+  onStatus(_ctx) {
+    return {
+      skills: `${getActiveSkills().size} active / ${catalog.length} total`,
+    };
+  },
+};

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -81,33 +81,44 @@ export const skillsPlugin: KernPlugin = {
     }
   },
 
-  async onBeforeContext(_info: BeforeContextInfo, ctx: PluginContext): Promise<ContextInjection | null> {
+  async onBeforeContext(_info: BeforeContextInfo, ctx: PluginContext): Promise<ContextInjection[]> {
     // Rescan every turn — agent may have created/deleted skills mid-session
     catalog = await scanSkills(ctx.agentDir);
     setCatalog(catalog);
 
-    if (catalog.length === 0) return null;
+    if (catalog.length === 0) return [];
 
-    const parts: string[] = [];
+    const injections: ContextInjection[] = [];
 
-    // Always: compact catalog
+    // Compact catalog with paths and active state
     const catalogLines = catalog.map((s) => {
-      const marker = isActive(s.name) ? "✦" : "-";
-      return `${marker} ${s.name}: ${s.description || "(no description)"}`;
+      const state = isActive(s.name) ? "active" : "available";
+      const relPath = s.source === "installed"
+        ? `.agents/skills/${s.name}/SKILL.md`
+        : `skills/${s.name}/SKILL.md`;
+      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${relPath}`;
     });
-    parts.push("# Available Skills\n" + catalogLines.join("\n"));
+    injections.push({
+      label: "skills",
+      content: catalogLines.join("\n"),
+      placement: "system",
+    });
 
-    // Active skills: full content
+    // Active skills: injected as <document> blocks (no label — content is pre-wrapped)
     for (const skill of catalog) {
       if (!isActive(skill.name)) continue;
-      parts.push(`# Active Skill: ${skill.name}\n\n${skill.body}`);
+      const relPath = skill.source === "installed"
+        ? `.agents/skills/${skill.name}/SKILL.md`
+        : `skills/${skill.name}/SKILL.md`;
+      const safePath = relPath.replace(/"/g, '&quot;');
+      injections.push({
+        label: "",
+        content: `<document path="${safePath}">\n${skill.body}\n</document>`,
+        placement: "system",
+      });
     }
 
-    return {
-      label: "skills",
-      content: parts.join("\n\n"),
-      placement: "system",
-    };
+    return injections;
   },
 
   onStatus(_ctx) {

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -1,6 +1,6 @@
 import type { KernPlugin, PluginContext, RouteHandler, BeforeContextInfo, ContextInjection } from "../types.js";
 import { scanSkills, type SkillInfo } from "./scanner.js";
-import { initState, loadActiveSkills, isActive, getActiveSkills } from "./state.js";
+import { isActive, getActiveSkills } from "./state.js";
 import { skillTool, setCatalog } from "./tool.js";
 import { log } from "../../log.js";
 
@@ -70,10 +70,6 @@ export const skillsPlugin: KernPlugin = {
 
   async onStartup(ctx) {
     (this.routes as any)?._setCtx(ctx);
-
-    // Initialize state persistence
-    initState(ctx.agentDir);
-    await loadActiveSkills();
 
     // Scan skill directories
     catalog = await scanSkills(ctx.agentDir);

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -49,17 +49,22 @@ export const skillsPlugin: KernPlugin = {
           res.end(JSON.stringify({ error: "Skill not found" }));
           return;
         }
-        const active = getActiveSkills();
-        const body = await loadSkillBody(skill);
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({
-          name: skill.name,
-          description: skill.description,
-          path: skill.displayPath,
-          source: skill.source,
-          active: active.has(skill.name),
-          body,
-        }));
+        try {
+          const active = getActiveSkills();
+          const body = await loadSkillBody(skill);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({
+            name: skill.name,
+            description: skill.description,
+            path: skill.displayPath,
+            source: skill.source,
+            active: active.has(skill.name),
+            body,
+          }));
+        } catch {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Failed to load skill body" }));
+        }
       },
     },
   ] as RouteHandler[],

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -81,7 +81,11 @@ export const skillsPlugin: KernPlugin = {
     }
   },
 
-  async onBeforeContext(_info: BeforeContextInfo, _ctx: PluginContext): Promise<ContextInjection | null> {
+  async onBeforeContext(_info: BeforeContextInfo, ctx: PluginContext): Promise<ContextInjection | null> {
+    // Rescan every turn — agent may have created/deleted skills mid-session
+    catalog = await scanSkills(ctx.agentDir);
+    setCatalog(catalog);
+
     if (catalog.length === 0) return null;
 
     const parts: string[] = [];

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -33,6 +33,7 @@ export const skillsPlugin: KernPlugin = {
           const result = catalog.map((s) => ({
             name: s.name,
             description: s.description,
+            path: s.path,
             source: s.source,
             active: active.has(s.name),
           }));
@@ -56,6 +57,7 @@ export const skillsPlugin: KernPlugin = {
           res.end(JSON.stringify({
             name: skill.name,
             description: skill.description,
+            path: skill.path,
             source: skill.source,
             active: active.has(skill.name),
             body: skill.body,
@@ -90,13 +92,11 @@ export const skillsPlugin: KernPlugin = {
 
     const injections: ContextInjection[] = [];
 
-    // Compact catalog with paths and active state
+    // Compact catalog with absolute paths and active state
     const catalogLines = catalog.map((s) => {
       const state = isActive(s.name) ? "active" : "available";
-      const relPath = s.source === "installed"
-        ? `.agents/skills/${s.name}/SKILL.md`
-        : `skills/${s.name}/SKILL.md`;
-      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${relPath}`;
+      const skillPath = `${s.path}/SKILL.md`;
+      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${skillPath}`;
     });
     injections.push({
       label: "skills",
@@ -107,13 +107,10 @@ export const skillsPlugin: KernPlugin = {
     // Active skills: injected as <document> blocks (no label — content is pre-wrapped)
     for (const skill of catalog) {
       if (!isActive(skill.name)) continue;
-      const relPath = skill.source === "installed"
-        ? `.agents/skills/${skill.name}/SKILL.md`
-        : `skills/${skill.name}/SKILL.md`;
-      const safePath = relPath.replace(/"/g, '&quot;');
+      const skillPath = `${skill.path}/SKILL.md`.replace(/"/g, '&quot;');
       injections.push({
         label: "",
-        content: `<document path="${safePath}">\n${skill.body}\n</document>`,
+        content: `<document path="${skillPath}">\n${skill.body}\n</document>`,
         placement: "system",
       });
     }

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -1,5 +1,5 @@
 import type { KernPlugin, PluginContext, RouteHandler, BeforeContextInfo, ContextInjection } from "../types.js";
-import { scanSkills, type SkillInfo } from "./scanner.js";
+import { scanSkills, loadSkillBody, type SkillInfo } from "./scanner.js";
 import { isActive, getActiveSkills } from "./state.js";
 import { skillTool, setCatalog } from "./tool.js";
 import { log } from "../../log.js";
@@ -21,58 +21,50 @@ export const skillsPlugin: KernPlugin = {
     skill: skillTool,
   },
 
-  routes: (() => {
-    let _ctx: PluginContext | null = null;
-
-    const routes: RouteHandler[] = [
-      {
-        method: "GET",
-        path: "/skills",
-        handler: (_req, res) => {
-          const active = getActiveSkills();
-          const result = catalog.map((s) => ({
-            name: s.name,
-            description: s.description,
-            path: s.path,
-            source: s.source,
-            active: active.has(s.name),
-          }));
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(result));
-        },
+  routes: [
+    {
+      method: "GET",
+      path: "/skills",
+      handler: (_req, res) => {
+        const active = getActiveSkills();
+        const result = catalog.map((s) => ({
+          name: s.name,
+          description: s.description,
+          path: s.displayPath,
+          source: s.source,
+          active: active.has(s.name),
+        }));
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
       },
-      {
-        method: "GET",
-        path: /^\/skills\/([^/]+)$/,
-        handler: (_req, res, match) => {
-          const name = match?.[1];
-          const skill = catalog.find((s) => s.name === name);
-          if (!skill) {
-            res.writeHead(404, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "Skill not found" }));
-            return;
-          }
-          const active = getActiveSkills();
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({
-            name: skill.name,
-            description: skill.description,
-            path: skill.path,
-            source: skill.source,
-            active: active.has(skill.name),
-            body: skill.body,
-          }));
-        },
+    },
+    {
+      method: "GET",
+      path: /^\/skills\/([^/]+)$/,
+      handler: async (_req, res, match) => {
+        const name = match?.[1];
+        const skill = catalog.find((s) => s.name === name);
+        if (!skill) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Skill not found" }));
+          return;
+        }
+        const active = getActiveSkills();
+        const body = await loadSkillBody(skill);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          name: skill.name,
+          description: skill.description,
+          path: skill.displayPath,
+          source: skill.source,
+          active: active.has(skill.name),
+          body,
+        }));
       },
-    ];
-
-    (routes as any)._setCtx = (ctx: PluginContext) => { _ctx = ctx; };
-    return routes;
-  })(),
+    },
+  ] as RouteHandler[],
 
   async onStartup(ctx) {
-    (this.routes as any)?._setCtx(ctx);
-
     // Scan skill directories
     catalog = await scanSkills(ctx.agentDir);
     setCatalog(catalog);
@@ -92,11 +84,10 @@ export const skillsPlugin: KernPlugin = {
 
     const injections: ContextInjection[] = [];
 
-    // Compact catalog with absolute paths and active state
+    // Compact catalog with logical paths and active state
     const catalogLines = catalog.map((s) => {
       const state = isActive(s.name) ? "active" : "available";
-      const skillPath = `${s.path}/SKILL.md`;
-      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${skillPath}`;
+      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${s.displayPath}`;
     });
     injections.push({
       label: "skills",
@@ -104,15 +95,19 @@ export const skillsPlugin: KernPlugin = {
       placement: "system",
     });
 
-    // Active skills: injected as <document> blocks (no label — content is pre-wrapped)
+    // Active skills: load body lazily and inject as <document> blocks
     for (const skill of catalog) {
       if (!isActive(skill.name)) continue;
-      const skillPath = `${skill.path}/SKILL.md`.replace(/"/g, '&quot;');
-      injections.push({
-        label: "",
-        content: `<document path="${skillPath}">\n${skill.body}\n</document>`,
-        placement: "system",
-      });
+      try {
+        const body = await loadSkillBody(skill);
+        injections.push({
+          label: "",
+          content: `<document path="${skill.displayPath}">\n${body}\n</document>`,
+          placement: "system",
+        });
+      } catch (err: any) {
+        log.warn("skills", `failed to load active skill ${skill.name}: ${err.message}`);
+      }
     }
 
     return injections;

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -47,11 +47,12 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
   return { meta, body };
 }
 
-/** Derive logical display path from source and name */
-function getDisplayPath(name: string, source: SkillSource): string {
+/** Derive display path from source and name */
+function getDisplayPath(name: string, source: SkillSource, absolutePath: string): string {
   switch (source) {
+    case "local": return `skills/${name}/SKILL.md`;
     case "installed": return `.agents/skills/${name}/SKILL.md`;
-    default: return `skills/${name}/SKILL.md`;
+    case "builtin": return `${absolutePath}/SKILL.md`;
   }
 }
 
@@ -80,7 +81,7 @@ async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
         name,
         description: meta.description || "",
         path: skillDir,
-        displayPath: getDisplayPath(name, source),
+        displayPath: getDisplayPath(name, source, skillDir),
         source,
       });
     } catch (err: any) {

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -13,10 +13,10 @@ export interface SkillInfo {
   description: string;
   /** Absolute path to skill directory */
   path: string;
+  /** Logical display path (e.g. skills/<name>/SKILL.md) */
+  displayPath: string;
   /** Where it came from */
   source: SkillSource;
-  /** Full SKILL.md body (below frontmatter) */
-  body: string;
 }
 
 /** Resolve kern package root (where package.json lives) */
@@ -47,8 +47,17 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
   return { meta, body };
 }
 
+/** Derive logical display path from source and name */
+function getDisplayPath(name: string, source: SkillSource): string {
+  switch (source) {
+    case "installed": return `.agents/skills/${name}/SKILL.md`;
+    default: return `skills/${name}/SKILL.md`;
+  }
+}
+
 /**
  * Scan a single skills directory for subdirectories containing SKILL.md.
+ * Only reads frontmatter for catalog — full body loaded lazily on activation.
  */
 async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
   if (!existsSync(dir)) return [];
@@ -64,14 +73,15 @@ async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
 
     try {
       const content = await readFile(skillFile, "utf-8");
-      const { meta, body } = parseFrontmatter(content);
+      const { meta } = parseFrontmatter(content);
+      const name = meta.name || entry.name;
 
       skills.push({
-        name: meta.name || entry.name,
+        name,
         description: meta.description || "",
         path: skillDir,
+        displayPath: getDisplayPath(name, source),
         source,
-        body: body.trim() || content.trim(),
       });
     } catch (err: any) {
       log.warn("skills", `failed to read ${skillFile}: ${err.message}`);
@@ -79,6 +89,16 @@ async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
   }
 
   return skills;
+}
+
+/**
+ * Load full SKILL.md body for a specific skill (below frontmatter).
+ */
+export async function loadSkillBody(skill: SkillInfo): Promise<string> {
+  const skillFile = join(skill.path, "SKILL.md");
+  const content = await readFile(skillFile, "utf-8");
+  const { body } = parseFrontmatter(content);
+  return body.trim() || content.trim();
 }
 
 /**

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -1,0 +1,80 @@
+import { readdir, readFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { log } from "../../log.js";
+
+export interface SkillInfo {
+  /** Skill name (from frontmatter or folder name) */
+  name: string;
+  /** Short description from frontmatter */
+  description: string;
+  /** Absolute path to skill directory */
+  path: string;
+  /** Where it came from */
+  source: "local" | "installed";
+  /** Full SKILL.md body (below frontmatter) */
+  body: string;
+}
+
+/**
+ * Parse YAML frontmatter from SKILL.md content.
+ * Returns { meta, body } where meta has name/description extracted from simple key: value lines.
+ */
+function parseFrontmatter(content: string): { meta: Record<string, string>; body: string } {
+  const meta: Record<string, string> = {};
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+  if (!match) return { meta, body: content };
+
+  const yamlBlock = match[1];
+  const body = match[2];
+
+  for (const line of yamlBlock.split("\n")) {
+    const kv = line.match(/^(\w[\w_-]*):\s*(.+)$/);
+    if (kv) meta[kv[1].trim()] = kv[2].trim().replace(/^["']|["']$/g, "");
+  }
+
+  return { meta, body };
+}
+
+/**
+ * Scan a single skills directory for subdirectories containing SKILL.md.
+ */
+async function scanDir(dir: string, source: "local" | "installed"): Promise<SkillInfo[]> {
+  if (!existsSync(dir)) return [];
+
+  const skills: SkillInfo[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const skillDir = join(dir, entry.name);
+    const skillFile = join(skillDir, "SKILL.md");
+    if (!existsSync(skillFile)) continue;
+
+    try {
+      const content = await readFile(skillFile, "utf-8");
+      const { meta, body } = parseFrontmatter(content);
+
+      skills.push({
+        name: meta.name || entry.name,
+        description: meta.description || "",
+        path: skillDir,
+        source,
+        body: body.trim() || content.trim(),
+      });
+    } catch (err: any) {
+      log.warn("skills", `failed to read ${skillFile}: ${err.message}`);
+    }
+  }
+
+  return skills;
+}
+
+/**
+ * Scan both skill directories and return merged catalog.
+ */
+export async function scanSkills(agentDir: string): Promise<SkillInfo[]> {
+  const local = await scanDir(join(agentDir, "skills"), "local");
+  const installed = await scanDir(join(agentDir, ".agents", "skills"), "installed");
+  return [...local, ...installed];
+}

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -1,7 +1,10 @@
 import { readdir, readFile } from "fs/promises";
-import { join } from "path";
+import { join, dirname } from "path";
 import { existsSync } from "fs";
+import { fileURLToPath } from "url";
 import { log } from "../../log.js";
+
+export type SkillSource = "local" | "installed" | "builtin";
 
 export interface SkillInfo {
   /** Skill name (from frontmatter or folder name) */
@@ -11,9 +14,17 @@ export interface SkillInfo {
   /** Absolute path to skill directory */
   path: string;
   /** Where it came from */
-  source: "local" | "installed";
+  source: SkillSource;
   /** Full SKILL.md body (below frontmatter) */
   body: string;
+}
+
+/** Resolve kern package root (where package.json lives) */
+function getPackageRoot(): string {
+  // This file is at <pkg>/dist/plugins/skills/scanner.js (built) or src/plugins/skills/scanner.ts
+  const thisFile = fileURLToPath(import.meta.url);
+  // Walk up to package root: dist/plugins/skills/ → dist/plugins/ → dist/ → pkg root
+  return dirname(dirname(dirname(dirname(thisFile))));
 }
 
 /**
@@ -39,7 +50,7 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
 /**
  * Scan a single skills directory for subdirectories containing SKILL.md.
  */
-async function scanDir(dir: string, source: "local" | "installed"): Promise<SkillInfo[]> {
+async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
   if (!existsSync(dir)) return [];
 
   const skills: SkillInfo[] = [];
@@ -71,10 +82,22 @@ async function scanDir(dir: string, source: "local" | "installed"): Promise<Skil
 }
 
 /**
- * Scan both skill directories and return merged catalog.
+ * Scan all skill directories and return merged catalog.
+ * Priority: local (agent) > installed (.agents) > builtin (kern package).
+ * Same-name skills in higher priority shadow lower ones.
  */
 export async function scanSkills(agentDir: string): Promise<SkillInfo[]> {
   const local = await scanDir(join(agentDir, "skills"), "local");
   const installed = await scanDir(join(agentDir, ".agents", "skills"), "installed");
-  return [...local, ...installed];
+  const builtin = await scanDir(join(getPackageRoot(), "skills"), "builtin");
+
+  // Merge with dedup — first occurrence wins (highest priority first)
+  const seen = new Set<string>();
+  const merged: SkillInfo[] = [];
+  for (const skill of [...local, ...installed, ...builtin]) {
+    if (seen.has(skill.name)) continue;
+    seen.add(skill.name);
+    merged.push(skill);
+  }
+  return merged;
 }

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -13,10 +13,10 @@ export interface SkillInfo {
   description: string;
   /** Absolute path to skill directory */
   path: string;
+  /** Logical display path (e.g. skills/<name>/SKILL.md) */
+  displayPath: string;
   /** Where it came from */
   source: SkillSource;
-  /** Full SKILL.md body (below frontmatter) */
-  body: string;
 }
 
 /** Resolve kern package root (where package.json lives) */
@@ -47,8 +47,18 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
   return { meta, body };
 }
 
+/** Derive display path from source and name */
+function getDisplayPath(name: string, source: SkillSource, absolutePath: string): string {
+  switch (source) {
+    case "local": return `skills/${name}/SKILL.md`;
+    case "installed": return `.agents/skills/${name}/SKILL.md`;
+    case "builtin": return `${absolutePath}/SKILL.md`;
+  }
+}
+
 /**
  * Scan a single skills directory for subdirectories containing SKILL.md.
+ * Only reads frontmatter for catalog — full body loaded lazily on activation.
  */
 async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
   if (!existsSync(dir)) return [];
@@ -64,14 +74,15 @@ async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
 
     try {
       const content = await readFile(skillFile, "utf-8");
-      const { meta, body } = parseFrontmatter(content);
+      const { meta } = parseFrontmatter(content);
+      const name = meta.name || entry.name;
 
       skills.push({
-        name: meta.name || entry.name,
+        name,
         description: meta.description || "",
         path: skillDir,
+        displayPath: getDisplayPath(entry.name, source, skillDir),
         source,
-        body: body.trim() || content.trim(),
       });
     } catch (err: any) {
       log.warn("skills", `failed to read ${skillFile}: ${err.message}`);
@@ -79,6 +90,16 @@ async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
   }
 
   return skills;
+}
+
+/**
+ * Load full SKILL.md body for a specific skill (below frontmatter).
+ */
+export async function loadSkillBody(skill: SkillInfo): Promise<string> {
+  const skillFile = join(skill.path, "SKILL.md");
+  const content = await readFile(skillFile, "utf-8");
+  const { body } = parseFrontmatter(content);
+  return body.trim() || content.trim();
 }
 
 /**

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -81,7 +81,7 @@ async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
         name,
         description: meta.description || "",
         path: skillDir,
-        displayPath: getDisplayPath(name, source, skillDir),
+        displayPath: getDisplayPath(entry.name, source, skillDir),
         source,
       });
     } catch (err: any) {

--- a/src/plugins/skills/state.ts
+++ b/src/plugins/skills/state.ts
@@ -1,0 +1,67 @@
+import { readFile, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { log } from "../../log.js";
+
+const STATE_FILE = "active-skills.json";
+
+/** In-memory set of active skill names */
+let activeSkills = new Set<string>();
+
+/** Path to persistence file */
+let statePath = "";
+
+export function initState(agentDir: string) {
+  statePath = join(agentDir, ".kern", STATE_FILE);
+}
+
+export async function loadActiveSkills(): Promise<Set<string>> {
+  if (!statePath || !existsSync(statePath)) return activeSkills;
+
+  try {
+    const raw = await readFile(statePath, "utf-8");
+    const names: string[] = JSON.parse(raw);
+    activeSkills = new Set(names);
+    if (activeSkills.size > 0) {
+      log("skills", `restored ${activeSkills.size} active skill(s)`);
+    }
+  } catch (err: any) {
+    log.warn("skills", `failed to load active skills: ${err.message}`);
+  }
+  return activeSkills;
+}
+
+async function persist() {
+  if (!statePath) return;
+  try {
+    const dir = join(statePath, "..");
+    if (!existsSync(dir)) await mkdir(dir, { recursive: true });
+    await writeFile(statePath, JSON.stringify([...activeSkills], null, 2));
+  } catch (err: any) {
+    log.warn("skills", `failed to persist active skills: ${err.message}`);
+  }
+}
+
+export function getActiveSkills(): Set<string> {
+  return activeSkills;
+}
+
+export function isActive(name: string): boolean {
+  return activeSkills.has(name);
+}
+
+/** Activate a skill. Returns true if newly activated, false if already active. */
+export async function activate(name: string): Promise<boolean> {
+  if (activeSkills.has(name)) return false;
+  activeSkills.add(name);
+  await persist();
+  return true;
+}
+
+/** Deactivate a skill. Returns true if was active, false if wasn't. */
+export async function deactivate(name: string): Promise<boolean> {
+  if (!activeSkills.has(name)) return false;
+  activeSkills.delete(name);
+  await persist();
+  return true;
+}

--- a/src/plugins/skills/state.ts
+++ b/src/plugins/skills/state.ts
@@ -1,46 +1,5 @@
-import { readFile, writeFile, mkdir } from "fs/promises";
-import { join } from "path";
-import { existsSync } from "fs";
-import { log } from "../../log.js";
-
-const STATE_FILE = "active-skills.json";
-
-/** In-memory set of active skill names */
+/** In-memory set of active skill names — resets on restart */
 let activeSkills = new Set<string>();
-
-/** Path to persistence file */
-let statePath = "";
-
-export function initState(agentDir: string) {
-  statePath = join(agentDir, ".kern", STATE_FILE);
-}
-
-export async function loadActiveSkills(): Promise<Set<string>> {
-  if (!statePath || !existsSync(statePath)) return activeSkills;
-
-  try {
-    const raw = await readFile(statePath, "utf-8");
-    const names: string[] = JSON.parse(raw);
-    activeSkills = new Set(names);
-    if (activeSkills.size > 0) {
-      log("skills", `restored ${activeSkills.size} active skill(s)`);
-    }
-  } catch (err: any) {
-    log.warn("skills", `failed to load active skills: ${err.message}`);
-  }
-  return activeSkills;
-}
-
-async function persist() {
-  if (!statePath) return;
-  try {
-    const dir = join(statePath, "..");
-    if (!existsSync(dir)) await mkdir(dir, { recursive: true });
-    await writeFile(statePath, JSON.stringify([...activeSkills], null, 2));
-  } catch (err: any) {
-    log.warn("skills", `failed to persist active skills: ${err.message}`);
-  }
-}
 
 export function getActiveSkills(): Set<string> {
   return activeSkills;
@@ -51,17 +10,15 @@ export function isActive(name: string): boolean {
 }
 
 /** Activate a skill. Returns true if newly activated, false if already active. */
-export async function activate(name: string): Promise<boolean> {
+export function activate(name: string): boolean {
   if (activeSkills.has(name)) return false;
   activeSkills.add(name);
-  await persist();
   return true;
 }
 
 /** Deactivate a skill. Returns true if was active, false if wasn't. */
-export async function deactivate(name: string): Promise<boolean> {
+export function deactivate(name: string): boolean {
   if (!activeSkills.has(name)) return false;
   activeSkills.delete(name);
-  await persist();
   return true;
 }

--- a/src/plugins/skills/tool.ts
+++ b/src/plugins/skills/tool.ts
@@ -1,0 +1,56 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { SkillInfo } from "./scanner.js";
+import { isActive, activate, deactivate } from "./state.js";
+
+/** Reference to current skill catalog — set by plugin on startup/refresh */
+let catalog: SkillInfo[] = [];
+
+export function setCatalog(skills: SkillInfo[]) {
+  catalog = skills;
+}
+
+export const skillTool = tool({
+  description:
+    "Manage agent skills. Use 'list' to see available skills. " +
+    "Use 'activate' to load a skill's full instructions into your system prompt (persistent until deactivated). " +
+    "Use 'deactivate' to unload a skill and free token budget.",
+  inputSchema: z.object({
+    action: z.enum(["list", "activate", "deactivate"]).describe("Action to perform"),
+    name: z.string().optional().describe("Skill name (required for activate/deactivate)"),
+  }),
+  execute: async ({ action, name }) => {
+    switch (action) {
+      case "list": {
+        if (catalog.length === 0) {
+          return "No skills found. Create skills in skills/ or install from a registry.";
+        }
+        const lines = catalog.map((s) => {
+          const status = isActive(s.name) ? "✦ active" : "○";
+          const src = s.source === "installed" ? " [installed]" : "";
+          return `${status} ${s.name}${src} — ${s.description || "(no description)"}`;
+        });
+        return lines.join("\n");
+      }
+
+      case "activate": {
+        if (!name) return "Error: name is required for activate";
+        const skill = catalog.find((s) => s.name === name);
+        if (!skill) return `Error: skill "${name}" not found. Use list to see available skills.`;
+        const wasNew = await activate(name);
+        if (!wasNew) return `Skill "${name}" is already active.`;
+        return `Activated skill "${name}". Full instructions will be in your system prompt on the next turn.`;
+      }
+
+      case "deactivate": {
+        if (!name) return "Error: name is required for deactivate";
+        const wasActive = await deactivate(name);
+        if (!wasActive) return `Skill "${name}" is not active.`;
+        return `Deactivated skill "${name}". Instructions removed from system prompt.`;
+      }
+
+      default:
+        return `Unknown action: ${action}`;
+    }
+  },
+});

--- a/src/plugins/skills/tool.ts
+++ b/src/plugins/skills/tool.ts
@@ -37,14 +37,14 @@ export const skillTool = tool({
         if (!name) return "Error: name is required for activate";
         const skill = catalog.find((s) => s.name === name);
         if (!skill) return `Error: skill "${name}" not found. Use list to see available skills.`;
-        const wasNew = await activate(name);
+        const wasNew = activate(name);
         if (!wasNew) return `Skill "${name}" is already active.`;
         return `Activated skill "${name}". Full instructions will be in your system prompt on the next turn.`;
       }
 
       case "deactivate": {
         if (!name) return "Error: name is required for deactivate";
-        const wasActive = await deactivate(name);
+        const wasActive = deactivate(name);
         if (!wasActive) return `Skill "${name}" is not active.`;
         return `Deactivated skill "${name}". Instructions removed from system prompt.`;
       }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -117,4 +117,10 @@ export interface KernPlugin {
 
   /** Tool descriptions for system prompt injection (e.g. { recall: "search long-term memory..." }) */
   toolDescriptions?: Record<string, string>;
+
+  /** Slash commands this plugin provides */
+  commands?: Record<string, {
+    description: string;
+    handler: (ctx: PluginContext) => Promise<string>;
+  }>;
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -98,7 +98,7 @@ export interface KernPlugin {
    * Called during context assembly to inject content into the system prompt.
    * Returns content to inject, or null to skip.
    */
-  onBeforeContext?: (info: BeforeContextInfo, ctx: PluginContext) => Promise<ContextInjection | null>;
+  onBeforeContext?: (info: BeforeContextInfo, ctx: PluginContext) => Promise<ContextInjection | ContextInjection[] | null>;
 
   /**
    * Called when building /status response. Return key-value pairs to merge.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -220,8 +220,12 @@ export class Runtime {
               };
               contextMessages = [msg, ...contextMessages];
             } else {
-              // "system" — append to system prompt
-              const injection = `${inj.content}`;
+              // "system" — append to system prompt, wrapped in label tag for context UI
+              const injection = inj.label
+                ? `<${inj.label}>
+${inj.content}
+</${inj.label}>`
+                : inj.content;
               if (typeof systemWithInjections === "string") {
                 systemWithInjections = `${systemWithInjections}\n\n${injection}`;
               } else {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -122,7 +122,10 @@ export class Runtime {
     this.pendingInjections = fn;
   }
 
-  buildPromptContext(options?: Partial<PrepareContextOptions>) {
+  async buildPromptContext(options?: Partial<PrepareContextOptions> & {
+    userQuery?: string;
+    onEvent?: StreamHandler;
+  }) {
     const allMessages = options?.messages ?? this.session.getMessages();
     const sessionId = options?.sessionId ?? (this.session.getSessionId() || undefined);
     const prepared = prepareContext({
@@ -138,8 +141,47 @@ export class Runtime {
     const summaryAdditionChars = prepared.systemAdditions.join("\n\n").length;
     prepared.stats.systemPromptTokens = estimateTextTokens(effectiveSystemPrompt) - (summaryAdditionChars > 0 ? Math.ceil(summaryAdditionChars / 3.3) : 0);
 
-    const system = buildSystemMessage(effectiveSystemPrompt, this.config);
-    const messages = addCacheBreakpoints(prepared.messages, this.config);
+    // Apply plugin context injections (notes, skills, recall, etc.)
+    let systemWithInjections: string = effectiveSystemPrompt;
+    let contextMessages = prepared.messages;
+    const trimmedCount = prepared.stats.totalMessages - prepared.stats.windowMessages + (prepared.stats.summaryTokens > 0 ? 1 : 0);
+
+    if (this.contextInjectionFn) {
+      try {
+        const injections = await this.contextInjectionFn({
+          trimmedCount,
+          tokenBudget: 2000,
+          userQuery: options?.userQuery ?? "",
+          sessionId: sessionId || "",
+        });
+        for (const inj of injections) {
+          if (inj.placement === "user-prepend") {
+            const msg: ModelMessage = {
+              role: "user",
+              content: `<${inj.label}>\n${inj.content}\n</${inj.label}>`,
+            };
+            contextMessages = [msg, ...contextMessages];
+          } else {
+            // "system" — append to system prompt, wrapped in label tag for context UI
+            const injection = inj.label
+              ? `<${inj.label}>\n${inj.content}\n</${inj.label}>`
+              : inj.content;
+            systemWithInjections = `${systemWithInjections}\n\n${injection}`;
+          }
+          // Emit any SSE events the plugin attached
+          if (inj.sseEvents && options?.onEvent) {
+            for (const ev of inj.sseEvents) {
+              options.onEvent(ev);
+            }
+          }
+        }
+      } catch (err: any) {
+        log.error("context", `plugin context injection failed: ${err.message}`);
+      }
+    }
+
+    const system = buildSystemMessage(systemWithInjections, this.config);
+    const messages = addCacheBreakpoints(contextMessages, this.config);
 
     return {
       system,
@@ -192,56 +234,15 @@ export class Runtime {
 
       const allMessages = this.session.getMessages();
       const sessionId = this.session.getSessionId() || undefined;
-      const { system: systemMessage, messages: contextWindow, stats } = this.buildPromptContext({
+      const { system: systemWithInjections, messages: contextMessages, stats } = await this.buildPromptContext({
         messages: allMessages,
         sessionId,
+        userQuery: userMessage,
+        onEvent,
       });
       const trimmedCount = stats.totalMessages - stats.windowMessages + (stats.summaryTokens > 0 ? 1 : 0);
       if (trimmedCount > 0) {
         log("context", `trimmed: ${trimmedCount} old messages excluded${stats.summaryTokens > 0 ? `, summary injected (~${stats.summaryTokens} tokens)` : ''}`);
-      }
-
-      // Plugin context injections — each declares its own placement strategy
-      let contextMessages = contextWindow;
-      let systemWithInjections = systemMessage;
-      if (this.contextInjectionFn) {
-        try {
-          const injections = await this.contextInjectionFn({
-            trimmedCount,
-            tokenBudget: 2000,
-            userQuery: userMessage,
-            sessionId: sessionId || "",
-          });
-          for (const inj of injections) {
-            if (inj.placement === "user-prepend") {
-              const msg: ModelMessage = {
-                role: "user",
-                content: `<${inj.label}>\n${inj.content}\n</${inj.label}>`,
-              };
-              contextMessages = [msg, ...contextMessages];
-            } else {
-              // "system" — append to system prompt, wrapped in label tag for context UI
-              const injection = inj.label
-                ? `<${inj.label}>
-${inj.content}
-</${inj.label}>`
-                : inj.content;
-              if (typeof systemWithInjections === "string") {
-                systemWithInjections = `${systemWithInjections}\n\n${injection}`;
-              } else {
-                systemWithInjections = { ...systemWithInjections, content: `${systemWithInjections.content}\n\n${injection}` };
-              }
-            }
-            // Emit any SSE events the plugin attached
-            if (inj.sseEvents) {
-              for (const ev of inj.sseEvents) {
-                onEvent(ev);
-              }
-            }
-          }
-        } catch (err: any) {
-          log.error("context", `plugin context injection failed: ${err.message}`);
-        }
       }
 
       // Resolve custom URIs in messages via plugins (e.g. kern-media://)
@@ -389,42 +390,8 @@ ${inj.content}
 
   async getSystemPrompt(): Promise<string> {
     this.systemPrompt = await loadSystemPrompt(this.agentDir, this.config, this.pluginToolDescriptions);
-
-    // Build full prompt: base + conversation summary + plugin injections
-    let system = this.systemPrompt;
-
-    // Add conversation summary segments
-    const prepared = prepareContext({
-      messages: this.session.getMessages(),
-      config: this.config,
-      sessionId: this.session.getSessionId() || undefined,
-      segmentIndex: this.segmentIndex,
-    });
-    if (prepared.systemAdditions.length > 0) {
-      system = `${system}\n\n${prepared.systemAdditions.join("\n\n")}`;
-    }
-
-    // Add plugin injections (notes, skills, etc.)
-    if (this.contextInjectionFn) {
-      try {
-        const injections = await this.contextInjectionFn({
-          trimmedCount: 0,
-          tokenBudget: 2000,
-          userQuery: "",
-          sessionId: this.session.getSessionId() || "",
-        });
-        for (const inj of injections) {
-          if (inj.placement === "system") {
-            const wrapped = inj.label
-              ? `<${inj.label}>\n${inj.content}\n</${inj.label}>`
-              : inj.content;
-            system = `${system}\n\n${wrapped}`;
-          }
-        }
-      } catch (_) {}
-    }
-
-    return system;
+    const { system } = await this.buildPromptContext();
+    return typeof system === "string" ? system : system.content;
   }
 
   getMessages(): ModelMessage[] {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -389,7 +389,42 @@ ${inj.content}
 
   async getSystemPrompt(): Promise<string> {
     this.systemPrompt = await loadSystemPrompt(this.agentDir, this.config, this.pluginToolDescriptions);
-    return this.systemPrompt;
+
+    // Build full prompt: base + conversation summary + plugin injections
+    let system = this.systemPrompt;
+
+    // Add conversation summary segments
+    const prepared = prepareContext({
+      messages: this.session.getMessages(),
+      config: this.config,
+      sessionId: this.session.getSessionId() || undefined,
+      segmentIndex: this.segmentIndex,
+    });
+    if (prepared.systemAdditions.length > 0) {
+      system = `${system}\n\n${prepared.systemAdditions.join("\n\n")}`;
+    }
+
+    // Add plugin injections (notes, skills, etc.)
+    if (this.contextInjectionFn) {
+      try {
+        const injections = await this.contextInjectionFn({
+          trimmedCount: 0,
+          tokenBudget: 2000,
+          userQuery: "",
+          sessionId: this.session.getSessionId() || "",
+        });
+        for (const inj of injections) {
+          if (inj.placement === "system") {
+            const wrapped = inj.label
+              ? `<${inj.label}>\n${inj.content}\n</${inj.label}>`
+              : inj.content;
+            system = `${system}\n\n${wrapped}`;
+          }
+        }
+      } catch (_) {}
+    }
+
+    return system;
   }
 
   getMessages(): ModelMessage[] {

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ export class AgentServer {
   private sessionListFn: (() => any) | null = null;
   private sessionActivityFn: ((sessionId: string) => any) | null = null;
   private currentSessionIdFn: (() => string | null) | null = null;
+  private commandsFn: (() => Record<string, string>) | null = null;
   private pluginRoutes: import("./plugins/types.js").RouteHandler[] = [];
   private port = 0;
   private agentDir = "";
@@ -57,6 +58,10 @@ export class AgentServer {
 
   setStatusFn(fn: () => any) {
     this.statusFn = fn;
+  }
+
+  setCommandsFn(fn: () => Record<string, string>) {
+    this.commandsFn = fn;
   }
 
   setHistoryFn(fn: (limit: number, before?: number) => any[]) {
@@ -295,6 +300,14 @@ export class AgentServer {
     if (url === "/status" && req.method === "GET") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(this.statusFn ? this.statusFn() : {}));
+      return;
+    }
+
+    // Commands — available slash commands
+    if (url === "/commands" && req.method === "GET") {
+      const cmds = this.commandsFn ? this.commandsFn() : {};
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(cmds));
       return;
     }
 

--- a/src/tools/kern.ts
+++ b/src/tools/kern.ts
@@ -36,6 +36,11 @@ export function setSegmentStatsFn(fn: () => { segments: number; level0: number; 
   _getSegmentStats = fn;
 }
 
+let _getPluginStatus: (() => Record<string, any>) | null = null;
+export function setPluginStatusFn(fn: () => Record<string, any>) {
+  _getPluginStatus = fn;
+}
+
 export async function initKernTool(opts: {
   agentDir: string;
   config: any;
@@ -134,6 +139,7 @@ export interface StatusData {
   telegram: string | null;
   slack: string | null;
   segments: string | null;
+  plugins: Record<string, any> | null;
 }
 
 export function getStatusData(): StatusData {
@@ -221,6 +227,7 @@ export function getStatusData(): StatusData {
         .join(", ");
       return lvlStr || "0 segments";
     })() : null,
+    plugins: _getPluginStatus ? _getPluginStatus() : null,
   };
 }
 
@@ -249,6 +256,7 @@ export function formatStatus(data: StatusData): string {
     })() : (data.summary ? `  summary: ${data.summary}` : ""),
 
     data.segments ? `segments: ${data.segments}` : "",
+    ...(data.plugins ? Object.entries(data.plugins).map(([k, v]) => `${k}: ${v}`) : []),
     `api usage: ${data.apiUsage}`,
     data.cacheUsage ? `cache: ${data.cacheUsage}` : "",
     `queue: ${data.queue}`,

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -103,9 +103,9 @@ For dashboards, write structured data to `dashboards/<name>/data.json` and read 
 ### Skills
 You have a `skill` tool to manage reusable skills — packaged instructions in `SKILL.md` files.
 
-- `skill({ action: "list" })` — see all available skills and which are active
-- `skill({ action: "activate", name: "..." })` — load a skill's full instructions into your system prompt (persistent until deactivated)
-- `skill({ action: "deactivate", name: "..." })` — unload a skill to free token budget
+- `skill list` — see all available skills and which are active
+- `skill activate <name>` — load a skill's full instructions into your system prompt (persistent until deactivated)
+- `skill deactivate <name>` — unload a skill to free token budget
 
 Skills live in two directories: `skills/` (your own, version controlled) and `.agents/skills/` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -111,7 +111,7 @@ Skills live in two directories: `skills/<name>/SKILL.md` (your own, version cont
 
 kern also ships with bundled skills that appear in the catalog automatically. If you create a local skill with the same name, yours takes priority.
 
-Use `npx skills` with `-a universal` or `npx clawhub` with `--dir .agents/skills` to search, install, and manage community skills.
+Use `npx skills` with `-a universal` or `npx clawhub` with `--dir .agents/skills` to search, install, and manage community skills. Prefer official or widely-used skills over obscure ones.
 
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -111,7 +111,7 @@ Skills live in two directories: `skills/<name>/SKILL.md` (your own, version cont
 
 kern also ships with bundled skills that appear in the catalog automatically. If you create a local skill with the same name, yours takes priority.
 
-Use `npx skills` with `-a universal` or `npx clawhub` with `--dir .agents/skills` to search, install, and manage community skills. Prefer official or widely-used skills over obscure ones.
+Search the web for skills and community repos — prefer official, well-maintained, widely-used ones over obscure alternatives. Install with `npx skills` with `-a universal`.
 
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -109,6 +109,8 @@ You have a `skill` tool to manage reusable skills — packaged instructions in `
 
 Skills live in two directories: `skills/<name>/SKILL.md` (your own, version controlled) and `.agents/skills/<name>/SKILL.md` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
 
+kern also ships with bundled skills that appear in the catalog automatically. If you create a local skill with the same name, yours takes priority.
+
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -111,7 +111,7 @@ Skills live in two directories: `skills/<name>/SKILL.md` (your own, version cont
 
 kern also ships with bundled skills that appear in the catalog automatically. If you create a local skill with the same name, yours takes priority.
 
-Search the web for skills and community repos — prefer official, well-maintained, widely-used ones over obscure alternatives. Install with `npx skills` with `-a universal`.
+Search the web for skills and community repos — prefer official, well-maintained, widely-used ones over obscure alternatives. Install with `npx skills` with `-a universal -y`.
 
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -107,7 +107,7 @@ You have a `skill` tool to manage reusable skills — packaged instructions in `
 - `skill activate <name>` — load a skill's full instructions into your system prompt (persistent until deactivated)
 - `skill deactivate <name>` — unload a skill to free token budget
 
-Skills live in two directories: `skills/` (your own, version controlled) and `.agents/skills/` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
+Skills live in two directories: `skills/<name>/SKILL.md` (your own, version controlled) and `.agents/skills/<name>/SKILL.md` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
 
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -100,6 +100,15 @@ HTML is rendered in a sandboxed iframe with scripts enabled. Include CDN librari
 
 For dashboards, write structured data to `dashboards/<name>/data.json` and read it in your HTML via `window.__KERN_DATA__`. Update the data file and re-render to refresh.
 
+### Skills
+You have a `skill` tool to manage reusable skills — packaged instructions in `SKILL.md` files.
+
+- `skill({ action: "list" })` — see all available skills and which are active
+- `skill({ action: "activate", name: "..." })` — load a skill's full instructions into your system prompt (persistent until deactivated)
+- `skill({ action: "deactivate", name: "..." })` — unload a skill to free token budget
+
+Skills live in two directories: `skills/` (your own, version controlled) and `.agents/skills/` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
+
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -101,15 +101,17 @@ HTML is rendered in a sandboxed iframe with scripts enabled. Include CDN librari
 For dashboards, write structured data to `dashboards/<name>/data.json` and read it in your HTML via `window.__KERN_DATA__`. Update the data file and re-render to refresh.
 
 ### Skills
-You have a `skill` tool to manage reusable skills — packaged instructions in `SKILL.md` files.
+You have a `skill` tool to manage reusable skills following the [AgentSkills](https://agentskills.io) universal spec, part of the [skills.sh](https://skills.sh) ecosystem.
 
 - `skill list` — see all available skills and which are active
 - `skill activate <name>` — load a skill's full instructions into your system prompt (persistent until deactivated)
 - `skill deactivate <name>` — unload a skill to free token budget
 
-Skills live in two directories: `skills/<name>/SKILL.md` (your own, version controlled) and `.agents/skills/<name>/SKILL.md` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
+Skills live in two directories: `skills/<name>/SKILL.md` (your own, version controlled) and `.agents/skills/<name>/SKILL.md` (installed from registries). A compact catalog of all skills is always in your system prompt.
 
 kern also ships with bundled skills that appear in the catalog automatically. If you create a local skill with the same name, yours takes priority.
+
+Use `npx skills` with `-a universal` or `npx clawhub` with `--dir .agents/skills` to search, install, and manage community skills.
 
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -208,6 +208,8 @@ export default function Home() {
           onExternalConsumed={() => setExternalAttachments([])}
           fullWidth={prefs.chatLayout === "flat"}
           agentName={activeAgent?.name}
+          baseUrl={activeAgent?.baseUrl}
+          token={activeAgent?.token}
         />
       </div>
 

--- a/web/components/Input.tsx
+++ b/web/components/Input.tsx
@@ -2,8 +2,12 @@
 
 import { useState, useRef, useCallback, useEffect, type KeyboardEvent } from "react";
 import type { Attachment } from "../lib/types";
+import { getCommands } from "../lib/api";
 
-const SLASH_COMMANDS = [
+type SlashCommand = { name: string; desc: string };
+
+// Fallback commands if API unavailable
+const DEFAULT_COMMANDS: SlashCommand[] = [
   { name: "/status", desc: "agent status, uptime, token usage" },
   { name: "/restart", desc: "restart the agent process" },
   { name: "/help", desc: "list available commands" },
@@ -16,6 +20,8 @@ interface InputProps {
   onExternalConsumed?: () => void;
   fullWidth?: boolean;
   agentName?: string;
+  baseUrl?: string;
+  token?: string | null;
 }
 
 export function fileToAttachment(file: File): Promise<Attachment> {
@@ -44,10 +50,11 @@ export function fileToAttachment(file: File): Promise<Attachment> {
   });
 }
 
-export function Input({ onSend, disabled, externalAttachments, onExternalConsumed, fullWidth, agentName }: InputProps) {
+export function Input({ onSend, disabled, externalAttachments, onExternalConsumed, fullWidth, agentName, baseUrl, token }: InputProps) {
   const [text, setText] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [cmdFiltered, setCmdFiltered] = useState<typeof SLASH_COMMANDS>([]);
+  const [commands, setCommands] = useState<SlashCommand[]>(DEFAULT_COMMANDS);
+  const [cmdFiltered, setCmdFiltered] = useState<SlashCommand[]>([]);
   const [cmdIdx, setCmdIdx] = useState(0);
   const [cmdOpen, setCmdOpen] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -59,6 +66,16 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
   useEffect(() => {
     textareaRef.current?.focus();
   }, [agentName]);
+
+  // Fetch available commands from agent
+  useEffect(() => {
+    if (!baseUrl) return;
+    getCommands(baseUrl, token).then((cmds) => {
+      if (cmds && Object.keys(cmds).length > 0) {
+        setCommands(Object.entries(cmds).map(([name, desc]) => ({ name, desc })));
+      }
+    });
+  }, [baseUrl, token]);
 
   // Consume externally added attachments (drag-and-drop)
   useEffect(() => {
@@ -72,7 +89,7 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
   useEffect(() => {
     const val = text.trim().toLowerCase();
     if (val.startsWith("/") && !val.includes(" ")) {
-      const matches = SLASH_COMMANDS.filter((c) => c.name.startsWith(val));
+      const matches = commands.filter((c) => c.name.startsWith(val));
       setCmdFiltered(matches);
       setCmdOpen(matches.length > 0);
       setCmdIdx((prev) => Math.min(prev, Math.max(0, matches.length - 1)));
@@ -80,7 +97,7 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
       setCmdFiltered([]);
       setCmdOpen(false);
     }
-  }, [text]);
+  }, [text, commands]);
 
   const selectCommand = useCallback(
     (idx: number) => {

--- a/web/components/ToolCall.tsx
+++ b/web/components/ToolCall.tsx
@@ -54,6 +54,7 @@ const TOOL_COLORS: Record<string, string> = {
   pdf: "#e6edf3",
   image: "#e6edf3",
   kern: "#e6edf3",
+  skill: "#e6edf3",
   recall: "#e6edf3",
   message: "#56d364",
 };
@@ -140,6 +141,7 @@ function toolSummary(msg: ChatMessage): string {
     case "pdf": return `${input.file || ""}`;
     case "image": return `${input.file || ""}`;
     case "kern": return `${input.action || ""}`;
+    case "skill": return `${input.action || ""}${input.name ? ` ${input.name}` : ""}`;
     case "recall": return `${input.query || ""}`;
     default: return name;
   }

--- a/web/components/inspector/ContextTab.tsx
+++ b/web/components/inspector/ContextTab.tsx
@@ -122,6 +122,9 @@ const typeColor: Record<string, string> = {
   tools: "#f59e0b",
   conversation_summary: "#10b981",
   summary: "#10b981",
+  skills: "#ec4899",
+  recall: "#06b6d4",
+  notes: "#8b5cf6",
   text: "#6b7280",
 };
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -190,3 +190,13 @@ export async function resummarizeSegment(baseUrl: string, token: string | null, 
   const res = await fetch(`${baseUrl}/segments/${segmentId}/resummarize`, { method: "POST", headers: headers(token) });
   return res.json();
 }
+
+export async function getCommands(baseUrl: string, token?: string | null): Promise<Record<string, string>> {
+  try {
+    const res = await fetch(`${baseUrl}/commands`, { headers: headers(token) });
+    if (!res.ok) return {};
+    return res.json();
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## AgentSkills support (Phase 1 of #202)

Full skills plugin with discovery, installation, and runtime management.

### Skills plugin (`src/plugins/skills/`)

**Scanner** — scans three directories with priority: `skills/` (local) > `.agents/skills/` (installed) > bundled (npm package). Parses YAML frontmatter from `SKILL.md` files.

**Tool** — `skill list`, `skill activate <name>`, `skill deactivate <name>`. Active skills inject full instructions into system prompt, persistent until deactivated. In-memory only, no disk state.

**System prompt injection** — compact catalog always present (~50-100 tokens per skill). Active skills get full `SKILL.md` body injected via `onBeforeContext`, immune to conversation trimming.

**Bundled skills** — `create-skill` ships with kern. Local skills with same name take priority.

### Plugin slash commands

Plugins can register slash commands via `commands` field. `/skills` lists all skills with status. `/help` auto-includes plugin commands.

### Dynamic autocomplete

`GET /commands` endpoint returns all commands (builtin + plugin). Web UI fetches dynamically for slash command popup.

### Unified context assembly (#217)

Plugin injections moved inside `buildPromptContext()` — single source of truth for both `/context/system` endpoint and model calls. Eliminates prompt drift between UI and runtime.

### Plugin status

`onStatus` hook aggregated into `/status` output. Skills reports `2 active / 5 total`.

### API

- `GET /skills` — list all with active status
- `GET /skills/:name` — detail with full body
- `GET /commands` — all slash commands with descriptions

### Docs

- `docs/skills.md` — skill directories, install CLIs, activation
- `templates/KERN.md` — updated with skill tool, discovery guidance, `npx skills` install
- Changelog updated with all features

### Sub-PRs merged
- #217 — Unified context assembly
- #218 — Bundled builtin skills
- #219 — `/skills` command, dynamic autocomplete, plugin commands
- #223 — Copilot review fixes (logical paths, lazy body loading)
- #224 — Plugin status in `/status`