### PR TITLE
skills: bundled skills from kern package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "files": [
     "dist",
     "templates",
+    "skills",
     "docs",
     "web/out"
   ],

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: create-skill
+description: Create a new skill following the AgentSkills format
+---
+
+# Create Skill
+
+Create well-structured skill files for yourself or other agents.
+
+## Skill format
+
+A skill is a folder containing `SKILL.md` with optional supporting files:
+
+```
+my-skill/
+├── SKILL.md          # Required: YAML frontmatter + instructions
+├── scripts/          # Optional: executable scripts
+├── references/       # Optional: docs, examples
+└── assets/           # Optional: templates, data
+```
+
+## SKILL.md structure
+
+```markdown
+---
+name: my-skill
+description: One-line description of what this skill does
+---
+
+# Skill Title
+
+Instructions the agent follows when this skill is activated.
+Include context, steps, commands, and examples.
+Reference files in this directory using the absolute path shown in the skill catalog.
+```
+
+## Guidelines
+
+- **Name**: lowercase, hyphenated (e.g. `deploy-app`, `run-tests`)
+- **Description**: one line, starts with a verb (e.g. "Deploy applications to production")
+- **Body**: actionable instructions, not documentation. Write for an agent, not a human.
+- **Scripts**: include executable scripts the agent can run via bash tool
+- **References**: include docs the agent can read on demand — don't put everything in SKILL.md
+
+## Where to create skills
+
+- `skills/` in the agent's repo for agent-specific skills
+- `.agents/skills/` for skills installed from registries
+
+## Example
+
+```markdown
+---
+name: check-health
+description: Run health checks on all homelab services
+---
+
+# Check Health
+
+Run health checks across all services and report status.
+
+## Steps
+
+1. Read the service list from `knowledge/services.md`
+2. For each service, run the check script:
+   ```bash
+   bash scripts/check.sh <service-name>
+   ```
+3. Collect results and report summary
+4. If any service is down, notify operator via message tool
+```

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -33,6 +33,7 @@ export const skillsPlugin: KernPlugin = {
           const result = catalog.map((s) => ({
             name: s.name,
             description: s.description,
+            path: s.path,
             source: s.source,
             active: active.has(s.name),
           }));
@@ -56,6 +57,7 @@ export const skillsPlugin: KernPlugin = {
           res.end(JSON.stringify({
             name: skill.name,
             description: skill.description,
+            path: skill.path,
             source: skill.source,
             active: active.has(skill.name),
             body: skill.body,
@@ -90,13 +92,11 @@ export const skillsPlugin: KernPlugin = {
 
     const injections: ContextInjection[] = [];
 
-    // Compact catalog with paths and active state
+    // Compact catalog with absolute paths and active state
     const catalogLines = catalog.map((s) => {
       const state = isActive(s.name) ? "active" : "available";
-      const relPath = s.source === "installed"
-        ? `.agents/skills/${s.name}/SKILL.md`
-        : `skills/${s.name}/SKILL.md`;
-      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${relPath}`;
+      const skillPath = `${s.path}/SKILL.md`;
+      return `${state === "active" ? "✦" : "○"} ${s.name} (${state}): ${s.description || "(no description)"}\n  ${skillPath}`;
     });
     injections.push({
       label: "skills",
@@ -107,13 +107,10 @@ export const skillsPlugin: KernPlugin = {
     // Active skills: injected as <document> blocks (no label — content is pre-wrapped)
     for (const skill of catalog) {
       if (!isActive(skill.name)) continue;
-      const relPath = skill.source === "installed"
-        ? `.agents/skills/${skill.name}/SKILL.md`
-        : `skills/${skill.name}/SKILL.md`;
-      const safePath = relPath.replace(/"/g, '&quot;');
+      const skillPath = `${skill.path}/SKILL.md`.replace(/"/g, '&quot;');
       injections.push({
         label: "",
-        content: `<document path="${safePath}">\n${skill.body}\n</document>`,
+        content: `<document path="${skillPath}">\n${skill.body}\n</document>`,
         placement: "system",
       });
     }

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -1,7 +1,10 @@
 import { readdir, readFile } from "fs/promises";
-import { join } from "path";
+import { join, dirname } from "path";
 import { existsSync } from "fs";
+import { fileURLToPath } from "url";
 import { log } from "../../log.js";
+
+export type SkillSource = "local" | "installed" | "builtin";
 
 export interface SkillInfo {
   /** Skill name (from frontmatter or folder name) */
@@ -11,9 +14,17 @@ export interface SkillInfo {
   /** Absolute path to skill directory */
   path: string;
   /** Where it came from */
-  source: "local" | "installed";
+  source: SkillSource;
   /** Full SKILL.md body (below frontmatter) */
   body: string;
+}
+
+/** Resolve kern package root (where package.json lives) */
+function getPackageRoot(): string {
+  // This file is at <pkg>/dist/plugins/skills/scanner.js (built) or src/plugins/skills/scanner.ts
+  const thisFile = fileURLToPath(import.meta.url);
+  // Walk up to package root: dist/plugins/skills/ → dist/plugins/ → dist/ → pkg root
+  return dirname(dirname(dirname(dirname(thisFile))));
 }
 
 /**
@@ -39,7 +50,7 @@ function parseFrontmatter(content: string): { meta: Record<string, string>; body
 /**
  * Scan a single skills directory for subdirectories containing SKILL.md.
  */
-async function scanDir(dir: string, source: "local" | "installed"): Promise<SkillInfo[]> {
+async function scanDir(dir: string, source: SkillSource): Promise<SkillInfo[]> {
   if (!existsSync(dir)) return [];
 
   const skills: SkillInfo[] = [];
@@ -71,10 +82,22 @@ async function scanDir(dir: string, source: "local" | "installed"): Promise<Skil
 }
 
 /**
- * Scan both skill directories and return merged catalog.
+ * Scan all skill directories and return merged catalog.
+ * Priority: local (agent) > installed (.agents) > builtin (kern package).
+ * Same-name skills in higher priority shadow lower ones.
  */
 export async function scanSkills(agentDir: string): Promise<SkillInfo[]> {
   const local = await scanDir(join(agentDir, "skills"), "local");
   const installed = await scanDir(join(agentDir, ".agents", "skills"), "installed");
-  return [...local, ...installed];
+  const builtin = await scanDir(join(getPackageRoot(), "skills"), "builtin");
+
+  // Merge with dedup — first occurrence wins (highest priority first)
+  const seen = new Set<string>();
+  const merged: SkillInfo[] = [];
+  for (const skill of [...local, ...installed, ...builtin]) {
+    if (seen.has(skill.name)) continue;
+    seen.add(skill.name);
+    merged.push(skill);
+  }
+  return merged;
 }

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -109,6 +109,8 @@ You have a `skill` tool to manage reusable skills — packaged instructions in `
 
 Skills live in two directories: `skills/<name>/SKILL.md` (your own, version controlled) and `.agents/skills/<name>/SKILL.md` (installed from registries). A compact catalog of all skills is always in your system prompt. Activating a skill expands its full instructions.
 
+kern also ships with bundled skills that appear in the catalog automatically. If you create a local skill with the same name, yours takes priority.
+
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:
 


### PR DESCRIPTION
Adds a third skill scan directory inside the kern npm package, enabling skills that ship with kern.

## Changes
- Scanner resolves kern package root via import.meta.url, scans <pkg>/skills/ as builtin source (lowest priority)
- Dedup: local > installed > builtin — same-name skills shadow builtins
- Catalog and active skill injections use absolute real filesystem paths
- skills/ added to files array in package.json for npm
- First builtin: write-skill meta-skill
- API /skills responses include path field

Base: feat/skills-core (#216)