### PR TITLE
Skills: /skills command, dynamic autocomplete, plugin commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - Standalone `skill` tool with `list`, `activate`, `deactivate` actions
   - Active skill instructions injected into system prompt — durable, never trimmed
   - API endpoints: `GET /skills`, `GET /skills/:name`
+  - Bundled `create-skill` builtin — helps agents write new skills following the standard
+  - `/skills` slash command shows catalog with active state
+- **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
 
 ### Improvements
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Bundled `create-skill` builtin — helps agents write new skills following the standard
   - `/skills` slash command shows catalog with active state
 - **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
+- **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
 
 ### Improvements
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,8 @@ These are internal — the web proxy forwards to them, TUI connects directly.
 | `/context/segments` | GET | Segments currently in context |
 | `/sessions` | GET | Session list with current session ID |
 | `/recall/stats` | GET | Recall index stats |
+| `/commands` | GET | Available slash commands (builtins + plugins) |
+| `/skills` | GET | Skill catalog with active status |
 
 ### Auth
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -34,7 +34,7 @@ Browser-based chat served by `kern web`. See [Interfaces](interfaces.md#web-ui) 
 - Mid-turn messaging — send follow-ups injected between tool steps
 - Full history on connect, including tool call results
 - Switching agents mid-stream preserves the partial assistant response instead of dropping the in-progress text
-- Slash commands — `/status`, `/restart`, `/help` with autocomplete popup
+- Slash commands with dynamic autocomplete — fetches available commands from agent, including plugin commands
 - Markdown rendering — headers, lists, code blocks, tables, bold, italic, links
 - Syntax highlighting in code blocks and tool output
 - Dark theme, mobile-friendly

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -223,9 +223,17 @@ Restart the agent daemon.
 - The agent cannot restart itself — it must ask the operator to type `/restart`
 - Web UI auto-reconnects after restart (re-discovers the new agent port)
 
+### /skills
+
+List all available skills with active/inactive status. Provided by the skills plugin.
+
 ### /help
 
-List available slash commands with descriptions.
+List available slash commands with descriptions. Includes commands registered by plugins.
+
+### API: GET /commands
+
+Returns all available slash commands (builtins + plugins) as a JSON object mapping command names to descriptions. Used by the web UI for dynamic autocomplete.
 
 ## kern run \<name|path\>
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -60,6 +60,10 @@ The `skill` tool has three actions:
 | `activate` | Load a skill's full instructions into system prompt |
 | `deactivate` | Unload a skill to free token budget |
 
+## Slash command
+
+`/skills` lists all available skills with active/inactive status icons. This command is registered by the skills plugin and appears in web UI autocomplete automatically.
+
 ## API
 
 | Endpoint | Description |

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,7 +19,7 @@ import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusF
 import { plugins, type PluginContext } from "./plugins/index.js";
 import { log } from "./log.js";
 
-async function handleSlashCommand(cmd: string, userId: string, iface: string, agentName: string): Promise<string | null> {
+async function handleSlashCommand(cmd: string, userId: string, iface: string, agentName: string, agentDir: string): Promise<string | null> {
   switch (cmd) {
     case "/restart": {
       log("kern", `restart requested by ${userId} via ${iface}`);
@@ -47,9 +47,24 @@ async function handleSlashCommand(cmd: string, userId: string, iface: string, ag
       return formatStatus(getStatusDataFn());
     }
 
+    case "/skills": {
+      const { scanSkills } = await import("./plugins/skills/scanner.js");
+      const { getActiveSkills } = await import("./plugins/skills/state.js");
+      const skills = await scanSkills(agentDir);
+      if (skills.length === 0) return "No skills found.";
+
+      const active = getActiveSkills();
+      const lines = skills.map(s => {
+        const icon = active.has(s.name) ? "✦" : "○";
+        return `  ${icon} ${s.name} — ${s.description || "(no description)"}`;
+      });
+      return `Skills (${skills.length} available, ${active.size} active)\n\n${lines.join("\n")}`;
+    }
+
     case "/help":
       return [
         "/status   — show agent status, uptime, token usage",
+        "/skills   — list available skills",
         "/restart  — restart the agent process",
         "/help     — show this help",
       ].join("\n");
@@ -237,7 +252,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     // Slash commands bypass the queue — instant response even if queue is busy
     const cmd = text.trim();
     if (cmd.startsWith("/")) {
-      const result = await handleSlashCommand(cmd, userId, iface, agentName);
+      const result = await handleSlashCommand(cmd, userId, iface, agentName, agentDir);
       if (result !== null) {
         server.broadcast({
           type: "command-result" as any,

--- a/src/app.ts
+++ b/src/app.ts
@@ -267,6 +267,19 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     return getStatusDataFn();
   });
 
+  server.setCommandsFn(() => {
+    const cmds: Record<string, string> = {
+      "/status": "show agent status, uptime, token usage",
+      "/restart": "restart the agent process",
+    };
+    const pluginCmds = plugins.collectCommandDescriptions();
+    for (const [cmd, desc] of Object.entries(pluginCmds)) {
+      cmds[cmd] = desc;
+    }
+    cmds["/help"] = "show this help";
+    return cmds;
+  });
+
   server.setMessageHandler(async (text, userId, iface, channel, attachments) => {
     await enqueueMessage(text, userId, iface, channel, undefined, attachments);
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,8 @@ import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusF
 import { plugins, type PluginContext } from "./plugins/index.js";
 import { log } from "./log.js";
 
+let _pluginCtx: PluginContext | null = null;
+
 async function handleSlashCommand(cmd: string, userId: string, iface: string, agentName: string, agentDir: string): Promise<string | null> {
   switch (cmd) {
     case "/restart": {
@@ -47,30 +49,25 @@ async function handleSlashCommand(cmd: string, userId: string, iface: string, ag
       return formatStatus(getStatusDataFn());
     }
 
-    case "/skills": {
-      const { scanSkills } = await import("./plugins/skills/scanner.js");
-      const { getActiveSkills } = await import("./plugins/skills/state.js");
-      const skills = await scanSkills(agentDir);
-      if (skills.length === 0) return "No skills found.";
-
-      const active = getActiveSkills();
-      const lines = skills.map(s => {
-        const icon = active.has(s.name) ? "✦" : "○";
-        return `  ${icon} ${s.name} — ${s.description || "(no description)"}`;
-      });
-      return `Skills (${skills.length} available, ${active.size} active)\n\n${lines.join("\n")}`;
+    case "/help": {
+      const builtins = [
+        "/status   — show agent status, uptime, token usage",
+        "/restart  — restart the agent process",
+      ];
+      const pluginCmds = plugins.collectCommandDescriptions();
+      for (const [cmd, desc] of Object.entries(pluginCmds)) {
+        builtins.push(`${cmd.padEnd(10)} — ${desc}`);
+      }
+      builtins.push("/help     — show this help");
+      return builtins.join("\n");
     }
 
-    case "/help":
-      return [
-        "/status   — show agent status, uptime, token usage",
-        "/skills   — list available skills",
-        "/restart  — restart the agent process",
-        "/help     — show this help",
-      ].join("\n");
-
-    default:
-      return null; // unknown command — fall through to LLM
+    default: {
+      // Check plugin commands before falling through to LLM
+      const pluginCmd = plugins.getCommand(cmd);
+      if (pluginCmd) return pluginCmd.handler(_pluginCtx!);
+      return null;
+    }
   }
 }
 
@@ -161,6 +158,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     db: memoryDB,
     sessionId: () => runtime.getSessionId(),
   };
+  _pluginCtx = pluginCtx;
   const loadedPlugins = await plugins.load(pluginCtx);
 
   // Register plugin tools and descriptions with runtime

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -121,6 +121,27 @@ export const plugins = {
     }
   },
 
+  /** Look up a slash command handler from plugins. */
+  getCommand(cmd: string): { description: string; handler: (ctx: PluginContext) => Promise<string> } | null {
+    for (const plugin of activePlugins) {
+      if (plugin.commands?.[cmd]) return plugin.commands[cmd];
+    }
+    return null;
+  },
+
+  /** Collect all plugin command descriptions for /help. */
+  collectCommandDescriptions(): Record<string, string> {
+    const cmds: Record<string, string> = {};
+    for (const plugin of activePlugins) {
+      if (plugin.commands) {
+        for (const [cmd, { description }] of Object.entries(plugin.commands)) {
+          cmds[cmd] = description;
+        }
+      }
+    }
+    return cmds;
+  },
+
   /** Process attachments — first plugin that returns a message wins. */
   async dispatchProcessAttachments(
     attachments: import("../interfaces/types.js").Attachment[],

--- a/src/plugins/skills/plugin.ts
+++ b/src/plugins/skills/plugin.ts
@@ -118,6 +118,21 @@ export const skillsPlugin: KernPlugin = {
     return injections;
   },
 
+  commands: {
+    "/skills": {
+      description: "list available skills",
+      handler: async () => {
+        if (catalog.length === 0) return "No skills found.";
+        const active = getActiveSkills();
+        const lines = catalog.map((s) => {
+          const icon = active.has(s.name) ? "✦" : "○";
+          return `  ${icon} ${s.name} — ${s.description || "(no description)"}`;
+        });
+        return `Skills (${catalog.length} available, ${active.size} active)\n\n${lines.join("\n")}`;
+      },
+    },
+  },
+
   onStatus(_ctx) {
     return {
       skills: `${getActiveSkills().size} active / ${catalog.length} total`,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -117,4 +117,10 @@ export interface KernPlugin {
 
   /** Tool descriptions for system prompt injection (e.g. { recall: "search long-term memory..." }) */
   toolDescriptions?: Record<string, string>;
+
+  /** Slash commands this plugin provides */
+  commands?: Record<string, {
+    description: string;
+    handler: (ctx: PluginContext) => Promise<string>;
+  }>;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ export class AgentServer {
   private sessionListFn: (() => any) | null = null;
   private sessionActivityFn: ((sessionId: string) => any) | null = null;
   private currentSessionIdFn: (() => string | null) | null = null;
+  private commandsFn: (() => Record<string, string>) | null = null;
   private pluginRoutes: import("./plugins/types.js").RouteHandler[] = [];
   private port = 0;
   private agentDir = "";
@@ -57,6 +58,10 @@ export class AgentServer {
 
   setStatusFn(fn: () => any) {
     this.statusFn = fn;
+  }
+
+  setCommandsFn(fn: () => Record<string, string>) {
+    this.commandsFn = fn;
   }
 
   setHistoryFn(fn: (limit: number, before?: number) => any[]) {
@@ -295,6 +300,14 @@ export class AgentServer {
     if (url === "/status" && req.method === "GET") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(this.statusFn ? this.statusFn() : {}));
+      return;
+    }
+
+    // Commands — available slash commands
+    if (url === "/commands" && req.method === "GET") {
+      const cmds = this.commandsFn ? this.commandsFn() : {};
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(cmds));
       return;
     }
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -208,6 +208,8 @@ export default function Home() {
           onExternalConsumed={() => setExternalAttachments([])}
           fullWidth={prefs.chatLayout === "flat"}
           agentName={activeAgent?.name}
+          baseUrl={activeAgent?.baseUrl}
+          token={activeAgent?.token}
         />
       </div>
 

--- a/web/components/Input.tsx
+++ b/web/components/Input.tsx
@@ -2,8 +2,12 @@
 
 import { useState, useRef, useCallback, useEffect, type KeyboardEvent } from "react";
 import type { Attachment } from "../lib/types";
+import { getCommands } from "../lib/api";
 
-const SLASH_COMMANDS = [
+type SlashCommand = { name: string; desc: string };
+
+// Fallback commands if API unavailable
+const DEFAULT_COMMANDS: SlashCommand[] = [
   { name: "/status", desc: "agent status, uptime, token usage" },
   { name: "/restart", desc: "restart the agent process" },
   { name: "/help", desc: "list available commands" },
@@ -16,6 +20,8 @@ interface InputProps {
   onExternalConsumed?: () => void;
   fullWidth?: boolean;
   agentName?: string;
+  baseUrl?: string;
+  token?: string | null;
 }
 
 export function fileToAttachment(file: File): Promise<Attachment> {
@@ -44,10 +50,11 @@ export function fileToAttachment(file: File): Promise<Attachment> {
   });
 }
 
-export function Input({ onSend, disabled, externalAttachments, onExternalConsumed, fullWidth, agentName }: InputProps) {
+export function Input({ onSend, disabled, externalAttachments, onExternalConsumed, fullWidth, agentName, baseUrl, token }: InputProps) {
   const [text, setText] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [cmdFiltered, setCmdFiltered] = useState<typeof SLASH_COMMANDS>([]);
+  const [commands, setCommands] = useState<SlashCommand[]>(DEFAULT_COMMANDS);
+  const [cmdFiltered, setCmdFiltered] = useState<SlashCommand[]>([]);
   const [cmdIdx, setCmdIdx] = useState(0);
   const [cmdOpen, setCmdOpen] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -59,6 +66,16 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
   useEffect(() => {
     textareaRef.current?.focus();
   }, [agentName]);
+
+  // Fetch available commands from agent
+  useEffect(() => {
+    if (!baseUrl) return;
+    getCommands(baseUrl, token).then((cmds) => {
+      if (cmds && Object.keys(cmds).length > 0) {
+        setCommands(Object.entries(cmds).map(([name, desc]) => ({ name, desc })));
+      }
+    });
+  }, [baseUrl, token]);
 
   // Consume externally added attachments (drag-and-drop)
   useEffect(() => {
@@ -72,7 +89,7 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
   useEffect(() => {
     const val = text.trim().toLowerCase();
     if (val.startsWith("/") && !val.includes(" ")) {
-      const matches = SLASH_COMMANDS.filter((c) => c.name.startsWith(val));
+      const matches = commands.filter((c) => c.name.startsWith(val));
       setCmdFiltered(matches);
       setCmdOpen(matches.length > 0);
       setCmdIdx((prev) => Math.min(prev, Math.max(0, matches.length - 1)));
@@ -80,7 +97,7 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
       setCmdFiltered([]);
       setCmdOpen(false);
     }
-  }, [text]);
+  }, [text, commands]);
 
   const selectCommand = useCallback(
     (idx: number) => {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -190,3 +190,13 @@ export async function resummarizeSegment(baseUrl: string, token: string | null, 
   const res = await fetch(`${baseUrl}/segments/${segmentId}/resummarize`, { method: "POST", headers: headers(token) });
   return res.json();
 }
+
+export async function getCommands(baseUrl: string, token?: string | null): Promise<Record<string, string>> {
+  try {
+    const res = await fetch(`${baseUrl}/commands`, { headers: headers(token) });
+    if (!res.ok) return {};
+    return res.json();
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
Adds `/skills` slash command, plugin command registration, and a `GET /commands` API for dynamic slash autocomplete.

**Features:**
- `/skills` slash command — lists all skills with active/inactive status icons
- Plugin `commands` field — plugins can register their own slash commands
- `/help` auto-includes plugin commands
- `GET /commands` endpoint — returns all available commands (builtins + plugins)
- Web UI fetches commands on connect for autocomplete; plugin commands appear automatically

**Docs:**
- `commands.md`: added `/skills`, `GET /commands`, updated `/help`
- `skills.md`: added slash command section
- `clients.md`: updated autocomplete description
- `architecture.md`: added `/commands` and `/skills` to endpoint table

Stacked on #218.