### PR TITLE
Add /mcp slash command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - **MCP support** ([#47](https://github.com/oguzbilgic/kern-ai/issues/47)) — connect to Model Context Protocol servers and expose their tools to the agent. Configure under `mcpServers` in `.kern/config.json`; supports `http`, `sse`, and `stdio` transports. Tools namespaced as `<server>__<tool>`. `${VAR}` substitution in config for tokens and secrets. See [docs/mcp.md](docs/mcp.md)
+- **`/mcp` slash command** ([#253](https://github.com/oguzbilgic/kern-ai/issues/253)) — list configured MCP servers, connection state, and tool names. Failed servers show short error reason
 
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position

--- a/src/plugins/mcp/plugin.ts
+++ b/src/plugins/mcp/plugin.ts
@@ -15,14 +15,30 @@ type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
 interface ActiveServer {
   name: string;
   client: MCPClient;
-  toolCount: number;
+  tools: Array<{ name: string }>;
+}
+
+/** One server we tried and failed to connect to. */
+interface FailedServer {
+  name: string;
+  reason: string;
 }
 
 /** Connected servers for the lifetime of this plugin. */
 const active: ActiveServer[] = [];
 
+/** Failed servers, for /status and /mcp visibility. */
+const failed: FailedServer[] = [];
+
 /** Count of servers present in config — for /status visibility even when all failed. */
 let configured = 0;
+
+/** First line of an error message, truncated for compact display. */
+function shortReason(err: unknown): string {
+  const msg = errMsg(err);
+  const firstLine = msg.split("\n")[0];
+  return firstLine.length > 80 ? firstLine.slice(0, 77) + "..." : firstLine;
+}
 
 /**
  * Merged tools from all servers, namespaced as `<server>__<tool>`.
@@ -68,14 +84,14 @@ async function connectServer(name: string, cfg: McpServerConfig): Promise<void> 
   try {
     const serverTools = await client.tools();
 
-    let count = 0;
+    const tools: Array<{ name: string }> = [];
     for (const [toolName, tool] of Object.entries(serverTools)) {
       mergedTools[`${name}__${toolName}`] = tool;
-      count++;
+      tools.push({ name: toolName });
     }
 
-    active.push({ name, client, toolCount: count });
-    log("mcp", `connected "${name}" — ${count} tool(s)`);
+    active.push({ name, client, tools });
+    log("mcp", `connected "${name}" — ${tools.length} tool(s)`);
   } catch (err) {
     // Client is open (stdio may have spawned a subprocess). Close it before rethrowing.
     try {
@@ -103,6 +119,7 @@ export const mcpPlugin: KernPlugin = {
       Object.entries(servers).map(([name, cfg]) =>
         connectServer(name, cfg).catch((err) => {
           log.error("mcp", `failed to connect "${name}": ${errMsg(err)}`);
+          failed.push({ name, reason: shortReason(err) });
         }),
       ),
     );
@@ -117,6 +134,7 @@ export const mcpPlugin: KernPlugin = {
       ),
     );
     active.length = 0;
+    failed.length = 0;
     configured = 0;
     for (const k of Object.keys(mergedTools)) delete mergedTools[k];
   },
@@ -125,9 +143,41 @@ export const mcpPlugin: KernPlugin = {
     // Only stay silent when MCP isn't configured at all. If it is configured
     // but all connections failed, surface that in /status so operators see it.
     if (configured === 0) return {};
-    const total = active.reduce((sum, s) => sum + s.toolCount, 0);
+    const total = active.reduce((sum, s) => sum + s.tools.length, 0);
     return {
       mcp: `${active.length}/${configured} server(s), ${total} tool(s)`,
     };
+  },
+
+  commands: {
+    "/mcp": {
+      description: "list MCP servers and their tools",
+      handler: async () => {
+        if (configured === 0) {
+          return "No MCP servers configured. See docs/mcp.md";
+        }
+
+        const total = active.reduce((sum, s) => sum + s.tools.length, 0);
+        const lines = [`MCP (${configured} configured, ${active.length}/${configured} connected, ${total} tools)`, ""];
+
+        for (const s of active) {
+          lines.push(`  ✦ ${s.name} — ${s.tools.length} tools`);
+          if (s.tools.length > 0) {
+            const TOOL_CAP = 20;
+            const names = s.tools.map((t) => t.name);
+            const shown = names.slice(0, TOOL_CAP);
+            const extra = names.length - shown.length;
+            const tail = extra > 0 ? `, (... ${extra} more)` : "";
+            lines.push(`      ${shown.join(", ")}${tail}`);
+          }
+        }
+
+        for (const f of failed) {
+          lines.push(`  ✗ ${f.name} — ${f.reason}`);
+        }
+
+        return lines.join("\n");
+      },
+    },
   },
 };


### PR DESCRIPTION
Closes #253. Stacks on #250 (feat/mcp-plugin).

User-facing command to inspect MCP server health and tool inventory, matching the `/skills` pattern.

## Shape

```
MCP (2 configured, 1/2 connected, 14 tools)

  ✦ github — 14 tools
      search_repositories, get_issue, create_issue, list_prs,
      create_pr, get_pr, add_comment, get_file, search_code, ...

  ✗ sentry — 401 Unauthorized
```

- Tool names shown unnamespaced (short form) — `/mcp` is for humans, `server__tool` prefix is noise here. The agent still uses the namespaced form in tool calls.
- Comma-joined on one wrapped line per server
- Capped at 20 tools per server with `(... N more)` tail
- Failed servers show first line of error, truncated at 80 chars

## Data model change

`ActiveServer.toolCount: number` → `tools: Array<{name: string}>`. Memory cost is trivial (a few strings per tool), and now `onStatus` and `/mcp` share the same source of truth.

Added `FailedServer` list populated from the existing `.catch()` in `onStartup`. Cleared in `onShutdown`.

## Out of scope

- `/mcp tools` / `/mcp reload` / `/mcp call` — revisit if needed
- Tool descriptions in output — available for free via `tool.description`, but A1 deliberately skips them to stay compact
- Agent view of output — user-only, same as `/status`

Changelog: sub-bullet under existing MCP Features entry.