### PR TITLE
CI: Docker manual dispatch with branch input

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,12 @@ name: Docker
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to build (default: master)"
+        required: false
+        default: "master"
 
 env:
   REGISTRY: ghcr.io
@@ -17,6 +22,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -30,7 +37,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=branch-${{ github.event.inputs.branch || 'master' }},enable=${{ github.event_name == 'workflow_dispatch' }}
       - uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Adds a `branch` input to the Docker workflow's manual dispatch trigger.

**Usage:** Actions tab → Docker → Run workflow → enter branch name (e.g. `feat/skills-core`)

**Tagging:**
- Release: `0.28.0`, `0.28`, `latest`
- Manual: `branch-feat-skills-core` (or `branch-master` if left blank)

**Changes:**
- `workflow_dispatch.inputs.branch` — optional, defaults to `master`
- Checkout uses input branch instead of default ref
- Tag pattern: `branch-<name>` for manual builds