### PR TITLE
Fix mid-turn injection position (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Fixes
+- **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — mid-turn user messages were re-appended to the end of the model's context on every step, making a directive sent 3 steps ago look like the freshest message each step. Model would over-acknowledge and re-course-correct repeatedly. Now splices injections at their chronological arrival position instead
+
 ## v0.29.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## next
 
 ### Fixes
-- **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — mid-turn user messages were re-appended to the end of the model's context on every step, making a directive sent 3 steps ago look like the freshest message each step. Model would over-acknowledge and re-course-correct repeatedly. Now splices injections at their chronological arrival position instead
+- **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position
 
 ## v0.29.0
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -312,8 +312,12 @@ export class Runtime {
               insertAt: messages.length,
               msg: { role: "user" as const, content: text },
             });
-            // Persist to session JSONL so the next turn sees it in proper order
-            this.session.append([{ role: "user", content: msg.content }]);
+            // Persist to session JSONL so the next turn sees it in proper order.
+            // prepareStep is synchronous — handle the Promise explicitly so a
+            // failed write logs instead of surfacing as an unhandled rejection.
+            void this.session.append([{ role: "user", content: msg.content }]).catch((err) => {
+              log("runtime", `prepareStep: failed to persist mid-turn message: ${err instanceof Error ? err.message : String(err)}`);
+            });
           }
 
           if (midTurnMessages.length === 0) return {};
@@ -322,9 +326,17 @@ export class Runtime {
 
           // Splice each injection at its recorded position. Process in reverse
           // order of insertAt so earlier indices don't shift when we insert later ones.
+          // When multiple injections share the same insertAt (arrived in the same
+          // step), process later arrivals first so repeated splices at the same
+          // index preserve original arrival order in the final array.
           const out = [...messages];
-          const sorted = [...midTurnMessages].sort((a, b) => b.insertAt - a.insertAt);
-          for (const { insertAt, msg } of sorted) {
+          const sorted = midTurnMessages
+            .map((entry, index) => ({ entry, index }))
+            .sort((a, b) => {
+              const byInsertAt = b.entry.insertAt - a.entry.insertAt;
+              return byInsertAt !== 0 ? byInsertAt : b.index - a.index;
+            });
+          for (const { entry: { insertAt, msg } } of sorted) {
             out.splice(insertAt, 0, msg);
           }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -259,8 +259,11 @@ export class Runtime {
 
       const pendingInjections = this.pendingInjections;
       let persistedCount = 0;
-      // Accumulate mid-turn injections so they persist across all subsequent steps
-      const midTurnMessages: { role: "user"; content: string }[] = [];
+      // Accumulate mid-turn injections so they persist across all subsequent steps.
+      // Each injection records the chronological position (insertAt) where it arrived,
+      // so we can splice it back into that position on later steps instead of pinning
+      // it to the end — otherwise the model keeps treating it as the freshest message.
+      const midTurnMessages: { insertAt: number; msg: { role: "user"; content: string } }[] = [];
 
       // For Ollama: pass num_ctx to limit KV cache allocation, disable thinking for speed
       const ollamaOptions = this.config.provider === "ollama"
@@ -300,22 +303,32 @@ export class Runtime {
         prepareStep: ({ messages, stepNumber }) => {
           if (stepNumber === 0 || !pendingInjections) return {};
 
-          // Collect new injections and add to persistent mid-turn list
+          // Collect any new injections; record the chronological position
+          // (current messages length) at which each arrived.
           const injections = pendingInjections();
           for (const msg of injections) {
             const text = typeof msg.content === "string" ? msg.content : extractText(msg.content);
-            midTurnMessages.push({ role: "user" as const, content: text });
-            // Persist to session JSONL
+            midTurnMessages.push({
+              insertAt: messages.length,
+              msg: { role: "user" as const, content: text },
+            });
+            // Persist to session JSONL so the next turn sees it in proper order
             this.session.append([{ role: "user", content: msg.content }]);
           }
 
           if (midTurnMessages.length === 0) return {};
 
-          log("runtime", `prepareStep: injecting ${midTurnMessages.length} mid-turn message(s) at step ${stepNumber}`);
+          log("runtime", `prepareStep: splicing ${midTurnMessages.length} mid-turn message(s) at step ${stepNumber}`);
 
-          return {
-            messages: [...messages, ...midTurnMessages],
-          };
+          // Splice each injection at its recorded position. Process in reverse
+          // order of insertAt so earlier indices don't shift when we insert later ones.
+          const out = [...messages];
+          const sorted = [...midTurnMessages].sort((a, b) => b.insertAt - a.insertAt);
+          for (const { insertAt, msg } of sorted) {
+            out.splice(insertAt, 0, msg);
+          }
+
+          return { messages: out };
         },
       });
 


### PR DESCRIPTION
Closes #245.

## Problem

Mid-turn user messages (e.g. "no dont add them" sent while agent is in a multi-step turn) were being re-appended to the **end** of the model's message list on every subsequent step. So on step 5 the model saw:

```
[original history]
[step 1 assistant + tool + result]
[step 2 assistant + tool + result]
[step 3 assistant + tool + result]
[step 4 assistant + tool + result]
"no dont add them"   ← looks like the freshest user message
```

Even though the injection was received 3 steps ago. Model kept re-acknowledging and re-course-correcting the same directive, over and over.

## Why the accumulator is still needed

AI SDK rebuilds step input messages fresh each step from \`initialMessages + responseMessages\` (see \`node_modules/ai/dist/index.mjs:4219\`). Overrides returned from \`prepareStep\` at step N do **not** carry into step N+1. So we can't inject once and rely on the SDK; we need to re-inject every step.

## Fix

Record \`insertAt: messages.length\` at the step where each injection arrived — that's its chronological position, right after whatever assistant output was in flight. On every subsequent step, splice injections back in at their recorded positions instead of pinning them to the end.

Now at step 5:

```
[original history]
[step 1 assistant + tool + result]
[step 2 assistant + tool + result]
"no dont add them"   ← at its actual chronological position
[step 3 assistant + tool + result]
[step 4 assistant + tool + result]
```

Model reads: "user said X three steps ago, I acknowledged and moved on, continuing." No more loops.

Splice is done in reverse index order so earlier insertions don't shift the positions of later ones.

Session JSONL persistence unchanged — next turn still sees the injection in its proper chronological place when context is rebuilt from session.

## Test

Reproduce by sending a mid-turn correction during a 4+ step tool-heavy turn. Before this fix: model re-acknowledges the correction on every step. After: acknowledges once, continues.

## Related

- Supersedes #60 (original "injections forgotten" bug — PR #94 over-corrected by pinning to end)
- #93 (mid-turn steering, same area)