### PR TITLE
fix(web): parallel agent discovery with timeout (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Fixes
+- **Offline agent no longer blocks sidebar load** ([#229](https://github.com/oguzbilgic/kern-ai/issues/229)) — agent discovery now probes all proxy servers and direct agents in parallel with a 2.5s per-probe timeout. One unreachable agent (e.g. stopped Docker container) no longer stalls the entire UI
+
 ### Improvements
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
 - **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## next
 
 ### Fixes
-- **Offline agent no longer blocks sidebar load** ([#229](https://github.com/oguzbilgic/kern-ai/issues/229)) — agent discovery now probes all proxy servers and direct agents in parallel with a 2.5s per-probe timeout. One unreachable agent (e.g. stopped Docker container) no longer stalls the entire UI
+- Offline agents no longer block sidebar load ([#229](https://github.com/oguzbilgic/kern-ai/issues/229))
 
 ### Improvements
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## next
 
-### Fixes
-- Offline agents no longer block sidebar load ([#229](https://github.com/oguzbilgic/kern-ai/issues/229))
-
 ### Improvements
 - **Docker base image** ([#225](https://github.com/oguzbilgic/kern-ai/issues/225)) — switched to Ubuntu 24.04 (GLIBC 2.39) with Node.js 22, added `curl`, `wget`, `jq`, `python3`, `pip`, `unzip`, `build-essential`; npm and pip install to user space by default, persisted when volume mounted at `/home/kern`
 - **Summary model defaults** ([#232](https://github.com/oguzbilgic/kern-ai/issues/232)) — refreshed hardcoded summary models: `openai` → `gpt-4.1-mini`, `anthropic` → `claude-haiku-4.5` (via OpenRouter), `openrouter` → `openai/gpt-4.1-mini`. Ollama now reuses the agent's chat model instead of requiring a separately-pulled `gemma3:4b`
@@ -12,6 +9,9 @@
 - **Default model bumped to Claude Opus 4.7** ([#234](https://github.com/oguzbilgic/kern-ai/pull/234)) — `configDefaults.model`, the `--init-if-needed` Docker fallback, and the `kern init` fallback lists all now default to `anthropic/claude-opus-4.7`. Live model-list fetch from the provider remains the normal path; these only apply when nothing is specified or the fetch fails. Sonnet stays on 4.6 — no Sonnet 4.7 exists yet
 - **Hardened default `.gitignore`** ([#226](https://github.com/oguzbilgic/kern-ai/issues/226)) — added `.kern/agent.pid`, swapped `.kern/recall.db` for the catch-all `.kern/*.db`. New agents only
 - **Init templates** ([#236](https://github.com/oguzbilgic/kern-ai/pull/236)) — moved `IDENTITY.md`, `KNOWLEDGE.md`, `USERS.md` into `templates/`. `IDENTITY.md` now prompts a first conversation to settle name / purpose / vibe instead of hardcoding the directory name
+
+### Fixes
+- Offline agents no longer block sidebar load ([#229](https://github.com/oguzbilgic/kern-ai/issues/229))
 
 ## v0.28.0
 

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -23,27 +23,30 @@ export function useAgents() {
   const storeUpdateName = useStore((s) => s.updateAgentName);
 
   const discover = useCallback(async () => {
+    // Probe all proxy servers and direct agents in parallel — one slow/offline
+    // agent must not block the rest of the sidebar from loading (#229).
+    const [serverResults, directResults] = await Promise.all([
+      Promise.allSettled(servers.map((s) => api.fetchAgents(s.url, s.token))),
+      Promise.allSettled(directs.map((d) => api.pingAgent(d.url, d.token))),
+    ]);
+
     const proxyAgents: AgentInfo[] = [];
+    serverResults.forEach((r, i) => {
+      if (r.status !== "fulfilled") return;
+      const server = servers[i];
+      for (const a of r.value) {
+        proxyAgents.push({
+          name: a.name,
+          running: a.running,
+          token: server.token,
+          baseUrl: `${server.url}/api/agents/${encodeURIComponent(a.name)}`,
+        });
+      }
+    });
 
-    // Discover from proxy servers
-    for (const server of servers) {
-      try {
-        const raw = await api.fetchAgents(server.url, server.token);
-        for (const a of raw) {
-          proxyAgents.push({
-            name: a.name,
-            running: a.running,
-            token: server.token,
-            baseUrl: `${server.url}/api/agents/${encodeURIComponent(a.name)}`,
-          });
-        }
-      } catch { /* ignore unreachable servers */ }
-    }
-
-    // Discover direct agents (order preserved from store array)
-    const directList: AgentInfo[] = [];
-    for (const d of directs) {
-      const status = await api.pingAgent(d.url, d.token);
+    const directList: AgentInfo[] = directResults.map((r, i) => {
+      const d = directs[i];
+      const status = r.status === "fulfilled" ? r.value : null;
       let name: string;
       if (status?.name) {
         name = status.name;
@@ -53,13 +56,13 @@ export function useAgents() {
         // Offline — use cached name or fall back to hostname
         name = d.name || new URL(d.url).hostname;
       }
-      directList.push({
+      return {
         name,
         running: status !== null,
         token: d.token,
         baseUrl: d.url,
-      });
-    }
+      };
+    });
 
     // Order: direct agents → proxy servers
     const all = [...directList, ...proxyAgents];

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -30,18 +30,15 @@ export function useAgents() {
       Promise.allSettled(directs.map((d) => api.pingAgent(d.url, d.token))),
     ]);
 
-    const proxyAgents: AgentInfo[] = [];
-    serverResults.forEach((r, i) => {
-      if (r.status !== "fulfilled") return;
+    const proxyAgents: AgentInfo[] = serverResults.flatMap((r, i) => {
+      if (r.status !== "fulfilled") return [];
       const server = servers[i];
-      for (const a of r.value) {
-        proxyAgents.push({
-          name: a.name,
-          running: a.running,
-          token: server.token,
-          baseUrl: `${server.url}/api/agents/${encodeURIComponent(a.name)}`,
-        });
-      }
+      return r.value.map((a) => ({
+        name: a.name,
+        running: a.running,
+        token: server.token,
+        baseUrl: `${server.url}/api/agents/${encodeURIComponent(a.name)}`,
+      }));
     });
 
     const directList: AgentInfo[] = directResults.map((r, i) => {

--- a/web/hooks/useAgents.ts
+++ b/web/hooks/useAgents.ts
@@ -68,10 +68,13 @@ export function useAgents() {
     const all = [...directList, ...proxyAgents];
     setAgents(all);
 
-    // Auto-select first running agent if none active
+    // Auto-select first running agent if none active.
+    // Only restore stored selection if that agent is currently running —
+    // picking an offline agent stalls history/SSE loads on a dead URL.
     if (!activeRef.current) {
       const stored = sessionStorage.getItem("kern_active_agent");
-      if (stored && all.some((a) => a.baseUrl === stored)) {
+      const storedAgent = stored ? all.find((a) => a.baseUrl === stored) : null;
+      if (storedAgent && storedAgent.running) {
         setActiveState(stored);
       } else {
         const first = all.find((a) => a.running);

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -9,6 +9,27 @@ function headers(token?: string | null): Record<string, string> {
   return h;
 }
 
+// Fetch with timeout — used for discovery probes so one slow/dead agent doesn't
+// stall the whole sidebar. Aborts after `ms` and rejects with an AbortError.
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit & { timeoutMs?: number } = {},
+): Promise<Response> {
+  const { timeoutMs = 2500, signal: outerSignal, ...rest } = init;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  // Forward an externally provided signal too
+  if (outerSignal) {
+    if (outerSignal.aborted) ctrl.abort();
+    else outerSignal.addEventListener("abort", () => ctrl.abort(), { once: true });
+  }
+  try {
+    return await fetch(url, { ...rest, signal: ctrl.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // SSE connection
 export interface SSEConnection {
   close: () => void;
@@ -68,17 +89,21 @@ export interface RawAgent {
 }
 
 export async function fetchAgents(serverUrl: string, token: string): Promise<RawAgent[]> {
-  const res = await fetch(`${serverUrl}/api/agents`, { headers: headers(token) });
-  if (!res.ok) return [];
-  return res.json();
+  try {
+    const res = await fetchWithTimeout(`${serverUrl}/api/agents`, { headers: headers(token) });
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
 }
 
 // Check if a direct agent is reachable
 export async function pingAgent(baseUrl: string, token: string): Promise<StatusData | null> {
   try {
-    const res = await fetch(`${baseUrl}/status`, { headers: headers(token) });
+    const res = await fetchWithTimeout(`${baseUrl}/status`, { headers: headers(token) });
     if (!res.ok) return null;
-    return res.json();
+    return await res.json();
   } catch {
     return null;
   }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -9,25 +9,13 @@ function headers(token?: string | null): Record<string, string> {
   return h;
 }
 
-// Fetch with timeout — used for discovery probes so one slow/dead agent doesn't
-// stall the whole sidebar. Aborts after `ms` and rejects with an AbortError.
-async function fetchWithTimeout(
+// Fetch with timeout — one slow/offline agent shouldn't stall the whole UI.
+function fetchWithTimeout(
   url: string,
   init: RequestInit & { timeoutMs?: number } = {},
 ): Promise<Response> {
-  const { timeoutMs = 2500, signal: outerSignal, ...rest } = init;
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-  // Forward an externally provided signal too
-  if (outerSignal) {
-    if (outerSignal.aborted) ctrl.abort();
-    else outerSignal.addEventListener("abort", () => ctrl.abort(), { once: true });
-  }
-  try {
-    return await fetch(url, { ...rest, signal: ctrl.signal });
-  } finally {
-    clearTimeout(timer);
-  }
+  const { timeoutMs = 2500, ...rest } = init;
+  return fetch(url, { ...rest, signal: AbortSignal.timeout(timeoutMs) });
 }
 
 // SSE connection

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -144,14 +144,14 @@ export async function sendMessage(
 }
 
 export async function getStatus(baseUrl: string, token?: string | null): Promise<StatusData> {
-  const res = await fetch(`${baseUrl}/status`, { headers: headers(token) });
+  const res = await fetchWithTimeout(`${baseUrl}/status`, { headers: headers(token), timeoutMs: 10_000 });
   return res.json();
 }
 
 export async function getHistory(baseUrl: string, token?: string | null, limit = 100, before?: number): Promise<HistoryMessage[]> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (before !== undefined) params.set("before", String(before));
-  const res = await fetch(`${baseUrl}/history?${params}`, { headers: headers(token) });
+  const res = await fetchWithTimeout(`${baseUrl}/history?${params}`, { headers: headers(token), timeoutMs: 10_000 });
   return res.json();
 }
 


### PR DESCRIPTION
## Problem
When a saved agent is unreachable (e.g. stopped Docker container), the agent discovery loop blocks the entire UI from rendering any agents until the fetch times out. After the timeout, a background refresh cycle eventually loads the working agents.

Most painful in the desktop app's WKWebView (default TCP timeouts are long), but browsers see it too.

## Fix
- `lib/api.ts`: added a `fetchWithTimeout` helper using `AbortController`, wired into `fetchAgents` and `pingAgent` with a 2.5s default timeout
- `hooks/useAgents.ts`: replaced two sequential `for...await` loops with a single `Promise.all([Promise.allSettled(...), Promise.allSettled(...)])` so all proxy servers and direct agents are probed in parallel

## Behavior
- One unreachable agent no longer holds up the rest of the sidebar
- Worst-case discovery latency is now bounded at ~2.5s instead of OS-level TCP timeout (~30-60s)
- Order, name caching, and offline fallback all preserved
- No UI changes — the offline state already renders correctly

Closes #229

## Test
1. Add a direct agent pointing at a non-routable address (e.g. `http://10.255.255.1:9999`)
2. Reload the UI
3. Other agents render within ~2.5s; the dead one shows offline