### PR TITLE
Refresh summary and embedding model defaults (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
 - **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`
+- **Embedding model defaults** — simplified `createEmbeddingModel` to a per-provider switch matching `createSummaryModel`: `openai` → `text-embedding-3-small`, `anthropic`/`openrouter` → `openai/text-embedding-3-small`, `ollama` → `nomic-embed-text`. No behavior change — same model IDs resolved, cleaner branching
 
 ## v0.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
+- **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`
 
 ## v0.28.0
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ First Telegram/Slack user is auto-paired as operator. Others pair with `KERN-XXX
 | **openai** | OpenAI / Azure |
 | **ollama** | Local models via [Ollama](https://ollama.com) |
 
-Models can be mixed per role: `model` for chat, `embeddingModel` for recall, `summaryModel` for segments, `mediaModel` for vision.
+Set `model` for chat and optionally `mediaModel` for image vision. Embedding and summary models are chosen automatically per provider — see [docs/config.md](docs/config.md#providers).
 
 ## Documentation
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,17 @@ Segment summarization uses a cheap chat model chosen automatically per provider:
 | `openrouter` | `openai/gpt-4.1-mini` |
 | `ollama` | reuses the agent's chat model (no extra model to pull) |
 
+### Embedding model
+
+Recall and segment boundary detection use an embedding model chosen automatically per provider:
+
+| Provider | Embedding model |
+|----------|-----------------|
+| `openai` | `text-embedding-3-small` |
+| `anthropic` | `openai/text-embedding-3-small` (via OpenRouter — Anthropic has no embeddings API) |
+| `openrouter` | `openai/text-embedding-3-small` |
+| `ollama` | `nomic-embed-text` |
+
 ## Environment variable overrides
 
 Environment variables override matching `config.json` fields. Useful for Docker deployments where config is passed via environment.

--- a/docs/config.md
+++ b/docs/config.md
@@ -46,6 +46,17 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 - **openai** — OpenAI or Azure. Model IDs like `gpt-4o`.
 - **ollama** — local Ollama server. Model IDs match Ollama model names like `gemma4:31b`. Set `OLLAMA_BASE_URL` in `.env` for remote servers (default: `http://localhost:11434`).
 
+### Summary model
+
+Segment summarization uses a cheap chat model chosen automatically per provider:
+
+| Provider | Summary model |
+|----------|--------------|
+| `openai` | `gpt-4.1-mini` |
+| `anthropic` | `anthropic/claude-haiku-4.5` (via OpenRouter — needs `OPENROUTER_API_KEY`) |
+| `openrouter` | `openai/gpt-4.1-mini` |
+| `ollama` | reuses the agent's chat model (no extra model to pull) |
+
 ## Environment variable overrides
 
 Environment variables override matching `config.json` fields. Useful for Docker deployments where config is passed via environment.

--- a/src/app.ts
+++ b/src/app.ts
@@ -113,7 +113,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   let segmentRunning = false;
   if (embeddingDims > 0) {
     try {
-      segmentIndex = new SegmentIndex(memoryDB, config.provider);
+      segmentIndex = new SegmentIndex(memoryDB, config);
       runtime.setSegmentIndex(segmentIndex);
       setSegmentStatsFn(() => segmentIndex ? segmentIndex.getStats() : null);
     } catch (err: any) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -100,7 +100,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   const runtime = new Runtime(agentDir);
 
   // Probe embedding model dimensions before creating DB
-  const embeddingDims = await MemoryDB.detectEmbeddingDimensions(config.provider);
+  const embeddingDims = await MemoryDB.detectEmbeddingDimensions(config);
 
   // Initialize memory DB before runtime.init() so media sidecar can backfill
   const memoryDB = new MemoryDB(agentDir, embeddingDims);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { log } from "./log.js";
 import { embed } from "ai";
 import { createEmbeddingModel } from "./model.js";
+import type { KernConfig } from "./config.js";
 
 const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
 
@@ -165,9 +166,9 @@ export class MemoryDB {
    * Probe the actual embedding model to detect its output dimensions.
    * Returns the dimension count, or the default if probing fails.
    */
-  static async detectEmbeddingDimensions(provider: string): Promise<number> {
+  static async detectEmbeddingDimensions(config: KernConfig): Promise<number> {
     try {
-      const model = createEmbeddingModel(provider);
+      const model = createEmbeddingModel(config);
       if (!model) return DEFAULT_EMBEDDING_DIMENSIONS;
       const result = await embed({ model, value: "dimension probe" });
       const dims = result.embedding.length;

--- a/src/model.ts
+++ b/src/model.ts
@@ -71,17 +71,28 @@ export function createEmbeddingModel(provider: string): Parameters<typeof embed>
 /**
  * Create a cheap chat model for segment summarization.
  * Returns null if no suitable provider/key is available.
+ *
+ * Defaults by provider:
+ * - openai: gpt-4.1-mini
+ * - anthropic: claude-haiku-4.5 (via OpenRouter)
+ * - openrouter: openai/gpt-4.1-mini
+ * - ollama: reuses the agent's chat model (avoids forcing users to pull
+ *   a separate model just for summaries)
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createSummaryModel(provider: string): any {
-  const client = createOpenAIClient(provider);
+export function createSummaryModel(config: KernConfig): any {
+  const client = createOpenAIClient(config.provider);
   if (!client) return null;
 
-  switch (provider) {
+  switch (config.provider) {
     case "openai":
-      return client.chat("gpt-4.1-nano");
+      return client.chat("gpt-4.1-mini");
+    case "anthropic":
+      return client.chat("anthropic/claude-haiku-4.5");
+    case "openrouter":
+      return client.chat("openai/gpt-4.1-mini");
     case "ollama":
-      return client.chat("gemma3:4b");
+      return client.chat(config.model);
     default:
       return client.chat("openai/gpt-4.1-mini");
   }

--- a/src/model.ts
+++ b/src/model.ts
@@ -42,30 +42,29 @@ function createOpenAIClient(provider: string) {
 /**
  * Create an embedding model for recall and segments.
  * Returns null if no suitable provider/key is available.
+ *
+ * Defaults by provider:
+ * - openai: text-embedding-3-small
+ * - anthropic: openai/text-embedding-3-small (Anthropic has no embeddings API; routed via OpenRouter)
+ * - openrouter: openai/text-embedding-3-small
+ * - ollama: nomic-embed-text (local, no API key)
  */
-export function createEmbeddingModel(provider: string): Parameters<typeof embed>[0]["model"] | null {
-  if (provider === "ollama") {
-    const client = createOpenAIClient("ollama");
-    return client!.embeddingModel("nomic-embed-text");
-  }
-
-  // For all other providers, try OpenAI or OpenRouter
-  if (provider === "openai") {
-    if (!process.env.OPENAI_API_KEY) return null;
-    const client = createOpenAI();
-    return client.embeddingModel("text-embedding-3-small");
-  }
-
-  // openrouter, anthropic, or unknown — try OpenRouter then OpenAI
-  const apiKey = process.env.OPENROUTER_API_KEY || process.env.OPENAI_API_KEY;
-  if (!apiKey) return null;
-
-  const client = createOpenAIClient(provider);
+export function createEmbeddingModel(config: KernConfig): Parameters<typeof embed>[0]["model"] | null {
+  const client = createOpenAIClient(config.provider);
   if (!client) return null;
-  const modelId = process.env.OPENROUTER_API_KEY
-    ? "openai/text-embedding-3-small"
-    : "text-embedding-3-small";
-  return client.embeddingModel(modelId);
+
+  switch (config.provider) {
+    case "openai":
+      return client.embeddingModel("text-embedding-3-small");
+    case "anthropic":
+      return client.embeddingModel("openai/text-embedding-3-small");
+    case "openrouter":
+      return client.embeddingModel("openai/text-embedding-3-small");
+    case "ollama":
+      return client.embeddingModel("nomic-embed-text");
+    default:
+      return client.embeddingModel("openai/text-embedding-3-small");
+  }
 }
 
 /**

--- a/src/plugins/recall/plugin.ts
+++ b/src/plugins/recall/plugin.ts
@@ -68,7 +68,7 @@ export const recallPlugin: KernPlugin = {
     if (ctx.config.recall === false) return;
 
     try {
-      recallIndex = new RecallIndex(ctx.db, ctx.agentDir, ctx.config.provider);
+      recallIndex = new RecallIndex(ctx.db, ctx.agentDir, ctx.config);
       setRecallIndex(recallIndex);
 
       // Backfill in background

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -7,6 +7,7 @@ import { extractText } from "../../util.js";
 import { createEmbeddingModel } from "../../model.js";
 import type { ModelMessage } from "ai";
 import type { MemoryDB } from "../../memory.js";
+import type { KernConfig } from "../../config.js";
 
 const MAX_CHUNK_TOKENS = 1000; // rough token limit per chunk
 
@@ -24,11 +25,11 @@ export class RecallIndex {
   private embeddingModel: Parameters<typeof embed>[0]["model"];
   private agentDir: string;
 
-  constructor(memoryDB: MemoryDB, agentDir: string, provider: string) {
+  constructor(memoryDB: MemoryDB, agentDir: string, config: KernConfig) {
     this.agentDir = agentDir;
     this.db = memoryDB.db;
 
-    const model = createEmbeddingModel(provider);
+    const model = createEmbeddingModel(config);
     if (!model) {
       throw new Error("No embedding model available (need OPENROUTER_API_KEY, OPENAI_API_KEY, or Ollama provider)");
     }

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -2,6 +2,7 @@ import { embed, embedMany, generateText } from "ai";
 import { log } from "./log.js";
 import { extractText } from "./util.js";
 import { createEmbeddingModel, createSummaryModel } from "./model.js";
+import type { KernConfig } from "./config.js";
 import type { MemoryDB } from "./memory.js";
 import type Database from "better-sqlite3";
 import { readFileSync, existsSync } from "fs";
@@ -146,16 +147,16 @@ export class SegmentIndex {
   private summaryModel: Parameters<typeof generateText>[0]["model"];
   private abortController: AbortController | null = null;
 
-  constructor(memoryDB: MemoryDB, provider: string) {
+  constructor(memoryDB: MemoryDB, config: KernConfig) {
     this.db = memoryDB.db;
 
-    const embModel = createEmbeddingModel(provider);
+    const embModel = createEmbeddingModel(config.provider);
     if (!embModel) {
       throw new Error("No embedding model available (need OPENROUTER_API_KEY, OPENAI_API_KEY, or Ollama provider)");
     }
     this.embeddingModel = embModel;
 
-    const sumModel = createSummaryModel(provider);
+    const sumModel = createSummaryModel(config);
     if (!sumModel) {
       throw new Error("No summary model available");
     }

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -150,7 +150,7 @@ export class SegmentIndex {
   constructor(memoryDB: MemoryDB, config: KernConfig) {
     this.db = memoryDB.db;
 
-    const embModel = createEmbeddingModel(config.provider);
+    const embModel = createEmbeddingModel(config);
     if (!embModel) {
       throw new Error("No embedding model available (need OPENROUTER_API_KEY, OPENAI_API_KEY, or Ollama provider)");
     }


### PR DESCRIPTION
Closes #232.

### Summary model (`createSummaryModel`)
| Provider | Before | After |
|----------|--------|-------|
| `openai` | `gpt-4.1-nano` | `gpt-4.1-mini` |
| `anthropic` | (fell through to `openai/gpt-4.1-mini`) | `anthropic/claude-haiku-4.5` via OpenRouter |
| `openrouter` | (fell through to default) | `openai/gpt-4.1-mini` (explicit) |
| `ollama` | `gemma3:4b` | **reuses `config.model`** |

### Embedding model (`createEmbeddingModel`)
Cleanup only — same model IDs resolve, but the branching is now a simple per-provider switch matching `createSummaryModel`:

| Provider | Embedding model |
|----------|-----------------|
| `openai` | `text-embedding-3-small` |
| `anthropic` | `openai/text-embedding-3-small` (via OpenRouter — Anthropic has no embeddings API) |
| `openrouter` | `openai/text-embedding-3-small` |
| `ollama` | `nomic-embed-text` |

Drops the old `which API key is set` probing — `createOpenAIClient` already picks the right client from `config.provider`.

### Why
- **Ollama**: `gemma3:4b` forced Ollama users to pull a second model just for summaries. Reusing the chat model costs nothing (already in VRAM).
- **Anthropic**: `claude-haiku-4.5` is Anthropic's actual cheap summarization model. Previously anthropic-provider agents silently routed through OpenAI for summaries.
- **OpenAI**: `gpt-4.1-mini` is a better quality/cost point than nano for summarization.
- **Embedding cleanup**: consistent shape with `createSummaryModel`, no runtime key-probing.

### Signature changes
- `createSummaryModel(provider: string)` → `createSummaryModel(config: KernConfig)`
- `createEmbeddingModel(provider: string)` → `createEmbeddingModel(config: KernConfig)`
- `MemoryDB.detectEmbeddingDimensions(provider)` → `(config)`

Callsites updated in `app.ts`, `memory.ts`, `segments.ts`, `plugins/recall/recall.ts`, `plugins/recall/plugin.ts`.

### Docs
`docs/config.md` gains a Summary model table and Embedding model table under Providers. README had a stale claim that `summaryModel`/`embeddingModel` were config fields — fixed.

### Backwards compat
- Existing Ollama agents with `gemma3:4b` pulled will switch to their chat model for summaries. Works without any extra pulls.
- Embedding model IDs unchanged per provider — no vector-dim migration triggered.