### PR TITLE
Skill activation takes effect mid-turn (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 - **Mid-turn injection position** ([#245](https://github.com/oguzbilgic/kern-ai/issues/245)) — injections were re-appended as the freshest message every step, causing repeated re-acknowledgment. Now spliced at chronological arrival position
+- **Skill activation takes effect immediately** ([#252](https://github.com/oguzbilgic/kern-ai/issues/252)) — `skill activate` now returns the full skill body as its tool result so instructions are available in the current turn. Previously the body only appeared in the system prompt on the following turn
 
 ## v0.29.0
 

--- a/src/plugins/skills/tool.ts
+++ b/src/plugins/skills/tool.ts
@@ -2,6 +2,7 @@ import { tool } from "ai";
 import { z } from "zod";
 import { loadSkillBody, type SkillInfo } from "./scanner.js";
 import { isActive, activate, deactivate } from "./state.js";
+import { log } from "../../log.js";
 
 /** Reference to current skill catalog — set by plugin on startup/refresh */
 let catalog: SkillInfo[] = [];
@@ -38,15 +39,15 @@ export const skillTool = tool({
         if (!name) return "Error: name is required for activate";
         const skill = catalog.find((s) => s.name === name);
         if (!skill) return `Error: skill "${name}" not found. Use list to see available skills.`;
-        // Load the body first so we can roll back the activation on failure.
-        // If we can't read the body, onBeforeContext will also fail next turn
-        // and silently drop — better to fail cleanly than leave a broken skill active.
+        // Load the body before activating the skill.
+        // If we can't read the body, return an error and leave the skill inactive
+        // rather than marking a skill active whose instructions can't be loaded.
         let body: string;
         try {
           body = await loadSkillBody(skill);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          console.warn(`[skills] failed to load body for "${name}":`, err);
+          log.warn("skills", `failed to load body for "${name}": ${msg}`);
           return `Error: failed to load instructions for skill "${name}": ${msg}. Skill not activated.`;
         }
         const wasNew = activate(name);

--- a/src/plugins/skills/tool.ts
+++ b/src/plugins/skills/tool.ts
@@ -1,6 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import type { SkillInfo } from "./scanner.js";
+import { loadSkillBody, type SkillInfo } from "./scanner.js";
 import { isActive, activate, deactivate } from "./state.js";
 
 /** Reference to current skill catalog — set by plugin on startup/refresh */
@@ -13,7 +13,7 @@ export function setCatalog(skills: SkillInfo[]) {
 export const skillTool = tool({
   description:
     "Manage agent skills. Use 'list' to see available skills. " +
-    "Use 'activate' to load a skill's full instructions into your system prompt (persistent until deactivated). " +
+    "Use 'activate' to load a skill's full instructions — they're returned in the tool result so you can act on them immediately, and also added to your system prompt from the next turn onward. " +
     "Use 'deactivate' to unload a skill and free token budget.",
   inputSchema: z.object({
     action: z.enum(["list", "activate", "deactivate"]).describe("Action to perform"),
@@ -39,7 +39,15 @@ export const skillTool = tool({
         if (!skill) return `Error: skill "${name}" not found. Use list to see available skills.`;
         const wasNew = activate(name);
         if (!wasNew) return `Skill "${name}" is already active.`;
-        return `Activated skill "${name}". Full instructions will be in your system prompt on the next turn.`;
+        // Return the full body so instructions take effect this turn, not next.
+        // The system prompt will also include it from the next turn onward.
+        try {
+          const body = await loadSkillBody(skill);
+          return `Activated: ${name}\n\n${body}`;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return `Activated skill "${name}" but failed to load instructions: ${msg}. They will appear in your system prompt on the next turn.`;
+        }
       }
 
       case "deactivate": {

--- a/src/plugins/skills/tool.ts
+++ b/src/plugins/skills/tool.ts
@@ -13,7 +13,8 @@ export function setCatalog(skills: SkillInfo[]) {
 export const skillTool = tool({
   description:
     "Manage agent skills. Use 'list' to see available skills. " +
-    "Use 'activate' to load a skill's full instructions — they're returned in the tool result so you can act on them immediately, and also added to your system prompt from the next turn onward. " +
+    "Use 'activate' to load a skill's full instructions into your system prompt (persistent until deactivated). " +
+    "The instructions are also returned in the tool result so you can act on them in the current turn. " +
     "Use 'deactivate' to unload a skill and free token budget.",
   inputSchema: z.object({
     action: z.enum(["list", "activate", "deactivate"]).describe("Action to perform"),
@@ -37,17 +38,22 @@ export const skillTool = tool({
         if (!name) return "Error: name is required for activate";
         const skill = catalog.find((s) => s.name === name);
         if (!skill) return `Error: skill "${name}" not found. Use list to see available skills.`;
+        // Load the body first so we can roll back the activation on failure.
+        // If we can't read the body, onBeforeContext will also fail next turn
+        // and silently drop — better to fail cleanly than leave a broken skill active.
+        let body: string;
+        try {
+          body = await loadSkillBody(skill);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`[skills] failed to load body for "${name}":`, err);
+          return `Error: failed to load instructions for skill "${name}": ${msg}. Skill not activated.`;
+        }
         const wasNew = activate(name);
         if (!wasNew) return `Skill "${name}" is already active.`;
         // Return the full body so instructions take effect this turn, not next.
         // The system prompt will also include it from the next turn onward.
-        try {
-          const body = await loadSkillBody(skill);
-          return `Activated: ${name}\n\n${body}`;
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          return `Activated skill "${name}" but failed to load instructions: ${msg}. They will appear in your system prompt on the next turn.`;
-        }
+        return `Activated: ${name}\n\n${body}`;
       }
 
       case "deactivate": {


### PR DESCRIPTION
Fixes #252.

## Problem

`skill({action:'activate', name})` flipped in-memory state but the skill body only appeared in the system prompt on the *next* turn, because `buildPromptContext()` runs once per turn before the streaming loop.

Agents would activate a skill, then have to either wait a turn or guess at the instructions from the description line.

## Fix

Option A from the ticket: return the full skill body directly as the tool result.

```
Activated: add-mcp-server

<full SKILL.md body>
```

The body is available to the model in the current turn via the tool result. `onBeforeContext` still runs next turn and injects the body into the system prompt as before, so behavior is unchanged from turn 2 onward.

## Behavior details

- **Load body before activating.** If `loadSkillBody` throws (missing SKILL.md, permission error), return a hard error and leave the skill inactive. Avoids leaving a broken skill flagged active whose instructions would also fail to inject next turn.
- **Already-active path unchanged.** Returns `Skill "name" is already active.` without reloading the body.
- **One-turn body duplication** (tool result this turn, system prompt next turn). Acceptable — bundled skills are 3-8KB. Tool outputs are downstream of cache breakpoints, so no prompt cache impact.
- **Tool description updated** to document both paths and preserve the "persistent until deactivated" hint.

## Out of scope

- Deactivate unchanged — no mid-turn takeeffect needed.
- Other plugins with `onBeforeContext` (notes, recall, mcp) don't have mid-turn activation semantics.

## Test

Activate `add-mcp-server` on atlas — agent should see the install steps in the same turn it activates.