### PR TITLE
Add plugin status to /status endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Improvements
 - **Plugin status in `/status`** — plugins report status via `onStatus` hook, aggregated and shown in `/status` output (e.g. `skills: 2 active / 3 total`)
 - **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
-- **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
+  - Web UI fetches available commands from `GET /commands` endpoint; plugin commands appear in autocomplete automatically
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.
 
 ## v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Bundled `create-skill` builtin — helps agents write new skills following the standard
   - `/skills` slash command shows catalog with active state
 ### Improvements
+- **Plugin status in `/status`** — plugins report status via `onStatus` hook, aggregated and shown in `/status` output (e.g. `skills: 2 active / 3 total`)
 - **Plugin slash commands** — plugins can register slash commands via `commands` field; `/help` auto-lists all available commands
 - **Dynamic slash autocomplete** — web UI fetches available commands from `GET /commands` endpoint on connect; plugin commands appear in autocomplete automatically
 - **Unified context assembly** ([#217](https://github.com/oguzbilgic/kern-ai/pull/217)) — plugin injections (notes, skills, recall) now applied inside `buildPromptContext()`, making it the single source of truth for both model calls and the `/context/system` debug endpoint. Cache breakpoints now computed on the final message array including injections.

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,7 +15,7 @@ import { setMessageSender } from "./tools/message.js";
 import { SegmentIndex } from "./segments.js";
 import { MemoryDB } from "./memory.js";
 import { MessageQueue } from "./queue.js";
-import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusFn, setSegmentStatsFn, type InterfaceStatus } from "./tools/kern.js";
+import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusFn, setSegmentStatsFn, setPluginStatusFn, type InterfaceStatus } from "./tools/kern.js";
 import { plugins, type PluginContext } from "./plugins/index.js";
 import { log } from "./log.js";
 
@@ -160,6 +160,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   };
   _pluginCtx = pluginCtx;
   const loadedPlugins = await plugins.load(pluginCtx);
+  setPluginStatusFn(() => plugins.collectStatus(pluginCtx));
 
   // Register plugin tools and descriptions with runtime
   const pluginTools = plugins.collectTools();

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -142,6 +142,21 @@ export const plugins = {
     return cmds;
   },
 
+  /** Collect status info from all plugins. */
+  collectStatus(ctx: PluginContext): Record<string, any> {
+    const status: Record<string, any> = {};
+    for (const plugin of activePlugins) {
+      if (plugin.onStatus) {
+        try {
+          Object.assign(status, plugin.onStatus(ctx));
+        } catch (err: any) {
+          log.error("plugin", `onStatus error in ${plugin.name}: ${err.message}`);
+        }
+      }
+    }
+    return status;
+  },
+
   /** Process attachments — first plugin that returns a message wins. */
   async dispatchProcessAttachments(
     attachments: import("../interfaces/types.js").Attachment[],

--- a/src/tools/kern.ts
+++ b/src/tools/kern.ts
@@ -36,6 +36,11 @@ export function setSegmentStatsFn(fn: () => { segments: number; level0: number; 
   _getSegmentStats = fn;
 }
 
+let _getPluginStatus: (() => Record<string, any>) | null = null;
+export function setPluginStatusFn(fn: () => Record<string, any>) {
+  _getPluginStatus = fn;
+}
+
 export async function initKernTool(opts: {
   agentDir: string;
   config: any;
@@ -134,6 +139,7 @@ export interface StatusData {
   telegram: string | null;
   slack: string | null;
   segments: string | null;
+  plugins: Record<string, any> | null;
 }
 
 export function getStatusData(): StatusData {
@@ -221,6 +227,7 @@ export function getStatusData(): StatusData {
         .join(", ");
       return lvlStr || "0 segments";
     })() : null,
+    plugins: _getPluginStatus ? _getPluginStatus() : null,
   };
 }
 
@@ -249,6 +256,7 @@ export function formatStatus(data: StatusData): string {
     })() : (data.summary ? `  summary: ${data.summary}` : ""),
 
     data.segments ? `segments: ${data.segments}` : "",
+    ...(data.plugins ? Object.entries(data.plugins).map(([k, v]) => `${k}: ${v}`) : []),
     `api usage: ${data.apiUsage}`,
     data.cacheUsage ? `cache: ${data.cacheUsage}` : "",
     `queue: ${data.queue}`,


### PR DESCRIPTION
Stacked on #216.

Wires the existing `onStatus` plugin hook into the `/status` endpoint and `formatStatus` output.

- `plugins.collectStatus()` aggregates status from all plugins
- `setPluginStatusFn()` setter + wired in `app.ts` after plugin load
- `StatusData.plugins` field added, rendered as flat key-value lines
- Skills plugin already returns `skills: 2 active / 3 total` — now visible in status

Closes the last missing item from #213.