### PR TITLE
CI: simplify Docker dispatch to use branch dropdown

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,12 +3,7 @@ name: Docker
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: "Branch to build (default: master)"
-        required: false
-        default: "master"
+  workflow_dispatch: {}
 
 env:
   REGISTRY: ghcr.io
@@ -22,8 +17,6 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch || github.ref }}
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -37,7 +30,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=raw,value=branch-${{ github.event.inputs.branch || 'master' }},enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
       - uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Removes the custom `branch` text input from #221. GitHub's built-in "Use workflow from" branch picker already does the same thing.

**Usage:** Actions → Docker → Run workflow → pick branch from dropdown → Run

**Tags:** `branch-<name>` for manual, semver + `latest` for releases.