### PR TITLE
Dynamic slash command autocomplete via /commands API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Bundled `create-skill` builtin — helps agents write new skills following the standard
   - `/skills` slash command shows catalog with active state
 - **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
+- **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
 
 ### Improvements
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.

--- a/src/app.ts
+++ b/src/app.ts
@@ -267,6 +267,19 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     return getStatusDataFn();
   });
 
+  server.setCommandsFn(() => {
+    const cmds: Record<string, string> = {
+      "/status": "show agent status, uptime, token usage",
+      "/restart": "restart the agent process",
+    };
+    const pluginCmds = plugins.collectCommandDescriptions();
+    for (const [cmd, desc] of Object.entries(pluginCmds)) {
+      cmds[cmd] = desc;
+    }
+    cmds["/help"] = "show this help";
+    return cmds;
+  });
+
   server.setMessageHandler(async (text, userId, iface, channel, attachments) => {
     await enqueueMessage(text, userId, iface, channel, undefined, attachments);
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ export class AgentServer {
   private sessionListFn: (() => any) | null = null;
   private sessionActivityFn: ((sessionId: string) => any) | null = null;
   private currentSessionIdFn: (() => string | null) | null = null;
+  private commandsFn: (() => Record<string, string>) | null = null;
   private pluginRoutes: import("./plugins/types.js").RouteHandler[] = [];
   private port = 0;
   private agentDir = "";
@@ -57,6 +58,10 @@ export class AgentServer {
 
   setStatusFn(fn: () => any) {
     this.statusFn = fn;
+  }
+
+  setCommandsFn(fn: () => Record<string, string>) {
+    this.commandsFn = fn;
   }
 
   setHistoryFn(fn: (limit: number, before?: number) => any[]) {
@@ -295,6 +300,14 @@ export class AgentServer {
     if (url === "/status" && req.method === "GET") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(this.statusFn ? this.statusFn() : {}));
+      return;
+    }
+
+    // Commands — available slash commands
+    if (url === "/commands" && req.method === "GET") {
+      const cmds = this.commandsFn ? this.commandsFn() : {};
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(cmds));
       return;
     }
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -208,6 +208,8 @@ export default function Home() {
           onExternalConsumed={() => setExternalAttachments([])}
           fullWidth={prefs.chatLayout === "flat"}
           agentName={activeAgent?.name}
+          baseUrl={activeAgent?.baseUrl}
+          token={activeAgent?.token}
         />
       </div>
 

--- a/web/components/Input.tsx
+++ b/web/components/Input.tsx
@@ -2,8 +2,12 @@
 
 import { useState, useRef, useCallback, useEffect, type KeyboardEvent } from "react";
 import type { Attachment } from "../lib/types";
+import { getCommands } from "../lib/api";
 
-const SLASH_COMMANDS = [
+type SlashCommand = { name: string; desc: string };
+
+// Fallback commands if API unavailable
+const DEFAULT_COMMANDS: SlashCommand[] = [
   { name: "/status", desc: "agent status, uptime, token usage" },
   { name: "/restart", desc: "restart the agent process" },
   { name: "/help", desc: "list available commands" },
@@ -16,6 +20,8 @@ interface InputProps {
   onExternalConsumed?: () => void;
   fullWidth?: boolean;
   agentName?: string;
+  baseUrl?: string;
+  token?: string | null;
 }
 
 export function fileToAttachment(file: File): Promise<Attachment> {
@@ -44,10 +50,11 @@ export function fileToAttachment(file: File): Promise<Attachment> {
   });
 }
 
-export function Input({ onSend, disabled, externalAttachments, onExternalConsumed, fullWidth, agentName }: InputProps) {
+export function Input({ onSend, disabled, externalAttachments, onExternalConsumed, fullWidth, agentName, baseUrl, token }: InputProps) {
   const [text, setText] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [cmdFiltered, setCmdFiltered] = useState<typeof SLASH_COMMANDS>([]);
+  const [commands, setCommands] = useState<SlashCommand[]>(DEFAULT_COMMANDS);
+  const [cmdFiltered, setCmdFiltered] = useState<SlashCommand[]>([]);
   const [cmdIdx, setCmdIdx] = useState(0);
   const [cmdOpen, setCmdOpen] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -59,6 +66,16 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
   useEffect(() => {
     textareaRef.current?.focus();
   }, [agentName]);
+
+  // Fetch available commands from agent
+  useEffect(() => {
+    if (!baseUrl) return;
+    getCommands(baseUrl, token).then((cmds) => {
+      if (cmds && Object.keys(cmds).length > 0) {
+        setCommands(Object.entries(cmds).map(([name, desc]) => ({ name, desc })));
+      }
+    });
+  }, [baseUrl, token]);
 
   // Consume externally added attachments (drag-and-drop)
   useEffect(() => {
@@ -72,7 +89,7 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
   useEffect(() => {
     const val = text.trim().toLowerCase();
     if (val.startsWith("/") && !val.includes(" ")) {
-      const matches = SLASH_COMMANDS.filter((c) => c.name.startsWith(val));
+      const matches = commands.filter((c) => c.name.startsWith(val));
       setCmdFiltered(matches);
       setCmdOpen(matches.length > 0);
       setCmdIdx((prev) => Math.min(prev, Math.max(0, matches.length - 1)));
@@ -80,7 +97,7 @@ export function Input({ onSend, disabled, externalAttachments, onExternalConsume
       setCmdFiltered([]);
       setCmdOpen(false);
     }
-  }, [text]);
+  }, [text, commands]);
 
   const selectCommand = useCallback(
     (idx: number) => {

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -190,3 +190,13 @@ export async function resummarizeSegment(baseUrl: string, token: string | null, 
   const res = await fetch(`${baseUrl}/segments/${segmentId}/resummarize`, { method: "POST", headers: headers(token) });
   return res.json();
 }
+
+export async function getCommands(baseUrl: string, token?: string | null): Promise<Record<string, string>> {
+  try {
+    const res = await fetch(`${baseUrl}/commands`, { headers: headers(token) });
+    if (!res.ok) return {};
+    return res.json();
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
Adds a `GET /commands` endpoint that returns available slash commands (builtins + plugin commands). Web UI fetches on agent connect and uses them for autocomplete, replacing the hardcoded list.

**Changes:**
- `server.ts`: new `/commands` endpoint via `commandsFn` setter
- `app.ts`: wires endpoint with builtin + plugin command descriptions
- `api.ts`: `getCommands()` client function with graceful fallback
- `Input.tsx`: fetches commands on agent connect, falls back to defaults
- `page.tsx`: passes `baseUrl`/`token` to Input

Stacked on #219.