### PR TITLE
Default model: Claude Opus 4.6 → 4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
 - **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`
 - **Embedding model defaults** — simplified `createEmbeddingModel` to a per-provider switch matching `createSummaryModel`: `openai` → `text-embedding-3-small`, `anthropic`/`openrouter` → `openai/text-embedding-3-small`, `ollama` → `nomic-embed-text`. No behavior change — same model IDs resolved, cleaner branching
-- **Default model bumped to Claude Opus 4.7** — `configDefaults.model` and the `--init-if-needed` fallback now default to `anthropic/claude-opus-4.7`. `kern init` fallback lists (Anthropic + OpenRouter) also bumped. Live model-list fetch remains the normal path; fallbacks/defaults only apply when nothing else is specified
+- **Default model bumped to Claude Opus 4.7** ([#234](https://github.com/oguzbilgic/kern-ai/pull/234)) — `configDefaults.model`, the `--init-if-needed` Docker fallback, and the `kern init` fallback lists all now default to `anthropic/claude-opus-4.7`. Live model-list fetch from the provider remains the normal path; these only apply when nothing is specified or the fetch fails. Sonnet stays on 4.6 — no Sonnet 4.7 exists yet
 
 ## v0.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
 - **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`
 - **Embedding model defaults** — simplified `createEmbeddingModel` to a per-provider switch matching `createSummaryModel`: `openai` → `text-embedding-3-small`, `anthropic`/`openrouter` → `openai/text-embedding-3-small`, `ollama` → `nomic-embed-text`. No behavior change — same model IDs resolved, cleaner branching
+- **`kern init` fallback models** — bumped Anthropic/OpenRouter fallback lists to Claude Opus 4.7. Only used when live model-list fetch fails (no network / bad key); live fetch is the normal path
 
 ## v0.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
 - **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`
 - **Embedding model defaults** — simplified `createEmbeddingModel` to a per-provider switch matching `createSummaryModel`: `openai` → `text-embedding-3-small`, `anthropic`/`openrouter` → `openai/text-embedding-3-small`, `ollama` → `nomic-embed-text`. No behavior change — same model IDs resolved, cleaner branching
-- **`kern init` fallback models** — bumped Anthropic/OpenRouter fallback lists to Claude Opus 4.7. Only used when live model-list fetch fails (no network / bad key); live fetch is the normal path
+- **Default model bumped to Claude Opus 4.7** — `configDefaults.model` and the `--init-if-needed` fallback now default to `anthropic/claude-opus-4.7`. `kern init` fallback lists (Anthropic + OpenRouter) also bumped. Live model-list fetch remains the normal path; fallbacks/defaults only apply when nothing else is specified
 
 ## v0.28.0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 
 ```json
 {
-  "model": "anthropic/claude-opus-4.6",
+  "model": "anthropic/claude-opus-4.7",
   "provider": "openrouter",
   "toolScope": "full"
 }
@@ -17,7 +17,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 | Field | Default | Description |
 |-------|---------|-------------|
 | `name` | directory name | Agent name. Auto-set to directory basename on first startup if missing. Exposed in `/status` response. |
-| `model` | `anthropic/claude-opus-4.6` | Model ID. Format depends on provider. |
+| `model` | `anthropic/claude-opus-4.7` | Model ID. Format depends on provider. |
 | `provider` | `openrouter` | API provider: `openrouter`, `anthropic`, `openai`, `ollama` |
 | `toolScope` | `full` | Tool access level: `full`, `write`, `read` |
 | `maxSteps` | `30` | Max tool-use steps per message |
@@ -41,8 +41,8 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 
 ### Providers
 
-- **openrouter** — routes to cheapest provider. Model IDs like `anthropic/claude-opus-4.6`. Uses OpenAI-compatible chat completions API.
-- **anthropic** — direct Anthropic API. Model IDs like `claude-opus-4-6-20260301`.
+- **openrouter** — routes to cheapest provider. Model IDs like `anthropic/claude-opus-4.7`. Uses OpenAI-compatible chat completions API.
+- **anthropic** — direct Anthropic API. Model IDs like `claude-opus-4-7`.
 - **openai** — OpenAI or Azure. Model IDs like `gpt-4o`.
 - **ollama** — local Ollama server. Model IDs match Ollama model names like `gemma4:31b`. Set `OLLAMA_BASE_URL` in `.env` for remote servers (default: `http://localhost:11434`).
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,7 @@ const TOOL_SCOPES: Record<ToolScope, string[]> = {
 
 export const configDefaults: KernConfig = {
   name: "",
-  model: "anthropic/claude-opus-4.6",
+  model: "anthropic/claude-opus-4.7",
   provider: "openrouter",
   toolScope: "full",
   maxSteps: 30,

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,7 +368,7 @@ async function main() {
       const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
       await scaffoldAgent({
         name, dir: agentDir, provider, envVar, skipStart: true,
-        model: process.env.KERN_MODEL || "anthropic/claude-opus-4.6",
+        model: process.env.KERN_MODEL || "anthropic/claude-opus-4.7",
         apiKey: process.env[envVar] || "",
         telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
         slackBotToken: process.env.SLACK_BOT_TOKEN || "",

--- a/src/init.ts
+++ b/src/init.ts
@@ -10,12 +10,12 @@ import { log } from "./log.js";
 // Fallback models used when live fetch fails (e.g. no network, bad key)
 const FALLBACK_MODELS: Record<string, { name: string; value: string }[]> = {
   openrouter: [
-    { name: "Claude Opus 4.6", value: "anthropic/claude-opus-4.6" },
+    { name: "Claude Opus 4.7", value: "anthropic/claude-opus-4.7" },
     { name: "Claude Sonnet 4.6", value: "anthropic/claude-sonnet-4.6" },
     { name: "Gemini 2.5 Flash", value: "google/gemini-2.5-flash" },
   ],
   anthropic: [
-    { name: "Claude Opus 4.6", value: "claude-opus-4-6" },
+    { name: "Claude Opus 4.7", value: "claude-opus-4-7" },
     { name: "Claude Sonnet 4.6", value: "claude-sonnet-4-6" },
   ],
   openai: [
@@ -319,7 +319,7 @@ export async function runInit(targetArg?: string, flags?: Record<string, string>
     let model = flags.model;
     if (!model) {
       const choices = await getModelChoices(provider, apiKey);
-      model = choices[0]?.value || "anthropic/claude-opus-4.6";
+      model = choices[0]?.value || "anthropic/claude-opus-4.7";
     }
     const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
     const telegramToken = flags["telegram-token"] || "";


### PR DESCRIPTION
Bumps every hardcoded Claude Opus 4.6 reference in the codebase to 4.7.

### Changed
- `src/config.ts` — `configDefaults.model`: the default written into every agent's merged config when nothing else is specified
- `src/index.ts` — `--init-if-needed` fallback: what Docker agents scaffold with when `KERN_MODEL` isn't set
- `src/init.ts` — `kern init` fallback lists (Anthropic + OpenRouter): shown only when live model-list fetch fails
- `docs/config.md` — JSON example, default column in config table, Anthropic provider example (`claude-opus-4-7`)
- `CHANGELOG.md` — single consolidated entry under `## next`

### Not changed
- Sonnet stays on 4.6 — [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview) show no Sonnet 4.7 exists yet
- Live model-list fetch from providers is unchanged — this PR only touches the defaults/fallbacks that kick in when live fetch doesn't apply

### Impact
- New agents default to Opus 4.7 instead of 4.6
- Existing agents with `model` already set in their config are unaffected
- Users on offline networks or with bad API keys will see 4.7 in `kern init` picker instead of 4.6