### PR TITLE
Docker: Ubuntu 24.04 base with dev tools and user-space package paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## next
+
+### Improvements
+- **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
+
 ## v0.28.0
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM node:22-slim
+FROM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y git openssh-client && rm -rf /var/lib/apt/lists/*
+# System packages
+RUN apt-get update && apt-get install -y \
+    curl wget jq git openssh-client \
+    python3 python3-pip \
+    unzip build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
+# Node.js 22 via NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build kern from source
 WORKDIR /app
 COPY . .
 RUN npm ci && cd web && npm ci && cd .. \
@@ -9,12 +20,22 @@ RUN npm ci && cd web && npm ci && cd .. \
     && npm pack && npm install -g kern-ai-*.tgz \
     && rm -rf /app
 
+# Create non-root user with user-space package paths
 RUN useradd -m kern \
-    && mkdir -p /home/kern/agent \
+    && mkdir -p /home/kern/agent /home/kern/.npm-global /home/kern/.local \
     && chown -R kern:kern /home/kern
+
 USER kern
+
+# npm global installs to user space
+ENV NPM_CONFIG_PREFIX=/home/kern/.npm-global
+# pip installs to user space
+ENV PIP_USER=1
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+# All user-space binaries on PATH
+ENV PATH=/home/kern/.npm-global/bin:/home/kern/.local/bin:$PATH
+
 WORKDIR /home/kern/agent
-VOLUME ["/home/kern/agent"]
 
 EXPOSE 4100
 ENV KERN_PORT=4100

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,17 +43,27 @@ For other providers, pass the matching API key:
 
 ## Volumes
 
-The agent stores all state in its working directory. Mount a volume to persist it across container restarts.
+The agent stores all state in its working directory. Mount a volume to persist data across container restarts.
 
-**Agent only** — mounts just the agent directory:
+**Agent only** — persists agent config, sessions, and knowledge:
 ```bash
 -v kern-data:/home/kern/agent
 ```
 
-**Full home** — preserves global kern config, SSH keys, and any other user-level state:
+**Full home** — also persists globally installed packages (`npm install -g`, `pip install`), SSH keys, and user-level config:
 ```bash
 -v kern-data:/home/kern
 ```
+
+## Pre-installed tools
+
+The base image includes: `git`, `ssh`, `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`.
+
+Agents can install additional tools at runtime:
+- `npm install -g <package>` — installs to user space (`~/.npm-global`)
+- `pip install <package>` — installs to user space (`~/.local`)
+
+These persist across restarts when the volume is mounted at `/home/kern`.
 
 ## Web UI
 


### PR DESCRIPTION
Closes #225

## Changes
- **Base image**: `node:22-slim` → `ubuntu:24.04` + NodeSource Node 22 (GLIBC 2.39)
- **Packages**: `curl`, `wget`, `jq`, `python3`, `python3-pip`, `unzip`, `build-essential`, `ca-certificates`
- **User-space installs**: npm global prefix → `~/.npm-global`, pip user mode → `~/.local`, both on PATH
- **Docs**: updated volume mount options and pre-installed tools section

Agents can `npm install -g` and `pip install` without sudo. Tools persist when volume mounted at `/home/kern`.