### PR TITLE
fix(docker): restore apt-get update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM ubuntu:24.04
 
 # System packages
-# RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     curl wget jq git openssh-client \
     python3 python3-pip \
-    unzip ca-certificates
+    unzip ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # Node.js 22 via NodeSource
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-RUN apt-get install -y nodejs \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Build kern from source


### PR DESCRIPTION
## Problem

Docker builds on master are failing with:

```
E: Unable to locate package curl
E: Unable to locate package wget
E: Unable to locate package jq
...
ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get install -y ..." did not complete successfully: exit code: 100
```

Experimental commits from the Matrix PR (#240) landed `apt-get update` commented out and the install in a separate RUN, so the apt package lists were empty at install time.

## Fix

Combine `apt-get update && apt-get install` in a single RUN — the idiomatic Docker pattern. Also cleans the pkg cache in the same layer so the image stays small. Same treatment for the Node.js layer.

`build-essential` stays removed (was dropped earlier to shrink the image, not needed for current agent workloads).

## Verification

Ubuntu archive mirrors have been flaky today, so CI might retry. But once it builds, the resulting image should work the same as v0.28.0 minus `build-essential`.