### PR TITLE
feat: sub-agents plugin (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `subagents` tool for inspection: `list`, `status <id>`, `result <id>`, `cancel <id>`
   - Read-only toolset for children: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`. No `bash`, `edit`, `write`, `message`. No nested spawning
   - State persisted at `.kern/subagents/<id>/` (`record.json` metadata, `session.jsonl` transcript) — completed children survive restart, running ones are cancelled on shutdown
+  - `/subagents` slash command — operator peek at what the agent has spawned
   - Shipped as the `subagents` plugin
   - See [docs/subagents.md](docs/subagents.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## next
 
+### Features
+- **Sub-agents** ([#258](https://github.com/oguzbilgic/kern-ai/issues/258)) — delegate a bounded task to a child agent and keep working
+  - `spawn` tool returns immediately with a sub-agent id; the child runs in the background with its own LLM loop
+  - Result announces back as a new turn on channel `subagent:<id>` when the child finishes — parent can react to it like any other message
+  - `subagents` tool for inspection: `list` / `get <id>` / `cancel <id>`
+  - Read-only toolset for children (`read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`). No `bash`, `edit`, `write`, `message`. No nested spawning
+  - Records persisted at `.kern/subagents/<id>/` (prompt, session transcript, result)
+  - Shipped as a disable-able plugin
+
 ## v0.30.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
   - `spawn` tool returns immediately with a sub-agent id; the child runs in the background with its own LLM loop
   - Result announces back as a new turn on channel `subagent:<id>` when the child finishes — parent can react to it like any other message
   - `subagents` tool for inspection: `list`, `status <id>`, `result <id>`, `cancel <id>`
-  - Read-only toolset for children: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`. No `bash`, `edit`, `write`, `message`. No nested spawning
-  - State persisted at `.kern/subagents/<id>/` (`record.json` metadata, `session.jsonl` transcript) — completed children survive restart, running ones are cancelled on shutdown
+  - Read-only toolset for children: `read`, `glob`, `grep`, `webfetch`, `websearch`. No `bash`, `edit`, `write`, `message`, plugin tools, or nested spawning
+  - State persisted at `.kern/subagents/<id>/` (`record.json` metadata, `session.jsonl` transcript); running children are cancelled on shutdown
   - `/subagents` slash command — operator peek at what the agent has spawned
   - Shipped as the `subagents` plugin
   - See [docs/subagents.md](docs/subagents.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 - **Sub-agents** ([#258](https://github.com/oguzbilgic/kern-ai/issues/258)) — delegate a bounded task to a child agent and keep working
   - `spawn` tool returns immediately with a sub-agent id; the child runs in the background with its own LLM loop
   - Result announces back as a new turn on channel `subagent:<id>` when the child finishes — parent can react to it like any other message
-  - `subagents` tool for inspection: `list` / `get <id>` / `cancel <id>`
-  - Read-only toolset for children (`read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`). No `bash`, `edit`, `write`, `message`. No nested spawning
-  - Records persisted at `.kern/subagents/<id>/` (prompt, session transcript, result)
-  - Shipped as a disable-able plugin
+  - `subagents` tool for inspection: `list`, `status <id>`, `result <id>`, `cancel <id>`
+  - Read-only toolset for children: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`. No `bash`, `edit`, `write`, `message`. No nested spawning
+  - State persisted at `.kern/subagents/<id>/` (`record.json` metadata, `session.jsonl` transcript) — completed children survive restart, running ones are cancelled on shutdown
+  - Shipped as the `subagents` plugin
+  - See [docs/subagents.md](docs/subagents.md)
 
 ## v0.30.0
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ Set `model` for chat and optionally `mediaModel` for image vision. Embedding and
 - [Context & segments](docs/context.md)
 - [Prompt caching](docs/caching.md)
 - [Skills](docs/skills.md)
+- [Sub-agents](docs/subagents.md)
+- [MCP](docs/mcp.md)
 - [Media](docs/media.md)
 - [Tools](docs/tools.md)
 - [Interfaces](docs/interfaces.md)

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -44,12 +44,14 @@ subagents({ action: "cancel", id: "sa_abc123" })   // abort a running child
 
 ### Runtime model
 
-Each sub-agent runs its own `Runtime` instance in-process, with:
+Each sub-agent runs as its own in-process task, with:
 
 - A restricted tool set (read-only — see below)
 - Its own session file at `.kern/subagents/<id>/session.jsonl`
 - Its own LLM loop using the same model and provider as the parent
 - An `AbortSignal` so `cancel` can interrupt mid-turn
+
+Sub-agents do **not** share the parent's plugin context — no notes, skills, recall, MCP. They're stateless workers, not full agents.
 
 Sub-agents run concurrently with the parent and with each other. The parent's turn is *not* blocked by any of them.
 
@@ -77,9 +79,6 @@ Sub-agents run with a strict read-only toolset:
 | `grep` | Search file contents |
 | `webfetch` | Fetch a URL |
 | `websearch` | Search the web |
-| `pdf` | Extract text from PDFs |
-| `image` | Analyze images |
-| `recall` | Search long-term memory |
 
 Sub-agents **cannot**:
 
@@ -87,6 +86,7 @@ Sub-agents **cannot**:
 - Edit or write files (`edit`, `write`)
 - Send messages (`message`)
 - Manage the runtime (`kern`)
+- Call plugin tools (`recall`, `pdf`, `image`, MCP tools)
 - Spawn further sub-agents (no nested delegation in v1)
 
 This boundary is intentional. If you need a child that can mutate state, call the destructive tool in the parent based on the sub-agent's report.
@@ -97,12 +97,12 @@ Sub-agent state lives under `.kern/subagents/<id>/`:
 
 | File | Contents |
 |---|---|
-| `record.json` | Metadata: id, status, prompt, result, timings, maxSteps |
+| `record.json` | Metadata: id, status, prompt, result, timings, tool call count, token totals |
 | `session.jsonl` | Full transcript — the child's messages, tool calls, tool results |
 
 Statuses: `running`, `done`, `failed`, `cancelled`.
 
-The `subagents` plugin reloads disk state on startup, so completed children survive a restart. Running children do not — they're cancelled on shutdown.
+Sub-agent state is written to disk under `.kern/subagents/<id>/`, but completed children are not reloaded into the in-memory list on startup — the `subagents` and `/subagents` commands only show sub-agents spawned in the current process lifetime. Running children do not survive a restart either — they're cancelled on shutdown.
 
 ## Slash command
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -1,0 +1,121 @@
+# Sub-agents
+
+Sub-agents let an agent spawn focused, read-only children to work on tasks in parallel. The parent keeps working while each child runs its own LLM loop and reports back.
+
+## When to use them
+
+- **Research fan-out** — spawn 3 sub-agents to look up different topics, synthesize the results
+- **Parallel documentation lookups** — one reads the source, another searches the web, a third checks notes
+- **Candidate evaluation** — one sub-agent per option, each returns a verdict
+- **Any read-only task you can hand off** while you keep working on something else
+
+Don't use them for trivial one-off reads — just call `read`, `grep`, or `webfetch` directly. Sub-agents are for work that needs its own reasoning loop.
+
+## Tools
+
+### spawn
+
+Creates a sub-agent. Returns immediately.
+
+```
+spawn({
+  prompt: "Read /root/kern/src/runtime.ts and list every singleton/module-level variable. Return a table.",
+  maxSteps: 20
+})
+```
+
+- `prompt` — self-contained task. The child starts with no context about the parent's current work.
+- `maxSteps` — max reasoning steps (default 20, max 50)
+
+Returns a sub-agent ID like `sa_abc123`. The child runs in the background.
+
+### subagents
+
+Inspect and manage sub-agents.
+
+```
+subagents({ action: "list" })                      // all sub-agents
+subagents({ action: "status", id: "sa_abc123" })   // detailed status
+subagents({ action: "result", id: "sa_abc123" })   // final result text
+subagents({ action: "cancel", id: "sa_abc123" })   // abort a running child
+```
+
+## How it works
+
+### Runtime model
+
+Each sub-agent runs its own `Runtime` instance in-process, with:
+
+- A restricted tool set (read-only — see below)
+- Its own session file at `.kern/subagents/<id>/session.jsonl`
+- Its own LLM loop using the same model and provider as the parent
+- An `AbortSignal` so `cancel` can interrupt mid-turn
+
+Sub-agents run concurrently with the parent and with each other. The parent's turn is *not* blocked by any of them.
+
+### Announces
+
+When a sub-agent finishes, its final answer is enqueued as a new message turn on a `subagent:<id>` channel, prefixed with a header like:
+
+```
+[subagent:sa_abc123 done, 12.4s, 5 tool calls]
+<the child's final answer>
+```
+
+From the parent's perspective, this looks like any other incoming message — it will be picked up after the current turn (or mid-turn if the parent is still running). `status` is `done`, `error`, or `cancelled`.
+
+The web UI renders these with a distinct orange ⎘ avatar so you can tell them apart from user messages.
+
+### Allowed tools
+
+Sub-agents run with a strict read-only toolset:
+
+| Tool | Purpose |
+|---|---|
+| `read` | Read files, list directories |
+| `glob` | Find files by pattern |
+| `grep` | Search file contents |
+| `webfetch` | Fetch a URL |
+| `websearch` | Search the web |
+| `pdf` | Extract text from PDFs |
+| `image` | Analyze images |
+| `recall` | Search long-term memory |
+
+Sub-agents **cannot**:
+
+- Run shell commands (`bash` / `pwsh`)
+- Edit or write files (`edit`, `write`)
+- Send messages (`message`)
+- Manage the runtime (`kern`)
+- Spawn further sub-agents (no nested delegation in v1)
+
+This boundary is intentional. If you need a child that can mutate state, call the destructive tool in the parent based on the sub-agent's report.
+
+### State and persistence
+
+Sub-agent state lives under `.kern/subagents/<id>/`:
+
+| File | Contents |
+|---|---|
+| `record.json` | Metadata: id, status, prompt, result, timings, maxSteps |
+| `session.jsonl` | Full transcript — the child's messages, tool calls, tool results |
+
+Statuses: `running`, `done`, `error`, `cancelled`.
+
+The `subagents` plugin reloads disk state on startup, so completed children survive a restart. Running children do not — they're cancelled on shutdown.
+
+## Limits and costs
+
+- **Concurrency** — no hard cap. Each sub-agent is a real LLM loop, so spawning 20 at once costs 20 model calls in flight.
+- **Tokens** — each sub-agent has its own context. A sub-agent with `maxSteps: 20` can easily burn 20k–100k tokens depending on the task.
+- **Cache** — sub-agents don't share prompt cache with the parent or each other (different prompts, different sessions).
+- **Model** — inherited from the parent's config. There's no per-sub-agent model override yet.
+
+## Disabling
+
+The sub-agents plugin is on by default. There's no config flag to disable it today — if you don't want it, the model simply won't call `spawn` without a reason to.
+
+## See also
+
+- [Tools](tools.md) — full tool list including `spawn` and `subagents`
+- [Memory](memory.md) — how `recall` works (sub-agents use it too)

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -62,7 +62,7 @@ When a sub-agent finishes, its final answer is enqueued as a new message turn on
 <the child's final answer>
 ```
 
-From the parent's perspective, this looks like any other incoming message — it will be picked up after the current turn (or mid-turn if the parent is still running). `status` is `done`, `error`, or `cancelled`.
+From the parent's perspective, this looks like any other incoming message — it will be picked up after the current turn (or mid-turn if the parent is still running). `status` is `done`, `failed`, or `cancelled`.
 
 The web UI renders these with a distinct orange ⎘ avatar so you can tell them apart from user messages.
 
@@ -100,9 +100,19 @@ Sub-agent state lives under `.kern/subagents/<id>/`:
 | `record.json` | Metadata: id, status, prompt, result, timings, maxSteps |
 | `session.jsonl` | Full transcript — the child's messages, tool calls, tool results |
 
-Statuses: `running`, `done`, `error`, `cancelled`.
+Statuses: `running`, `done`, `failed`, `cancelled`.
 
 The `subagents` plugin reloads disk state on startup, so completed children survive a restart. Running children do not — they're cancelled on shutdown.
+
+## Slash command
+
+As the operator, you can peek at what your agent has spawned:
+
+```
+/subagents
+```
+
+Lists all sub-agents with status, prompt preview, duration, and tool call count. Running first, then most recently finished. Output is user-only — the agent doesn't see it. For detailed inspection the agent has the `subagents` tool (`list`, `status <id>`, `result <id>`, `cancel <id>`).
 
 ## Limits and costs
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -131,6 +131,41 @@ image({ file: "screenshot.png", prompt: "What error is shown?" })
 - `file` — path to image file, or filename from `.kern/media/`
 - `prompt` — what to analyze (default: "Describe this image.")
 
+## spawn
+
+Spawn a sub-agent to work on a focused task in parallel. Returns immediately with a sub-agent ID — the child runs in the background with its own LLM loop.
+
+```
+spawn({ prompt: "Research Node.js 22 crypto changes and summarize breaking changes", maxSteps: 30 })
+```
+
+- `prompt` — the task for the sub-agent (self-contained — child starts with no context about your current work)
+- `maxSteps` — max reasoning steps (default 20, max 50)
+
+When the child finishes, its result arrives as a new turn with a header like `[subagent:sa_abc123 done, 12.4s, 5 tool calls]` followed by the result. You can spawn multiple sub-agents in parallel and synthesize their results as they arrive.
+
+Sub-agents run with a read-only toolset: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`. They cannot run shell commands, edit files, or spawn further sub-agents.
+
+Use sub-agents for research fan-out, parallel documentation lookups, evaluating multiple candidates, or any read-only task you can delegate while you keep working. Don't use them for trivial one-off reads — just call `read` directly.
+
+Sub-agent state is persisted under `.kern/subagents/<id>/` — `session.jsonl` holds the transcript, `record.json` holds the final metadata.
+
+## subagents
+
+Inspect and manage sub-agents.
+
+```
+subagents({ action: "list" })                      // all sub-agents with status
+subagents({ action: "status", id: "sa_abc123" })   // detailed status
+subagents({ action: "result", id: "sa_abc123" })   // final result text
+subagents({ action: "cancel", id: "sa_abc123" })   // abort a running sub-agent
+```
+
+- `action` — `list`, `status`, `result`, or `cancel`
+- `id` — sub-agent ID (required for `status`, `result`, `cancel`)
+
+Statuses: `running`, `done`, `error`, `cancelled`.
+
 ## kern
 
 Manage the runtime.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -144,7 +144,7 @@ spawn({ prompt: "Research Node.js 22 crypto changes and summarize breaking chang
 
 When the child finishes, its result arrives as a new turn with a header like `[subagent:sa_abc123 done, 12.4s, 5 tool calls]` followed by the result. You can spawn multiple sub-agents in parallel and synthesize their results as they arrive.
 
-Sub-agents run with a read-only toolset: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`. They cannot run shell commands, edit files, or spawn further sub-agents.
+Sub-agents run with a read-only toolset: `read`, `glob`, `grep`, `webfetch`, `websearch`. They cannot run shell commands, edit files, call plugin tools, or spawn further sub-agents.
 
 Use sub-agents for research fan-out, parallel documentation lookups, evaluating multiple candidates, or any read-only task you can delegate while you keep working. Don't use them for trivial one-off reads — just call `read` directly.
 
@@ -164,7 +164,7 @@ subagents({ action: "cancel", id: "sa_abc123" })   // abort a running sub-agent
 - `action` — `list`, `status`, `result`, or `cancel`
 - `id` — sub-agent ID (required for `status`, `result`, `cancel`)
 
-Statuses: `running`, `done`, `error`, `cancelled`.
+Statuses: `running`, `done`, `failed`, `cancelled`.
 
 ## kern
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,6 +18,7 @@ import { MemoryDB } from "./memory.js";
 import { MessageQueue } from "./queue.js";
 import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusFn, setSegmentStatsFn, setPluginStatusFn, type InterfaceStatus } from "./tools/kern.js";
 import { plugins, type PluginContext } from "./plugins/index.js";
+import { setSubAgentAnnouncer, formatAnnounce } from "./plugins/subagents/plugin.js";
 import { log } from "./log.js";
 
 let _pluginCtx: PluginContext | null = null;
@@ -195,6 +196,19 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   // Message queue — serializes messages, same-channel injection
   const queue = new MessageQueue();
   setQueueStatusFn(() => queue.getStatus());
+
+  // Sub-agent announces: when a child finishes, enqueue its result as a new
+  // turn so the parent can react to it. Channel is "subagent" so it doesn't
+  // collide with same-channel injection for human interfaces.
+  setSubAgentAnnouncer((id, record) => {
+    const text = formatAnnounce(record);
+    queue.enqueue({
+      text,
+      userId: "subagent",
+      interface: "subagent",
+      channel: `subagent:${id}`,
+    }).catch((e) => log.error("subagent", `announce enqueue failed for ${id}: ${e.message}`));
+  });
 
   queue.setHandler(async (msg, getPendingMessages) => {
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -5,6 +5,7 @@ import { recallPlugin } from "./recall/plugin.js";
 import { mediaPlugin } from "./media/plugin.js";
 import { skillsPlugin } from "./skills/plugin.js";
 import { mcpPlugin } from "./mcp/plugin.js";
+import { subagentsPlugin } from "./subagents/plugin.js";
 import { log } from "../log.js";
 
 export type { KernPlugin, PluginContext, RouteHandler, ContextInjection, BeforeContextInfo } from "./types.js";
@@ -20,6 +21,7 @@ const availablePlugins: KernPlugin[] = [
   dashboardPlugin,
   skillsPlugin,
   mcpPlugin,
+  subagentsPlugin,
 ];
 
 /** Active plugin instances after loading */

--- a/src/plugins/subagents/plugin.ts
+++ b/src/plugins/subagents/plugin.ts
@@ -1,0 +1,89 @@
+import type { KernPlugin, PluginContext } from "../types.js";
+import { SubAgentRegistry, type SubAgentRecord, type AnnounceFn } from "./registry.js";
+import { spawnTool, subagentsTool, setRegistry } from "./tools.js";
+import { log } from "../../log.js";
+
+/**
+ * Sub-agents plugin — spawn read-only worker agents in parallel.
+ *
+ * Parent agents call the spawn tool to delegate focused tasks. Children run
+ * in-process with a restricted toolset (read, glob, grep, webfetch, websearch)
+ * and no access to plugins. When a child finishes, its result is announced
+ * back to the parent as a new turn via an AnnounceFn that app.ts registers
+ * (connecting the completion event to the message queue).
+ *
+ * See src/plugins/subagents/registry.ts for the registry/worker split.
+ */
+
+/** The one live registry for this plugin instance. */
+let registry: SubAgentRegistry | null = null;
+
+/**
+ * Called by app.ts to wire child completion back into the message queue.
+ * Must be called before any sub-agents are spawned.
+ */
+export function setSubAgentAnnouncer(fn: AnnounceFn): void {
+  if (!registry) {
+    log.warn("subagent", "setSubAgentAnnouncer called before plugin loaded — ignored");
+    return;
+  }
+  registry.setAnnouncer(fn);
+}
+
+/** Format a child's completion as an announce message for the parent's queue. */
+export function formatAnnounce(record: SubAgentRecord): string {
+  const dur = record.finishedAt && record.startedAt
+    ? `${Math.round((+new Date(record.finishedAt) - +new Date(record.startedAt)) / 1000)}s`
+    : "?";
+  const header = `[subagent:${record.id} ${record.status}, ${dur}, ${record.toolCalls} tool calls]`;
+
+  if (record.status === "done") {
+    return `${header}\n${record.result || "(no result)"}`;
+  }
+  if (record.status === "failed") {
+    return `${header}\n${record.error || "unknown error"}`;
+  }
+  if (record.status === "cancelled") {
+    return header;
+  }
+  return header;
+}
+
+export const subagentsPlugin: KernPlugin = {
+  name: "subagents",
+
+  tools: {
+    spawn: spawnTool,
+    subagents: subagentsTool,
+  },
+
+  toolDescriptions: {
+    spawn:
+      "Spawn a sub-agent to work on a focused task in parallel (returns immediately; result arrives as a new turn when the child finishes).",
+    subagents:
+      "List, inspect, or cancel sub-agents you've spawned.",
+  },
+
+  onStartup: async (ctx: PluginContext) => {
+    registry = new SubAgentRegistry(ctx.agentDir, ctx.config);
+    setRegistry(registry);
+  },
+
+  onShutdown: async () => {
+    if (registry) {
+      const cancelled = registry.cancelAll();
+      if (cancelled > 0) log("subagent", `cancelled ${cancelled} running on shutdown`);
+    }
+    registry = null;
+  },
+
+  onStatus: () => {
+    if (!registry) return {};
+    return {
+      subagents: {
+        running: registry.countRunning(),
+        total: registry.list().length,
+      },
+    };
+  },
+};

--- a/src/plugins/subagents/plugin.ts
+++ b/src/plugins/subagents/plugin.ts
@@ -86,4 +86,52 @@ export const subagentsPlugin: KernPlugin = {
       },
     };
   },
+
+  commands: {
+    "/subagents": {
+      description: "list sub-agents",
+      handler: async () => {
+        if (!registry) return "Sub-agents plugin not loaded.";
+        const records = registry.list();
+        if (records.length === 0) {
+          return "No sub-agents. The agent can use the spawn tool to delegate a task.";
+        }
+
+        // running first, then by finishedAt desc (most recent on top)
+        const sorted = [...records].sort((a, b) => {
+          if (a.status === "running" && b.status !== "running") return -1;
+          if (b.status === "running" && a.status !== "running") return 1;
+          const aFin = a.finishedAt || "";
+          const bFin = b.finishedAt || "";
+          return bFin.localeCompare(aFin);
+        });
+
+        const running = records.filter((r) => r.status === "running").length;
+        const lines = [`Sub-agents (${running} running, ${records.length} total)`, ""];
+
+        for (const r of sorted) {
+          const icon =
+            r.status === "running" ? "⟳" :
+            r.status === "done"    ? "✓" :
+            r.status === "failed"  ? "✗" :
+            /* cancelled */          "⊘";
+
+          const prompt = r.prompt.length > 40
+            ? r.prompt.slice(0, 40) + "..."
+            : r.prompt;
+
+          const end = r.finishedAt ? new Date(r.finishedAt) : new Date();
+          const dur = `${Math.round((+end - +new Date(r.startedAt)) / 1000)}s`;
+          const calls = `${r.toolCalls} tool call${r.toolCalls === 1 ? "" : "s"}`;
+
+          const parts = [`"${prompt}"`, dur, calls];
+          if (r.status === "failed" || r.status === "cancelled") parts.push(r.status);
+
+          lines.push(`  ${icon} ${r.id} — ${parts.join(" · ")}`);
+        }
+
+        return lines.join("\n");
+      },
+    },
+  },
 };

--- a/src/plugins/subagents/registry.ts
+++ b/src/plugins/subagents/registry.ts
@@ -44,7 +44,7 @@ export class SubAgentRegistry {
   }
 
   spawn(prompt: string, maxSteps = 20): SubAgentHandle {
-    const id = randomUUID().slice(0, 8);
+    const id = "sa_" + randomUUID().slice(0, 8);
     const record: SubAgentRecord = {
       id,
       prompt,

--- a/src/plugins/subagents/registry.ts
+++ b/src/plugins/subagents/registry.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from "crypto";
+import { log } from "../../log.js";
+import { runSubAgent, writeRecord, loadRecord } from "./worker.js";
+import type { KernConfig } from "../../config.js";
+
+export type SubAgentStatus = "running" | "done" | "failed" | "cancelled";
+
+export interface SubAgentRecord {
+  id: string;
+  prompt: string;
+  status: SubAgentStatus;
+  startedAt: string;
+  finishedAt?: string;
+  result?: string;
+  error?: string;
+  toolCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface SubAgentHandle {
+  id: string;
+  record: SubAgentRecord;
+  abort: () => void;
+  promise: Promise<string>;
+}
+
+/** Announcer — fires when any sub-agent finishes. Registered by app.ts. */
+export type AnnounceFn = (id: string, record: SubAgentRecord) => void;
+
+export class SubAgentRegistry {
+  private handles = new Map<string, SubAgentHandle>();
+  private announceFn: AnnounceFn | null = null;
+  private agentDir: string;
+  private config: KernConfig;
+
+  constructor(agentDir: string, config: KernConfig) {
+    this.agentDir = agentDir;
+    this.config = config;
+  }
+
+  setAnnouncer(fn: AnnounceFn) {
+    this.announceFn = fn;
+  }
+
+  spawn(prompt: string, maxSteps = 20): SubAgentHandle {
+    const id = randomUUID().slice(0, 8);
+    const record: SubAgentRecord = {
+      id,
+      prompt,
+      status: "running",
+      startedAt: new Date().toISOString(),
+      toolCalls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+
+    const controller = new AbortController();
+
+    const promise = runSubAgent({
+      id,
+      prompt,
+      config: this.config,
+      agentDir: this.agentDir,
+      maxSteps: Math.min(maxSteps, 50),
+      signal: controller.signal,
+      onToolCall: () => {
+        record.toolCalls++;
+      },
+      onUsage: (input, output) => {
+        record.inputTokens = input;
+        record.outputTokens = output;
+      },
+    }).then(
+      (result) => {
+        record.status = "done";
+        record.result = result;
+        record.finishedAt = new Date().toISOString();
+        this.finalize(record);
+        return result;
+      },
+      (err: Error) => {
+        record.status = controller.signal.aborted ? "cancelled" : "failed";
+        record.error = err.message;
+        record.finishedAt = new Date().toISOString();
+        this.finalize(record);
+        throw err;
+      },
+    );
+
+    const handle: SubAgentHandle = {
+      id,
+      record,
+      abort: () => controller.abort(),
+      promise,
+    };
+
+    this.handles.set(id, handle);
+    // Swallow unhandled rejections — callers that care await `promise`.
+    promise.catch(() => {});
+
+    const preview = prompt.slice(0, 60).replace(/\n/g, " ");
+    log("subagent", `spawned ${id}: "${preview}${prompt.length > 60 ? "..." : ""}"`);
+
+    return handle;
+  }
+
+  get(id: string): SubAgentHandle | undefined {
+    return this.handles.get(id);
+  }
+
+  list(): SubAgentRecord[] {
+    return Array.from(this.handles.values()).map((h) => h.record);
+  }
+
+  cancel(id: string): boolean {
+    const handle = this.handles.get(id);
+    if (!handle) return false;
+    if (handle.record.status !== "running") return false;
+    handle.abort();
+    return true;
+  }
+
+  countRunning(): number {
+    let n = 0;
+    for (const h of this.handles.values()) {
+      if (h.record.status === "running") n++;
+    }
+    return n;
+  }
+
+  /** Cancel all running children — used on shutdown. */
+  cancelAll(): number {
+    let n = 0;
+    for (const h of this.handles.values()) {
+      if (h.record.status === "running") {
+        h.abort();
+        n++;
+      }
+    }
+    return n;
+  }
+
+  /**
+   * Load a record from disk. Used after process restart to fetch results of
+   * children that completed before this registry was populated.
+   */
+  async loadFromDisk(id: string): Promise<SubAgentRecord | null> {
+    return loadRecord(this.agentDir, id);
+  }
+
+  private finalize(record: SubAgentRecord) {
+    writeRecord(this.agentDir, record).catch((e) =>
+      log.warn("subagent", `record persist failed for ${record.id}: ${e.message}`),
+    );
+    if (this.announceFn) {
+      try {
+        this.announceFn(record.id, record);
+      } catch (e: any) {
+        log.warn("subagent", `announce failed for ${record.id}: ${e.message}`);
+      }
+    }
+  }
+}

--- a/src/plugins/subagents/tools.ts
+++ b/src/plugins/subagents/tools.ts
@@ -1,0 +1,131 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { SubAgentRegistry } from "./registry.js";
+
+let _registry: SubAgentRegistry | null = null;
+
+export function setRegistry(registry: SubAgentRegistry) {
+  _registry = registry;
+}
+
+export const spawnTool = tool({
+  description: [
+    "Spawn a sub-agent to work on a focused task in parallel.",
+    "",
+    "Sub-agents run with their own LLM loop and a read-only toolset",
+    "(read, glob, grep, webfetch, websearch). They cannot run shell commands,",
+    "edit files, or spawn further sub-agents.",
+    "",
+    "This call returns IMMEDIATELY with a sub-agent ID. The child runs in the",
+    "background. When it finishes, its result arrives as a new turn prefixed",
+    "with [subagent:<id> done]. You can spawn multiple children in parallel",
+    "and synthesize their results as they arrive.",
+    "",
+    "Use spawn for: research fan-out, parallel documentation lookups, evaluating",
+    "multiple candidates, any read-only task you can delegate while you keep",
+    "working on something else.",
+    "",
+    "Do NOT use spawn for trivial one-off reads — just use the read tool directly.",
+    "Sub-agents are for tasks that need their own reasoning loop.",
+  ].join("\n"),
+  inputSchema: z.object({
+    prompt: z.string().describe(
+      "The task for the sub-agent. Give a clear, self-contained instruction — " +
+      "the sub-agent starts with no context about your current work."
+    ),
+    maxSteps: z.number().optional().describe(
+      "Maximum reasoning steps for this child (default: 20, max: 50)."
+    ),
+  }),
+  execute: async ({ prompt, maxSteps }) => {
+    if (!_registry) return "Error: sub-agents not available.";
+
+    try {
+      const handle = _registry.spawn(prompt, maxSteps ?? 20);
+      return [
+        `Sub-agent spawned: ${handle.id}`,
+        `Status: running`,
+        ``,
+        `The child is working in the background. Its result will arrive as`,
+        `a new turn when it finishes. Keep working; you can spawn more`,
+        `sub-agents in parallel. Use the subagents tool to check status or`,
+        `cancel if needed.`,
+      ].join("\n");
+    } catch (e: any) {
+      return `Error spawning sub-agent: ${e.message}`;
+    }
+  },
+});
+
+export const subagentsTool = tool({
+  description: [
+    "Inspect and manage sub-agents you've spawned.",
+    "",
+    "Actions:",
+    "  list    — show all sub-agents with status",
+    "  status  — detailed status of a specific sub-agent (requires id)",
+    "  cancel  — abort a running sub-agent (requires id)",
+    "  result  — fetch the final result of a completed sub-agent (requires id)",
+  ].join("\n"),
+  inputSchema: z.object({
+    action: z
+      .enum(["list", "status", "cancel", "result"])
+      .describe("What to do"),
+    id: z
+      .string()
+      .optional()
+      .describe("Sub-agent ID (required for status, cancel, result)"),
+  }),
+  execute: async ({ action, id }) => {
+    if (!_registry) return "Error: sub-agents not available.";
+
+    if (action === "list") {
+      const all = _registry.list();
+      if (all.length === 0) return "No sub-agents.";
+      return all
+        .map((r) => {
+          const dur = r.finishedAt
+            ? `${Math.round((+new Date(r.finishedAt) - +new Date(r.startedAt)) / 1000)}s`
+            : `${Math.round((Date.now() - +new Date(r.startedAt)) / 1000)}s`;
+          const preview = r.prompt.slice(0, 60).replace(/\n/g, " ");
+          return `${r.id}  ${r.status.padEnd(10)}  ${dur.padStart(6)}  ${preview}${r.prompt.length > 60 ? "..." : ""}`;
+        })
+        .join("\n");
+    }
+
+    if (!id) return "Error: id required for this action.";
+
+    if (action === "cancel") {
+      const ok = _registry.cancel(id);
+      if (!ok) return `Cannot cancel ${id} — not found or not running.`;
+      return `Cancelled ${id}.`;
+    }
+
+    // status + result both need the record
+    let record = _registry.get(id)?.record;
+    if (!record) record = (await _registry.loadFromDisk(id)) ?? undefined;
+    if (!record) return `Sub-agent ${id} not found.`;
+
+    if (action === "result") {
+      if (record.status === "running") return `Sub-agent ${id} is still running.`;
+      if (record.status === "failed") return `Sub-agent ${id} failed: ${record.error || "unknown error"}`;
+      if (record.status === "cancelled") return `Sub-agent ${id} was cancelled.`;
+      return record.result || "(no result)";
+    }
+
+    // status
+    const lines = [
+      `id:         ${record.id}`,
+      `status:     ${record.status}`,
+      `started:    ${record.startedAt}`,
+    ];
+    if (record.finishedAt) lines.push(`finished:   ${record.finishedAt}`);
+    lines.push(`tool calls: ${record.toolCalls}`);
+    if (record.inputTokens || record.outputTokens) {
+      lines.push(`tokens:     ${record.inputTokens} in / ${record.outputTokens} out`);
+    }
+    lines.push(``, `prompt:`, record.prompt);
+    if (record.error) lines.push(``, `error:`, record.error);
+    return lines.join("\n");
+  },
+});

--- a/src/plugins/subagents/worker.ts
+++ b/src/plugins/subagents/worker.ts
@@ -1,0 +1,152 @@
+import { streamText, stepCountIs, type ModelMessage } from "ai";
+import { mkdir, writeFile, readFile } from "fs/promises";
+import { join } from "path";
+import { existsSync } from "fs";
+import { log } from "../../log.js";
+import { createModel } from "../../model.js";
+import { allTools, type ToolName } from "../../tools/index.js";
+import type { KernConfig } from "../../config.js";
+
+/**
+ * Sub-agent worker — runs the LLM loop for a single child.
+ *
+ * Design choices (v1):
+ * - In-process: shares prompt cache, MCP connections, no IPC overhead.
+ * - Read-only tools only: no bash/edit/write — crash surface is tiny.
+ * - No plugin hooks: children don't get notes, skills, recall, or MCP.
+ *   They're stateless workers, not full agents.
+ * - No nested spawning: children can't spawn grandchildren (enforced by
+ *   tool allowlist — spawn is not in SUBAGENT_TOOLS).
+ * - AbortSignal for cancellation: no process kill needed.
+ *
+ * On-disk layout for each child:
+ *   .kern/subagents/<id>/
+ *     prompt.md          — original task
+ *     session.jsonl      — running transcript (appended per step)
+ *     record.json        — final metadata (written on finish)
+ */
+
+/** Tools sub-agents are allowed to use in v1. Read-only + research. */
+const SUBAGENT_TOOLS: ToolName[] = [
+  "read",
+  "glob",
+  "grep",
+  "webfetch",
+  "websearch",
+];
+
+const SUBAGENT_SYSTEM_PROMPT = [
+  "You are a sub-agent spawned by a parent kern agent to complete a focused task.",
+  "",
+  "You have access to read-only tools: read, glob, grep, webfetch, websearch.",
+  "You cannot execute shell commands, edit files, or spawn further sub-agents.",
+  "",
+  "Complete the task given to you, then reply with a concise result.",
+  "The parent will see your final text response. Be direct and factual.",
+  "If the task is ambiguous or impossible, say so clearly.",
+].join("\n");
+
+export interface RunOptions {
+  id: string;
+  prompt: string;
+  config: KernConfig;
+  agentDir: string;
+  maxSteps: number;
+  signal: AbortSignal;
+  onToolCall?: () => void;
+  onUsage?: (inputTokens: number, outputTokens: number) => void;
+}
+
+/**
+ * Run a sub-agent to completion. Throws on cancellation or error.
+ * Returns the child's final text response on success.
+ */
+export async function runSubAgent(opts: RunOptions): Promise<string> {
+  const { id, prompt, config, agentDir, maxSteps, signal, onToolCall, onUsage } = opts;
+
+  const subDir = join(agentDir, ".kern", "subagents", id);
+  await mkdir(subDir, { recursive: true });
+  await writeFile(join(subDir, "prompt.md"), prompt, "utf-8");
+
+  const tools: Record<string, any> = {};
+  for (const name of SUBAGENT_TOOLS) {
+    if (name in allTools) {
+      tools[name] = allTools[name as ToolName];
+    }
+  }
+
+  const messages: ModelMessage[] = [{ role: "user", content: prompt }];
+  const model = createModel(config);
+  let fullText = "";
+  const persistedMessages: ModelMessage[] = [...messages];
+
+  const result = streamText({
+    model,
+    system: SUBAGENT_SYSTEM_PROMPT,
+    messages,
+    tools,
+    abortSignal: signal,
+    stopWhen: stepCountIs(maxSteps),
+    onStepFinish: async (step) => {
+      const allMsgs = step.response.messages as ModelMessage[];
+      // response.messages is cumulative across steps; skip what we already
+      // wrote. Offset by 1 because persistedMessages starts with the user prompt,
+      // which isn't in response.messages.
+      const already = persistedMessages.length - 1;
+      const newMsgs = allMsgs.slice(already);
+      if (newMsgs.length > 0) {
+        persistedMessages.push(...newMsgs);
+        await writeSessionFile(subDir, persistedMessages).catch((e) =>
+          log.warn("subagent", `session write failed for ${id}: ${e.message}`),
+        );
+      }
+    },
+  });
+
+  for await (const part of result.fullStream) {
+    if (signal.aborted) break;
+    if (part.type === "text-delta") {
+      const text = ("delta" in part ? part.delta : (part as any).text) || "";
+      fullText += text;
+    } else if (part.type === "tool-call") {
+      onToolCall?.();
+    }
+  }
+
+  try {
+    const usage = await result.totalUsage;
+    onUsage?.(usage.inputTokens || 0, usage.outputTokens || 0);
+  } catch {
+    // usage unavailable — non-critical
+  }
+
+  if (signal.aborted) {
+    throw new Error("Cancelled by parent");
+  }
+
+  log("subagent", `${id} finished: ${fullText.length} chars`);
+  return fullText || "(no text response)";
+}
+
+async function writeSessionFile(subDir: string, messages: ModelMessage[]): Promise<void> {
+  const path = join(subDir, "session.jsonl");
+  const lines = messages.map((m) => JSON.stringify(m));
+  await writeFile(path, lines.join("\n") + "\n", "utf-8");
+}
+
+export async function loadRecord(agentDir: string, id: string): Promise<any | null> {
+  const path = join(agentDir, ".kern", "subagents", id, "record.json");
+  if (!existsSync(path)) return null;
+  try {
+    const content = await readFile(path, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+export async function writeRecord(agentDir: string, record: any): Promise<void> {
+  const subDir = join(agentDir, ".kern", "subagents", record.id);
+  await mkdir(subDir, { recursive: true });
+  await writeFile(join(subDir, "record.json"), JSON.stringify(record, null, 2), "utf-8");
+}

--- a/src/plugins/subagents/worker.ts
+++ b/src/plugins/subagents/worker.ts
@@ -22,7 +22,7 @@ import type { KernConfig } from "../../config.js";
  * On-disk layout for each child:
  *   .kern/subagents/<id>/
  *     prompt.md          — original task
- *     session.jsonl      — running transcript (appended per step)
+ *     session.jsonl      — running transcript (rewritten per step)
  *     record.json        — final metadata (written on finish)
  */
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -113,6 +113,15 @@ kern also ships with bundled skills that appear in the catalog automatically. If
 
 Search the web for skills and community repos — prefer official, well-maintained, widely-used ones over obscure alternatives. Install with `npx skills` with `-a universal -y`.
 
+### Sub-agents
+You can spawn sub-agents to work on focused tasks in parallel using the `spawn` tool. Each sub-agent runs its own LLM loop with a read-only toolset (`read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`).
+
+- `spawn({ prompt })` returns immediately with a sub-agent ID. The child runs in the background.
+- When the child finishes, its result arrives as a new turn prefixed with `[subagent:<id> done]`.
+- Use `subagents({ action: "list" })` to inspect running children, `cancel` to abort one.
+
+Good uses: research fan-out across multiple sources, parallel doc lookups, evaluating candidates. Don't spawn for trivial one-off reads — just call the tool directly. Sub-agents can't run shell, edit files, or spawn further sub-agents; if the work needs those, do it yourself based on what the child reports.
+
 ### Heartbeat
 The runtime sends you a `[heartbeat]` message periodically (default every 60 minutes, configurable via `heartbeatInterval` in `.kern/config.json`). When you receive one:
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -114,7 +114,7 @@ kern also ships with bundled skills that appear in the catalog automatically. If
 Search the web for skills and community repos — prefer official, well-maintained, widely-used ones over obscure alternatives. Install with `npx skills` with `-a universal -y`.
 
 ### Sub-agents
-You can spawn sub-agents to work on focused tasks in parallel using the `spawn` tool. Each sub-agent runs its own LLM loop with a read-only toolset (`read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`, `recall`).
+You can spawn sub-agents to work on focused tasks in parallel using the `spawn` tool. Each sub-agent runs its own LLM loop with a read-only toolset (`read`, `glob`, `grep`, `webfetch`, `websearch`).
 
 - `spawn({ prompt })` returns immediately with a sub-agent ID. The child runs in the background.
 - When the child finishes, its result arrives as a new turn prefixed with `[subagent:<id> done]`.

--- a/web/components/MessageContent.tsx
+++ b/web/components/MessageContent.tsx
@@ -28,9 +28,11 @@ export function MediaAttachments({ media, baseUrl, token }: { media: MediaItem[]
   );
 }
 
-// Renders the text body of a message — markdown for assistant, plain for others
+// Renders the text body of a message — markdown for assistant and incoming
+// (agent-authored content from Telegram/Slack/Matrix/subagent), plain for
+// user-typed messages where pre-wrap preserves whatever they wrote.
 export function MessageBody({ msg }: { msg: ChatMessage }) {
-  if (msg.role === "assistant") {
+  if (msg.role === "assistant" || msg.role === "incoming") {
     return (
       <div className="markdown-body"
         dangerouslySetInnerHTML={{ __html: renderMarkdown(msg.text) }} />

--- a/web/components/ToolCall.tsx
+++ b/web/components/ToolCall.tsx
@@ -57,6 +57,8 @@ const TOOL_COLORS: Record<string, string> = {
   skill: "#e6edf3",
   recall: "#e6edf3",
   message: "#56d364",
+  spawn: "#f0883e",
+  subagents: "#f0883e",
 };
 
 const EXT_TO_LANG: Record<string, string> = {
@@ -143,6 +145,12 @@ function toolSummary(msg: ChatMessage): string {
     case "kern": return `${input.action || ""}`;
     case "skill": return `${input.action || ""}${input.name ? ` ${input.name}` : ""}`;
     case "recall": return `${input.query || ""}`;
+    case "spawn": {
+      const prompt = (input.prompt as string) || "";
+      const first = prompt.split("\n")[0];
+      return first.length > 80 ? first.slice(0, 80) + "…" : first;
+    }
+    case "subagents": return `${input.action || ""}${input.id ? ` ${input.id}` : ""}`;
     default: return name;
   }
 }
@@ -300,6 +308,84 @@ function WriteOutput({ path, input, output }: { path: string; input: Record<stri
   return <PlainOutput output={output} />;
 }
 
+function SpawnOutput({ output }: { output: string }) {
+  // First line typically: "Sub-agent spawned: sa_xxx" or "Error spawning..."
+  const lines = output.split("\n");
+  const first = lines[0] || "";
+  const rest = lines.slice(1).join("\n").trim();
+  const idMatch = first.match(/^(Sub-agent spawned):\s*(\S+)/);
+  const errMatch = first.match(/^Error/i);
+  return (
+    <div className="tool-output-inner text-[11px] leading-[1.5]">
+      {idMatch ? (
+        <div className="mb-1">
+          <span className="text-[var(--text-muted)]">{idMatch[1]}: </span>
+          <code className="text-[#f0883e]">{idMatch[2]}</code>
+        </div>
+      ) : (
+        <div className={`mb-1 ${errMatch ? "text-[#f97583]" : "text-[var(--text-muted)]"}`}>{first}</div>
+      )}
+      {rest && (
+        <div className="text-[var(--text-dim)] whitespace-pre-wrap">{rest}</div>
+      )}
+    </div>
+  );
+}
+
+function SubagentsListOutput({ output }: { output: string }) {
+  // Registry.list() renders: "id  status  dur  prompt..."
+  // Each line is whitespace-separated; render as a clean grid.
+  if (output === "No sub-agents.") {
+    return (
+      <div className="tool-output-inner text-[11px] text-[var(--text-muted)] italic">
+        No sub-agents.
+      </div>
+    );
+  }
+  const lines = output.split("\n").filter(Boolean);
+  const rows = lines.map((line) => {
+    // Split on 2+ spaces to preserve prompt content
+    const parts = line.split(/\s{2,}/);
+    if (parts.length < 4) return null;
+    const [id, status, dur, ...promptParts] = parts;
+    return { id, status: status.trim(), dur: dur.trim(), prompt: promptParts.join("  ") };
+  });
+
+  const statusColor = (s: string): string => {
+    if (s === "running") return "#f0883e";
+    if (s === "done") return "#56d364";
+    if (s === "cancelled" || s === "error") return "#f97583";
+    return "var(--text-dim)";
+  };
+
+  return (
+    <div className="tool-output-inner text-[11px] leading-[1.5]">
+      <table className="w-full border-collapse">
+        <tbody>
+          {rows.map((r, i) =>
+            r ? (
+              <tr key={i} className="align-top">
+                <td className="pr-3 py-0.5 whitespace-nowrap">
+                  <code className="text-[#f0883e]">{r.id}</code>
+                </td>
+                <td className="pr-3 py-0.5 whitespace-nowrap">
+                  <span style={{ color: statusColor(r.status) }}>{r.status}</span>
+                </td>
+                <td className="pr-3 py-0.5 whitespace-nowrap text-[var(--text-muted)]">{r.dur}</td>
+                <td className="py-0.5 text-[var(--text-dim)] break-words">{r.prompt}</td>
+              </tr>
+            ) : (
+              <tr key={i}>
+                <td colSpan={4} className="text-[var(--text-dim)]">{lines[i]}</td>
+              </tr>
+            )
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function MarkdownOutput({ output }: { output: string }) {
   return (
     <div className="markdown-body text-[12px]"
@@ -326,6 +412,11 @@ function renderToolOutput(msg: ChatMessage) {
     case "webfetch":
     case "websearch":
       return <MarkdownOutput output={output} />;
+    case "spawn":
+      return <SpawnOutput output={output} />;
+    case "subagents":
+      if ((input.action as string) === "list") return <SubagentsListOutput output={output} />;
+      return <PlainOutput output={output} />;
     default:
       return <PlainOutput output={output} />;
   }

--- a/web/components/ToolCall.tsx
+++ b/web/components/ToolCall.tsx
@@ -354,7 +354,7 @@ function SubagentsListOutput({ output }: { output: string }) {
   const statusColor = (s: string): string => {
     if (s === "running") return "#f0883e";
     if (s === "done") return "#56d364";
-    if (s === "cancelled" || s === "error") return "#f97583";
+    if (s === "cancelled" || s === "failed") return "#f97583";
     return "var(--text-dim)";
   };
 

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -265,6 +265,8 @@ const CHANNEL_INFO: Record<string, { icon: string; color: string; bg: string }> 
   telegram: { icon: "✈", color: "#58a6ff", bg: "#1c2d3d" },
   slack:    { icon: "#",  color: "#e6b450", bg: "#2d2a1c" },
   hub:      { icon: "◆",  color: "#a78bfa", bg: "#2a1c3d" },
+  matrix:   { icon: "▲",  color: "#7ee787", bg: "#1c3d26" },
+  subagent: { icon: "⎘",  color: "#f2a365", bg: "#3d2a1c" },
 };
 
 export function getChannelInfo(channel?: string) {


### PR DESCRIPTION
Closes #258

## What

A `spawn` tool that delegates a bounded task to a child agent and lets the parent keep working. The child runs its own LLM loop in the background; when it finishes, its result arrives in the parent's queue as a new turn on channel `subagent:<id>`.

```
spawn({ prompt: "..." }) → { id: "sa_a1b2c3d4", status: "running" }
                              │
                              ▼ (child runs async)
                   [subagent:sa_a1b2c3d4 done, 5.2s, 3 tool calls]
                   <result text>
```

Plus a `subagents` tool with four actions: `list`, `status <id>`, `result <id>`, `cancel <id>`.

And a `/subagents` slash command — operator-only peek at what the agent has spawned, with status icons, durations, and prompt previews.

## Why a plugin, not a core tool

Sub-agents fit the plugin shape cleanly — their own lifecycle, their own `/status` reporter, their own slash command, disable-able. Announcer wired via `setSubAgentAnnouncer` mirroring how Matrix/Telegram/Slack hook into the message queue.

## Scope (v1)

- **In-process, same workspace** — children share parent caches and cwd
- **Read-only toolset** — `read`, `glob`, `grep`, `webfetch`, `websearch`
- **No** `bash`, `edit`, `write`, `message`, plugin tools (notes/skills/recall/MCP/pdf/image), or nested spawning
- **Non-blocking announce** — parent gets an id, keeps going, result arrives as a new turn on channel `subagent:<id>`
- **AbortSignal cancellation** — clean unwind, no process kill
- **Disk-backed records** at `.kern/subagents/<id>/{prompt.md, session.jsonl, record.json}` — persisted but not reloaded into the in-memory list on startup

## Not in v1 (deferred)

- Body split / separate workspace
- Concurrency limits
- Reloading completed records into the list on startup
- Giving children access to plugin tools (recall, pdf, image, MCP)
- Web UI visibility beyond tool calls and `/status` count
- Nested sub-agents

## Tested

Ran three spikes against atlas's config directly invoking the registry:

- **Simple prompt** → spawns, runs, resolves with text result. ~930/28 tokens, 5s.
- **Tool use** — \"Read /root/kern/package.json and tell me the version\" → 1 tool call, returns version string, full transcript persisted to session.jsonl in AI SDK \`ModelMessage\` shape.
- **Cancel** — spawn a long task, cancel mid-flight → \`Cancelled by parent\`, status flips to \`cancelled\`.

Plugin loads cleanly on atlas startup (\`[plugin] loaded: subagents\`) and surfaces in \`/status\`. Web UI renders \`spawn\`/\`subagents\` tool calls with orange accent and renders announce messages on a distinct \`subagent\` channel.

## Files

```
src/plugins/subagents/
  plugin.ts     ~100 lines   KernPlugin def, announce setter/formatter, /subagents command
  registry.ts   ~165 lines   SubAgentRegistry (spawn/get/list/cancel)
  worker.ts     ~150 lines   runSubAgent() — LLM loop, tool whitelist, persistence
  tools.ts      ~130 lines   spawn + subagents tools
```

+ wire-up in `src/plugins/index.ts`, `src/app.ts`, web UI additions for `spawn`/`subagents` tool call rendering and the `subagent` channel badge.