### PR TITLE
docker: build + push on PR and master, auto-cleanup on close

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,14 +3,18 @@ name: Docker
 on:
   release:
     types: [published]
-  workflow_dispatch: {}
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  push:
+    branches: [master]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  docker:
+  build:
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -30,10 +34,31 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
-            type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=master,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
       - uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  cleanup-pr:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete PR image tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          package=$(basename "${{ env.IMAGE_NAME }}")
+          owner=$(dirname "${{ env.IMAGE_NAME }}")
+          gh api --paginate "/users/${owner}/packages/container/${package}/versions" \
+            --jq ".[] | select(.metadata.container.tags[]? | test(\"^pr-${PR}$\")) | .id" \
+            | while read -r id; do
+                echo "deleting version $id (pr-${PR})"
+                gh api -X DELETE "/users/${owner}/packages/container/${package}/versions/${id}"
+              done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## next
 
-### Improvements
-- **Docker images for every PR and master commit** ([#247](https://github.com/oguzbilgic/kern-ai/issues/247)) — pull `ghcr.io/oguzbilgic/kern-ai:pr-<N>` to test any open PR, `:master` for bleeding edge. PR tags auto-delete on close. `:latest` still only moves on release
-
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Improvements
+- **Docker images for every PR and master commit** ([#247](https://github.com/oguzbilgic/kern-ai/issues/247)) — pull `ghcr.io/oguzbilgic/kern-ai:pr-<N>` to test any open PR, `:master` for bleeding edge. PR tags auto-delete on close. `:latest` still only moves on release
+
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position
 


### PR DESCRIPTION
Closes #247.

Builds and pushes a Docker image on every PR and master commit so Docker regressions surface early, and any branch is pullable from GHCR.

## Triggers

- `pull_request` (opened, sync, reopened, closed)
- `push: branches: [master]`
- `release` (unchanged)
- Removed `workflow_dispatch`

## Tags

- PR → `pr-<N>`
- master push → `master`
- release → `x.y.z`, `x.y`, `latest`

`:latest` still only moves on release.

## Cleanup

When a PR closes (merged or not), `cleanup-pr` job deletes `pr-<N>` tags via `gh api`.

## Test plan

- Opening this PR should publish `ghcr.io/oguzbilgic/kern-ai:pr-<this-pr-number>`
- Closing this PR should delete it