### PR TITLE
MCP plugin — connect to Model Context Protocol servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Features
+- **MCP support** ([#47](https://github.com/oguzbilgic/kern-ai/issues/47)) — connect to Model Context Protocol servers and expose their tools to the agent. Configure under `mcpServers` in `.kern/config.json`; supports `http`, `sse`, and `stdio` transports. Tools namespaced as `<server>__<tool>`. `${VAR}` substitution in config for tokens and secrets. See [docs/mcp.md](docs/mcp.md)
+
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 - **MCP support** ([#47](https://github.com/oguzbilgic/kern-ai/issues/47)) — connect agents to Model Context Protocol servers and expose their tools alongside kern's native tools
   - Configure servers under `mcpServers` in `.kern/config.json`. Three transports: `http`, `sse`, `stdio`
   - `${VAR}` substitution in any config string so tokens and secrets live in `.kern/.env`
-  - Tools are namespaced as `<server>__<tool>` — connect two servers that expose the same tool without collision
-  - One failing server doesn't block others or the agent. Missing env vars surface as real auth errors from the server, not silent drops
   - `/mcp` slash command shows configured servers, connection state, and available tools at a glance ([#253](https://github.com/oguzbilgic/kern-ai/issues/253))
   - Bundled `add-mcp-server` skill walks the agent through adding a new server
   - See [docs/mcp.md](docs/mcp.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 ## next
 
 ### Features
-- **MCP support** ([#47](https://github.com/oguzbilgic/kern-ai/issues/47)) — connect to Model Context Protocol servers and expose their tools to the agent. Configure under `mcpServers` in `.kern/config.json`; supports `http`, `sse`, and `stdio` transports. Tools namespaced as `<server>__<tool>`. `${VAR}` substitution in config for tokens and secrets. See [docs/mcp.md](docs/mcp.md)
-- **`/mcp` slash command** ([#253](https://github.com/oguzbilgic/kern-ai/issues/253)) — list configured MCP servers, connection state, and tool names. Failed servers show short error reason
+- **MCP support** ([#47](https://github.com/oguzbilgic/kern-ai/issues/47)) — connect agents to Model Context Protocol servers and expose their tools alongside kern's native tools
+  - Configure servers under `mcpServers` in `.kern/config.json`. Three transports: `http`, `sse`, `stdio`
+  - `${VAR}` substitution in any config string so tokens and secrets live in `.kern/.env`
+  - Tools are namespaced as `<server>__<tool>` — connect two servers that expose the same tool without collision
+  - One failing server doesn't block others or the agent. Missing env vars surface as real auth errors from the server, not silent drops
+  - `/mcp` slash command shows configured servers, connection state, and available tools at a glance ([#253](https://github.com/oguzbilgic/kern-ai/issues/253))
+  - Bundled `add-mcp-server` skill walks the agent through adding a new server
+  - See [docs/mcp.md](docs/mcp.md)
 
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - **MCP support** ([#47](https://github.com/oguzbilgic/kern-ai/issues/47)) — connect to Model Context Protocol servers and expose their tools to the agent. Configure under `mcpServers` in `.kern/config.json`; supports `http`, `sse`, and `stdio` transports. Tools namespaced as `<server>__<tool>`. `${VAR}` substitution in config for tokens and secrets. See [docs/mcp.md](docs/mcp.md)
+- **`/mcp` slash command** ([#253](https://github.com/oguzbilgic/kern-ai/issues/253)) — list configured MCP servers, connection state, and tool names. Failed servers show short error reason
 
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 | `mediaDigest` | `true` | Enable image pre-digest: describes images via vision model on arrival, caches descriptions, and replaces raw images with text in context. Set to `false` to disable the entire digest pipeline. |
 | `mediaModel` | `""` | Vision model for media descriptions. Fallback chain: `mediaModel` → agent model → hardcoded provider default. Example: `"openai/gpt-4.1-mini"`. |
 | `mediaContext` | `0` | How many recent turns resolve raw media Buffers to the model. `0` = never send raw binary (text descriptions or placeholders only). Applies to all media types — useful for non-image files like PDFs on models with native support. |
+| `mcpServers` | `{}` | Model Context Protocol servers. Tools namespaced as `<server>__<tool>`. See [MCP](mcp.md). |
 
 ### Tool scopes
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,64 @@
+# MCP — Model Context Protocol
+
+Kern connects to [Model Context Protocol](https://modelcontextprotocol.io/) servers and exposes their tools to the agent. Each server is defined in the agent's config and connected at startup.
+
+## Configuring servers
+
+Add `mcpServers` to `.kern/config.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "transport": "http",
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    },
+    "filesystem": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    },
+    "zapier": {
+      "transport": "sse",
+      "url": "https://actions.zapier.com/mcp/..."
+    }
+  }
+}
+```
+
+Each server needs a `transport` field:
+
+| Transport | Fields | Notes |
+|---|---|---|
+| `http` | `url`, optional `headers` | Recommended for remote servers |
+| `sse` | `url`, optional `headers` | Alternative HTTP transport |
+| `stdio` | `command`, optional `args`, optional `env` | Spawns a local process |
+
+## Environment variable substitution
+
+`${VAR_NAME}` references in any string field (url, headers, command, args, env) are resolved from `.kern/.env` at startup. Missing vars are left as literal `${VAR}` and logged as a warning — the server will return its real auth error when it fails.
+
+Use this for tokens and secrets. Don't commit resolved values to config.
+
+## Tool naming
+
+MCP tools are namespaced with the server name: `<server>__<tool>`. So a `create_issue` tool from a server named `github` appears to the agent as `github__create_issue`. This prevents collisions when multiple servers expose tools with the same name.
+
+## Failure handling
+
+- Servers connect in parallel at startup. One server failing doesn't block others or the agent.
+- Failed connections log an error and are dropped. Fix the config and restart to retry.
+- The `/status` endpoint reports `mcp: <N> server(s), <M> tool(s)`.
+
+## Scope
+
+Kern's MCP integration is intentionally minimal:
+
+- **Tools only** — resources, prompts, and elicitation are not exposed.
+- **No OAuth flow** — authorize tokens out-of-band and pass via headers or env.
+- **All-or-nothing** — all tools from a connected server are available to the agent. There's no per-tool filter yet.
+
+File an issue if you need something beyond this.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -39,7 +39,7 @@ Each server needs a `transport` field:
 
 ## Environment variable substitution
 
-`${VAR_NAME}` references in any string field (url, headers, command, args, env) are resolved from `.kern/.env` at startup. Missing vars are left as literal `${VAR}` and logged as a warning — the server will return its real auth error when it fails.
+`${VAR}` references in any string field (url, headers, command, args, env) are resolved from `.kern/.env` at startup. Names follow shell convention (letters, digits, underscore; first char not a digit; case-sensitive). Missing vars are left as literal `${VAR}` and logged as a warning — the server will return its real auth error when it fails.
 
 Use this for tokens and secrets. Don't commit resolved values to config.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -51,7 +51,7 @@ MCP tools are namespaced with the server name: `<server>__<tool>`. So a `create_
 
 - Servers connect in parallel at startup. One server failing doesn't block others or the agent.
 - Failed connections log an error and are dropped. Fix the config and restart to retry.
-- The `/status` endpoint reports `mcp: <N> server(s), <M> tool(s)`.
+- The `/status` endpoint reports `mcp: <connected>/<configured> server(s), <M> tool(s)`. If `<connected>` is less than `<configured>`, check logs for the connection error.
 
 ## Scope
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.0",
+        "@ai-sdk/mcp": "^1.0.36",
         "@ai-sdk/openai": "^3.0.48",
         "@inquirer/prompts": "^8.3.2",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@openrouter/ai-sdk-provider": "^2.3.3",
         "@slack/bolt": "^4.6.0",
         "ai": "^6.0.0",
@@ -92,6 +94,52 @@
       "version": "4.0.21",
       "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.21.tgz",
       "integrity": "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.36.tgz",
+      "integrity": "sha512-THQKwlknp7OU2ViLPfIU7W01XvDRM2eqH+4UULQgP64AopnwI9mGqqJeGIx2l/pxUu9yIDQtW9YtYM8kHm2CQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "pkce-challenge": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
@@ -640,6 +688,18 @@
       "integrity": "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
@@ -982,6 +1042,46 @@
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@openrouter/ai-sdk-provider": {
       "version": "2.3.3",
@@ -1352,6 +1452,39 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -1750,6 +1883,23 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2052,6 +2202,18 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
@@ -2113,6 +2275,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -2127,6 +2313,22 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -2443,6 +2645,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -2594,6 +2805,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2678,11 +2898,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -2955,6 +3196,15 @@
         }
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3116,6 +3366,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/prebuild-install": {
@@ -3299,6 +3558,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -4109,6 +4377,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
   "author": "Oguz Bilgic",
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.0",
+    "@ai-sdk/mcp": "^1.0.36",
     "@ai-sdk/openai": "^3.0.48",
     "@inquirer/prompts": "^8.3.2",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@openrouter/ai-sdk-provider": "^2.3.3",
     "@slack/bolt": "^4.6.0",
     "ai": "^6.0.0",

--- a/skills/add-mcp-server/SKILL.md
+++ b/skills/add-mcp-server/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: add-mcp-server
+description: Add a Model Context Protocol (MCP) server to extend your toolbox with external tools
+---
+
+# Add MCP Server
+
+MCP (Model Context Protocol) lets you connect to external tool servers — GitHub, filesystem, databases, SaaS APIs, etc. — and call their tools like native kern tools. Use this skill when the operator asks you to add a capability that an MCP server provides, or when you need a tool kern doesn't ship.
+
+## Decide: which server?
+
+If the operator named a server ("add the GitHub MCP"), use that. Otherwise:
+
+1. **Check the official list**: https://github.com/modelcontextprotocol/servers — official reference servers (filesystem, git, memory, fetch, etc.)
+2. **Web search** for community servers: `websearch` for `"<capability> MCP server"`. Prefer well-maintained, popular ones.
+3. **Vendor-hosted**: many SaaS vendors expose MCP endpoints (GitHub, Cloudflare, Sentry, etc.). Check their docs.
+
+If nothing fits, tell the operator what you found and ask how to proceed.
+
+## Decide: which transport?
+
+- **`http`** — hosted endpoint (`https://...`). Best for SaaS / vendor MCPs.
+- **`sse`** — legacy streaming variant of HTTP. Use if the server only documents SSE.
+- **`stdio`** — local process. The server runs as a subprocess on your machine. Used for `npx`/`uvx` reference servers.
+
+Rule of thumb: if the server has a URL, use `http`. If the install instructions say `npx @scope/server-name`, use `stdio`.
+
+## Step 1: find the config values
+
+You need, depending on transport:
+
+| Transport | Required fields |
+|---|---|
+| `http` / `sse` | `url`, optional `headers` (for auth) |
+| `stdio` | `command`, `args`, optional `env` |
+
+Read the server's README. Find the example config. Note any required env vars (tokens, API keys, paths).
+
+## Step 2: add secrets to `.kern/.env`
+
+Never hardcode tokens. Add them to `.kern/.env`:
+
+```bash
+echo 'GITHUB_TOKEN=ghp_xxxxxxxxxxxx' >> .kern/.env
+```
+
+Use the exact variable name the server expects. Reference it in config as `${VAR_NAME}`.
+
+## Step 3: add the server to `.kern/config.json`
+
+Read the current config first so you don't clobber other fields. Then add or extend the `mcpServers` block.
+
+### Hosted HTTP example (GitHub)
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "transport": "http",
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+### Local stdio example (filesystem)
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
+    }
+  }
+}
+```
+
+### With env vars for stdio
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@sentry/mcp-server"],
+      "env": {
+        "SENTRY_AUTH_TOKEN": "${SENTRY_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Multiple servers live side-by-side in the same `mcpServers` object. Server names are free-form but must be valid identifiers (letters, digits, underscore); they become the prefix for tool names.
+
+## Step 4: restart
+
+Config is read at startup. Ask the operator to `/restart`.
+
+## Step 5: verify
+
+After restart, check `/status` or the kern tool:
+
+```
+/status
+```
+
+Look for a line like `mcp: 1 server(s), 14 tool(s)`. If the count is 0, the server failed to connect — the reason is in the logs (`kern({ action: "logs", level: "warn" })`).
+
+New tools appear in your toolbox as `<server>__<tool>` — e.g. `github__search_repositories`, `filesystem__read_file`. Call them the same way you'd call any other tool.
+
+## Troubleshooting
+
+**`mcp: 0 server(s)`**: server never connected. Check logs for the real error (bad URL, auth failure, npx not found, wrong env var name).
+
+**`${VAR}` stays literal in logs**: the env var isn't in `.kern/.env` or the name doesn't match (env var names are case-sensitive). Check `.kern/.env`.
+
+**Server connects but no tools appear**: server has zero tools (some MCP servers only expose resources or prompts, which kern doesn't use). Try a different server.
+
+**`command not found` for stdio**: the command must be on the agent's PATH. `npx` works because Node is installed. For other runtimes (uvx, python, etc.), confirm they're available on the host.
+
+**Tool name collisions**: two servers exposing the same tool name won't collide — they're namespaced by server. If you want shorter names, rename the server key.
+
+## Reporting back
+
+After verifying, tell the operator:
+- Which server you added
+- How many tools it exposes
+- A sample tool name they can try
+
+If it failed, report the exact error from the logs and what you tried.
+
+## Reference
+
+Full details: see `docs/mcp.md` in the kern repo.

--- a/skills/add-mcp-server/SKILL.md
+++ b/skills/add-mcp-server/SKILL.md
@@ -97,7 +97,7 @@ Read the current config first so you don't clobber other fields. Then add or ext
 }
 ```
 
-Multiple servers live side-by-side in the same `mcpServers` object. Server names are free-form but must be valid identifiers (letters, digits, underscore); they become the prefix for tool names.
+Multiple servers live side-by-side in the same `mcpServers` object. Server names become the prefix for tool names — prefer simple names using letters, digits, and underscores for readability.
 
 ## Step 4: restart
 
@@ -111,13 +111,13 @@ After restart, check `/status` or the kern tool:
 /status
 ```
 
-Look for a line like `mcp: 1 server(s), 14 tool(s)`. If the count is 0, the server failed to connect — the reason is in the logs (`kern({ action: "logs", level: "warn" })`).
+Look for a line like `mcp: 1/1 server(s), 14 tool(s)`. The first number is connected servers, the second is configured. If connected is less than configured, the server failed to connect — the reason is in the logs (`kern({ action: "logs", level: "warn" })`).
 
 New tools appear in your toolbox as `<server>__<tool>` — e.g. `github__search_repositories`, `filesystem__read_file`. Call them the same way you'd call any other tool.
 
 ## Troubleshooting
 
-**`mcp: 0 server(s)`**: server never connected. Check logs for the real error (bad URL, auth failure, npx not found, wrong env var name).
+**`mcp: 0/1 server(s), 0 tool(s)`**: server is configured but never connected. Check logs for the real error (bad URL, auth failure, npx not found, wrong env var name). The first number is connected servers, the second is configured servers.
 
 **`${VAR}` stays literal in logs**: the env var isn't in `.kern/.env` or the name doesn't match (env var names are case-sensitive). Check `.kern/.env`.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,23 @@ export interface KernConfig {
 
   // Runtime
   heartbeatInterval: number;
+
+  // MCP — Model Context Protocol servers. Agent-local. See docs/mcp.md.
+  mcpServers?: Record<string, McpServerConfig>;
 }
+
+export type McpServerConfig =
+  | {
+      transport: "http" | "sse";
+      url: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      transport: "stdio";
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    };
 
 const shell = process.platform === "win32" ? "pwsh" : "bash";
 
@@ -80,6 +96,7 @@ const FIELD_TYPES: Record<string, string> = {
   mediaContext: "number",
   telegramTools: "boolean",
   heartbeatInterval: "number",
+  mcpServers: "object",
 };
 
 function validateConfig(userConfig: Record<string, unknown>): void {

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,15 @@ const FIELD_TYPES: Record<string, string> = {
   mcpServers: "object",
 };
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function typeMatches(value: unknown, expected: string): boolean {
+  if (expected === "object") return isPlainObject(value);
+  return typeof value === expected;
+}
+
 function validateConfig(userConfig: Record<string, unknown>): void {
   for (const key of Object.keys(userConfig)) {
     if (!(key in FIELD_TYPES)) {
@@ -106,8 +115,12 @@ function validateConfig(userConfig: Record<string, unknown>): void {
       continue;
     }
     const expected = FIELD_TYPES[key];
-    const actual = typeof userConfig[key];
-    if (actual !== expected) {
+    if (!typeMatches(userConfig[key], expected)) {
+      const actual = userConfig[key] === null
+        ? "null"
+        : Array.isArray(userConfig[key])
+          ? "array"
+          : typeof userConfig[key];
       log.warn("config", `"${key}" should be ${expected}, got ${actual} — using default`);
     }
   }
@@ -138,7 +151,7 @@ export async function loadConfig(agentDir: string): Promise<KernConfig> {
     // Filter out unknown and wrong-type fields
     const cleaned: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(userConfig)) {
-      if (key in FIELD_TYPES && typeof value === FIELD_TYPES[key]) {
+      if (key in FIELD_TYPES && typeMatches(value, FIELD_TYPES[key])) {
         cleaned[key] = value;
       }
     }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -4,6 +4,7 @@ import { notesPlugin } from "./notes/plugin.js";
 import { recallPlugin } from "./recall/plugin.js";
 import { mediaPlugin } from "./media/plugin.js";
 import { skillsPlugin } from "./skills/plugin.js";
+import { mcpPlugin } from "./mcp/plugin.js";
 import { log } from "../log.js";
 
 export type { KernPlugin, PluginContext, RouteHandler, ContextInjection, BeforeContextInfo } from "./types.js";
@@ -18,6 +19,7 @@ const availablePlugins: KernPlugin[] = [
   mediaPlugin,
   dashboardPlugin,
   skillsPlugin,
+  mcpPlugin,
 ];
 
 /** Active plugin instances after loading */

--- a/src/plugins/mcp/plugin.ts
+++ b/src/plugins/mcp/plugin.ts
@@ -15,14 +15,30 @@ type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
 interface ActiveServer {
   name: string;
   client: MCPClient;
-  toolCount: number;
+  tools: Array<{ name: string }>;
+}
+
+/** One server we tried and failed to connect to. */
+interface FailedServer {
+  name: string;
+  reason: string;
 }
 
 /** Connected servers for the lifetime of this plugin. */
 const active: ActiveServer[] = [];
 
+/** Failed servers, for /status and /mcp visibility. */
+const failed: FailedServer[] = [];
+
 /** Count of servers present in config — for /status visibility even when all failed. */
 let configured = 0;
+
+/** First line of an error message, truncated for compact display. */
+function shortReason(err: unknown): string {
+  const msg = errMsg(err);
+  const firstLine = msg.split("\n")[0];
+  return firstLine.length > 80 ? firstLine.slice(0, 77) + "..." : firstLine;
+}
 
 /**
  * Merged tools from all servers, namespaced as `<server>__<tool>`.
@@ -68,14 +84,14 @@ async function connectServer(name: string, cfg: McpServerConfig): Promise<void> 
   try {
     const serverTools = await client.tools();
 
-    let count = 0;
+    const tools: Array<{ name: string }> = [];
     for (const [toolName, tool] of Object.entries(serverTools)) {
       mergedTools[`${name}__${toolName}`] = tool;
-      count++;
+      tools.push({ name: toolName });
     }
 
-    active.push({ name, client, toolCount: count });
-    log("mcp", `connected "${name}" — ${count} tool(s)`);
+    active.push({ name, client, tools });
+    log("mcp", `connected "${name}" — ${tools.length} tool(s)`);
   } catch (err) {
     // Client is open (stdio may have spawned a subprocess). Close it before rethrowing.
     try {
@@ -103,6 +119,7 @@ export const mcpPlugin: KernPlugin = {
       Object.entries(servers).map(([name, cfg]) =>
         connectServer(name, cfg).catch((err) => {
           log.error("mcp", `failed to connect "${name}": ${errMsg(err)}`);
+          failed.push({ name, reason: shortReason(err) });
         }),
       ),
     );
@@ -117,6 +134,7 @@ export const mcpPlugin: KernPlugin = {
       ),
     );
     active.length = 0;
+    failed.length = 0;
     configured = 0;
     for (const k of Object.keys(mergedTools)) delete mergedTools[k];
   },
@@ -125,9 +143,41 @@ export const mcpPlugin: KernPlugin = {
     // Only stay silent when MCP isn't configured at all. If it is configured
     // but all connections failed, surface that in /status so operators see it.
     if (configured === 0) return {};
-    const total = active.reduce((sum, s) => sum + s.toolCount, 0);
+    const total = active.reduce((sum, s) => sum + s.tools.length, 0);
     return {
       mcp: `${active.length}/${configured} server(s), ${total} tool(s)`,
     };
+  },
+
+  commands: {
+    "/mcp": {
+      description: "list MCP servers and their tools",
+      handler: async () => {
+        if (configured === 0) {
+          return "No MCP servers configured. See docs/mcp.md";
+        }
+
+        const total = active.reduce((sum, s) => sum + s.tools.length, 0);
+        const lines = [`MCP (${configured} configured, ${active.length}/${configured} connected, ${total} tools)`, ""];
+
+        for (const s of active) {
+          lines.push(`  ✦ ${s.name} — ${s.tools.length} tools`);
+          if (s.tools.length > 0) {
+            const TOOL_CAP = 20;
+            const names = s.tools.map((t) => t.name);
+            const shown = names.slice(0, TOOL_CAP);
+            const extra = names.length - shown.length;
+            const tail = extra > 0 ? `, (... ${extra} more)` : "";
+            lines.push(`      ${shown.join(", ")}${tail}`);
+          }
+        }
+
+        for (const f of failed) {
+          lines.push(`  ✗ ${f.name} — ${f.reason}`);
+        }
+
+        return lines.join("\n");
+      },
+    },
   },
 };

--- a/src/plugins/mcp/plugin.ts
+++ b/src/plugins/mcp/plugin.ts
@@ -5,6 +5,10 @@ import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import { substituteEnvDeep } from "../../util.js";
 import { log } from "../../log.js";
 
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
 
 /** One connected MCP server. */
@@ -16,6 +20,9 @@ interface ActiveServer {
 
 /** Connected servers for the lifetime of this plugin. */
 const active: ActiveServer[] = [];
+
+/** Count of servers present in config — for /status visibility even when all failed. */
+let configured = 0;
 
 /**
  * Merged tools from all servers, namespaced as `<server>__<tool>`.
@@ -57,16 +64,27 @@ async function connectServer(name: string, cfg: McpServerConfig): Promise<void> 
 
   const transport = buildTransport(name, resolved);
   const client = await createMCPClient({ transport });
-  const serverTools = await client.tools();
 
-  let count = 0;
-  for (const [toolName, tool] of Object.entries(serverTools)) {
-    mergedTools[`${name}__${toolName}`] = tool;
-    count++;
+  try {
+    const serverTools = await client.tools();
+
+    let count = 0;
+    for (const [toolName, tool] of Object.entries(serverTools)) {
+      mergedTools[`${name}__${toolName}`] = tool;
+      count++;
+    }
+
+    active.push({ name, client, toolCount: count });
+    log("mcp", `connected "${name}" — ${count} tool(s)`);
+  } catch (err) {
+    // Client is open (stdio may have spawned a subprocess). Close it before rethrowing.
+    try {
+      await client.close();
+    } catch (closeErr) {
+      log.warn("mcp", `server "${name}": close failed after startup error: ${errMsg(closeErr)}`);
+    }
+    throw err;
   }
-
-  active.push({ name, client, toolCount: count });
-  log("mcp", `connected "${name}" — ${count} tool(s)`);
 }
 
 export const mcpPlugin: KernPlugin = {
@@ -77,12 +95,14 @@ export const mcpPlugin: KernPlugin = {
     const servers = ctx.config.mcpServers;
     if (!servers || Object.keys(servers).length === 0) return;
 
+    configured = Object.keys(servers).length;
+
     // Connect to all servers in parallel; failures don't block the agent
     // or other servers — they just mean those tools aren't available.
     await Promise.all(
       Object.entries(servers).map(([name, cfg]) =>
-        connectServer(name, cfg).catch((err: any) => {
-          log.error("mcp", `failed to connect "${name}": ${err.message}`);
+        connectServer(name, cfg).catch((err) => {
+          log.error("mcp", `failed to connect "${name}": ${errMsg(err)}`);
         }),
       ),
     );
@@ -91,20 +111,23 @@ export const mcpPlugin: KernPlugin = {
   async onShutdown() {
     await Promise.all(
       active.map((s) =>
-        s.client.close().catch((err: any) => {
-          log.warn("mcp", `close error for "${s.name}": ${err.message}`);
+        s.client.close().catch((err) => {
+          log.warn("mcp", `close error for "${s.name}": ${errMsg(err)}`);
         }),
       ),
     );
     active.length = 0;
+    configured = 0;
     for (const k of Object.keys(mergedTools)) delete mergedTools[k];
   },
 
   onStatus() {
-    if (active.length === 0) return {};
+    // Only stay silent when MCP isn't configured at all. If it is configured
+    // but all connections failed, surface that in /status so operators see it.
+    if (configured === 0) return {};
     const total = active.reduce((sum, s) => sum + s.toolCount, 0);
     return {
-      mcp: `${active.length} server(s), ${total} tool(s)`,
+      mcp: `${active.length}/${configured} server(s), ${total} tool(s)`,
     };
   },
 };

--- a/src/plugins/mcp/plugin.ts
+++ b/src/plugins/mcp/plugin.ts
@@ -1,0 +1,110 @@
+import type { KernPlugin, PluginContext } from "../types.js";
+import type { McpServerConfig } from "../../config.js";
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { substituteEnvDeep } from "../../util.js";
+import { log } from "../../log.js";
+
+type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
+
+/** One connected MCP server. */
+interface ActiveServer {
+  name: string;
+  client: MCPClient;
+  toolCount: number;
+}
+
+/** Connected servers for the lifetime of this plugin. */
+const active: ActiveServer[] = [];
+
+/**
+ * Merged tools from all servers, namespaced as `<server>__<tool>`.
+ * Populated during onStartup; read by the plugin manager's collectTools()
+ * which runs after onStartup awaits complete, so a plain object is fine.
+ */
+const mergedTools: Record<string, any> = {};
+
+/**
+ * Build a transport from one server's config. Env vars already substituted.
+ */
+function buildTransport(name: string, cfg: McpServerConfig) {
+  if (cfg.transport === "http" || cfg.transport === "sse") {
+    return {
+      type: cfg.transport,
+      url: cfg.url,
+      ...(cfg.headers ? { headers: cfg.headers } : {}),
+    } as const;
+  }
+  if (cfg.transport === "stdio") {
+    return new Experimental_StdioMCPTransport({
+      command: cfg.command,
+      args: cfg.args ?? [],
+      env: cfg.env,
+    });
+  }
+  throw new Error(`unknown MCP transport for server "${name}"`);
+}
+
+/**
+ * Connect to one server, fetch its tools, and prefix them with the server name.
+ */
+async function connectServer(name: string, cfg: McpServerConfig): Promise<void> {
+  // Warn (don't fail) on unresolved ${VAR} references; let the server return
+  // the real auth error so the user sees what's missing.
+  const resolved = substituteEnvDeep(cfg, (missing) => {
+    log.warn("mcp", `server "${name}": ${missing} not set in env`);
+  });
+
+  const transport = buildTransport(name, resolved);
+  const client = await createMCPClient({ transport });
+  const serverTools = await client.tools();
+
+  let count = 0;
+  for (const [toolName, tool] of Object.entries(serverTools)) {
+    mergedTools[`${name}__${toolName}`] = tool;
+    count++;
+  }
+
+  active.push({ name, client, toolCount: count });
+  log("mcp", `connected "${name}" — ${count} tool(s)`);
+}
+
+export const mcpPlugin: KernPlugin = {
+  name: "mcp",
+  tools: mergedTools,
+
+  async onStartup(ctx: PluginContext) {
+    const servers = ctx.config.mcpServers;
+    if (!servers || Object.keys(servers).length === 0) return;
+
+    // Connect to all servers in parallel; failures don't block the agent
+    // or other servers — they just mean those tools aren't available.
+    await Promise.all(
+      Object.entries(servers).map(([name, cfg]) =>
+        connectServer(name, cfg).catch((err: any) => {
+          log.error("mcp", `failed to connect "${name}": ${err.message}`);
+        }),
+      ),
+    );
+  },
+
+  async onShutdown() {
+    await Promise.all(
+      active.map((s) =>
+        s.client.close().catch((err: any) => {
+          log.warn("mcp", `close error for "${s.name}": ${err.message}`);
+        }),
+      ),
+    );
+    active.length = 0;
+    for (const k of Object.keys(mergedTools)) delete mergedTools[k];
+  },
+
+  onStatus() {
+    if (active.length === 0) return {};
+    const total = active.reduce((sum, s) => sum + s.toolCount, 0);
+    return {
+      mcp: `${active.length} server(s), ${total} tool(s)`,
+    };
+  },
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,12 +30,15 @@ export function htmlToMarkdown(html: string): string {
  * Substitute ${VAR} references with values from process.env.
  * Read-only — never writes resolved values back. Matches OpenClaw's pattern.
  * Missing vars are left as literal `${VAR}` and logged (caller decides log policy).
+ *
+ * Variable names follow shell convention: letters, digits, underscore; first
+ * char must not be a digit. Case-sensitive (matches process.env key lookup).
  */
 export function substituteEnv(
   value: string,
   onMissing?: (name: string) => void,
 ): string {
-  return value.replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (match, name) => {
+  return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name) => {
     const v = process.env[name];
     if (v === undefined) {
       onMissing?.(name);

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,7 +62,13 @@ export function substituteEnvDeep<T>(
   if (Array.isArray(value)) {
     return value.map((v) => substituteEnvDeep(v, onMissing)) as T;
   }
-  if (value !== null && typeof value === "object") {
+  // Only traverse plain objects. Non-plain objects (Date, Map, class instances)
+  // would lose prototype/state if rebuilt via Object.entries, so pass them through.
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    Object.getPrototypeOf(value) === Object.prototype
+  ) {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
       out[k] = substituteEnvDeep(v, onMissing);

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,3 +25,46 @@ turndown.remove(["script", "style", "noscript", "iframe"]);
 export function htmlToMarkdown(html: string): string {
   return turndown.turndown(html);
 }
+
+/**
+ * Substitute ${VAR} references with values from process.env.
+ * Read-only — never writes resolved values back. Matches OpenClaw's pattern.
+ * Missing vars are left as literal `${VAR}` and logged (caller decides log policy).
+ */
+export function substituteEnv(
+  value: string,
+  onMissing?: (name: string) => void,
+): string {
+  return value.replace(/\$\{([A-Z_][A-Z0-9_]*)\}/g, (match, name) => {
+    const v = process.env[name];
+    if (v === undefined) {
+      onMissing?.(name);
+      return match;
+    }
+    return v;
+  });
+}
+
+/**
+ * Recursively apply substituteEnv to all string values in an object.
+ * Non-strings pass through unchanged. Arrays and nested objects are walked.
+ */
+export function substituteEnvDeep<T>(
+  value: T,
+  onMissing?: (name: string) => void,
+): T {
+  if (typeof value === "string") {
+    return substituteEnv(value, onMissing) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => substituteEnvDeep(v, onMissing)) as T;
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = substituteEnvDeep(v, onMissing);
+    }
+    return out as T;
+  }
+  return value;
+}


### PR DESCRIPTION
Closes #47.

## What

Minimal MCP integration as a kern plugin. Agents can connect to MCP servers and call their tools like native kern tools.

## Config

```json
{
  "mcpServers": {
    "github": {
      "transport": "http",
      "url": "https://api.githubcopilot.com/mcp",
      "headers": { "Authorization": "Bearer \${GITHUB_TOKEN}" }
    },
    "filesystem": {
      "transport": "stdio",
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
    }
  }
}
```

- Transports: \`http\`, \`sse\`, \`stdio\`
- Tools namespaced as \`<server>__<tool>\` — no collisions when two servers expose the same name
- \`\${VAR}\` substitution in any string field (url, headers, command, args, env). Missing vars log a warning and stay literal so the server's real auth error surfaces
- Servers connect in parallel. One failure doesn't block others or the agent
- \`/status\` reports \`mcp: <N> server(s), <M> tool(s)\`

## Scope (intentionally minimal)

- **Tools only** — no resources, prompts, or elicitation
- **No OAuth flow** — authorize tokens out-of-band and pass via headers or env
- **All-or-nothing per server** — no per-tool filtering yet

File-level filing if these are needed.

## Files

- \`src/plugins/mcp/plugin.ts\` — new plugin (~110 LoC)
- \`src/plugins/index.ts\` — register it
- \`src/config.ts\` — add \`mcpServers\` field + \`McpServerConfig\` type
- \`src/util.ts\` — \`substituteEnv\` / \`substituteEnvDeep\` helpers
- \`docs/mcp.md\` — user docs
- \`docs/config.md\` — one-line reference to the field

## Deps

- \`@ai-sdk/mcp\` — MCP client
- \`@modelcontextprotocol/sdk\` — needed by \`Experimental_StdioMCPTransport\` for stdio

## Testing

Build passes. Not tested against a live MCP server yet — will validate post-merge with a real server before shipping in a release.