### PR TITLE
refactor: move pdf and image to core tools (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@
   - `spawn` tool returns immediately with a sub-agent id; the child runs in the background with its own LLM loop
   - Result announces back as a new turn on channel `subagent:<id>` when the child finishes — parent can react to it like any other message
   - `subagents` tool for inspection: `list`, `status <id>`, `result <id>`, `cancel <id>`
-  - Read-only toolset for children: `read`, `glob`, `grep`, `webfetch`, `websearch`. No `bash`, `edit`, `write`, `message`, plugin tools, or nested spawning
+  - Read-only toolset for children: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`. No `bash`, `edit`, `write`, `message`, plugin tools, or nested spawning
   - State persisted at `.kern/subagents/<id>/` (`record.json` metadata, `session.jsonl` transcript); running children are cancelled on shutdown
   - `/subagents` slash command — operator peek at what the agent has spawned
   - Shipped as the `subagents` plugin
   - See [docs/subagents.md](docs/subagents.md)
+
+### Improvements
+- **`pdf` and `image` are now core tools** ([#262](https://github.com/oguzbilgic/kern-ai/issues/262)) — moved out of the media plugin. Same interface, no behavior change for existing agents. Sub-agents now have access to them, and they sit in the `read` tool scope alongside `read`/`glob`/`grep`
 
 ## v0.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
   - See [docs/subagents.md](docs/subagents.md)
 
 ### Improvements
-- **`pdf` and `image` are now core tools** ([#262](https://github.com/oguzbilgic/kern-ai/issues/262)) — moved out of the media plugin. Same interface, no behavior change for existing agents. Sub-agents now have access to them, and they sit in the `read` tool scope alongside `read`/`glob`/`grep`
+- **`pdf` and `image` are now core tools** ([#262](https://github.com/oguzbilgic/kern-ai/issues/262)) — moved out of the media plugin
 
 ## v0.30.0
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -87,26 +87,11 @@ Only images are pre-digested currently. Other file types pass through as-is (if 
 - **Slack** — files shared in messages. 50MB limit.
 - **Web UI** — drag-and-drop or file picker. Inline preview before send. Images rendered inline in chat history.
 
-## Tools
+## Related tools
 
-### `image(file, prompt?)`
+The `image` and `pdf` tools are core tools (not part of this plugin) — they operate on files on disk and work whether or not the media pipeline is active. Useful for re-examining images that have aged out of context, or extracting text from PDFs stored in `.kern/media/`.
 
-Analyze any image on disk or in `.kern/media/` using the AI model.
-
-- `file` — path to image, or just a `.kern/media/` filename
-- `prompt` — what to analyze (default: "Describe this image.")
-
-Useful for re-examining images that have aged out of context, or asking specific questions about stored screenshots.
-
-### `pdf(file, pages?, prompt?)`
-
-Read or analyze PDF files.
-
-- `file` — path to PDF
-- `pages` — page numbers to extract (default: page 1 for reading, all pages when `prompt` is provided). Supports `"1-5"`, `"2,4,7-9"`.
-- `prompt` — question to ask the AI model about the PDF content
-
-Returns extracted text with a header showing total page count. Agent's natural flow: read page 1 to understand structure, then read specific pages or ask a question.
+See [tools.md](tools.md) for full documentation.
 
 ## API
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -79,6 +79,8 @@ Sub-agents run with a strict read-only toolset:
 | `grep` | Search file contents |
 | `webfetch` | Fetch a URL |
 | `websearch` | Search the web |
+| `pdf` | Read or analyze PDF files |
+| `image` | Analyze an image with the AI model |
 
 Sub-agents **cannot**:
 
@@ -86,7 +88,7 @@ Sub-agents **cannot**:
 - Edit or write files (`edit`, `write`)
 - Send messages (`message`)
 - Manage the runtime (`kern`)
-- Call plugin tools (`recall`, `pdf`, `image`, MCP tools)
+- Call plugin tools (`recall`, MCP tools)
 - Spawn further sub-agents (no nested delegation in v1)
 
 This boundary is intentional. If you need a child that can mutate state, call the destructive tool in the parent based on the sub-agent's report.

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,9 +55,9 @@ export type McpServerConfig =
 const shell = process.platform === "win32" ? "pwsh" : "bash";
 
 const TOOL_SCOPES: Record<ToolScope, string[]> = {
-  full: [shell, "read", "write", "edit", "glob", "grep", "webfetch", "websearch", "kern", "message"],
-  write: ["read", "write", "edit", "glob", "grep", "webfetch", "websearch", "kern", "message"],
-  read: ["read", "glob", "grep", "webfetch", "websearch", "kern"],
+  full: [shell, "read", "write", "edit", "glob", "grep", "webfetch", "websearch", "pdf", "image", "kern", "message"],
+  write: ["read", "write", "edit", "glob", "grep", "webfetch", "websearch", "pdf", "image", "kern", "message"],
+  read: ["read", "glob", "grep", "webfetch", "websearch", "pdf", "image", "kern"],
 };
 
 export const configDefaults: KernConfig = {

--- a/src/context.ts
+++ b/src/context.ts
@@ -63,6 +63,8 @@ export async function loadSystemPrompt(agentDir: string, config: KernConfig, plu
     glob: "find files by pattern",
     grep: "search file contents",
     webfetch: "fetch URLs",
+    pdf: "extract text or analyze PDF files",
+    image: "analyze image files using the AI model",
     kern: "manage your own runtime (status, config, env)",
     message: "send messages proactively",
     ...pluginToolDescriptions,

--- a/src/plugins/media/plugin.ts
+++ b/src/plugins/media/plugin.ts
@@ -4,8 +4,6 @@ import type { Attachment } from "../../interfaces/types.js";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { saveMedia, buildUserContent, MediaSidecar, resolveMediaInMessages, digestMediaAtIngest } from "./media.js";
-import { imageTool } from "./image.js";
-import { pdfTool } from "./pdf.js";
 import { log } from "../../log.js";
 
 const MIME_MAP: Record<string, string> = {
@@ -19,16 +17,6 @@ let mediaSidecar: MediaSidecar | null = null;
 
 export const mediaPlugin: KernPlugin = {
   name: "media",
-
-  tools: {
-    pdf: pdfTool,
-    image: imageTool,
-  },
-
-  toolDescriptions: {
-    pdf: "read or analyze PDF files",
-    image: "analyze images using AI",
-  },
 
   routes: (() => {
     let _ctx: PluginContext | null = null;

--- a/src/plugins/subagents/worker.ts
+++ b/src/plugins/subagents/worker.ts
@@ -33,12 +33,14 @@ const SUBAGENT_TOOLS: ToolName[] = [
   "grep",
   "webfetch",
   "websearch",
+  "pdf",
+  "image",
 ];
 
 const SUBAGENT_SYSTEM_PROMPT = [
   "You are a sub-agent spawned by a parent kern agent to complete a focused task.",
   "",
-  "You have access to read-only tools: read, glob, grep, webfetch, websearch.",
+  "You have access to read-only tools: read, glob, grep, webfetch, websearch, pdf, image.",
   "You cannot execute shell commands, edit files, or spawn further sub-agents.",
   "",
   "Complete the task given to you, then reply with a concise result.",

--- a/src/tools/image.ts
+++ b/src/tools/image.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { readFile } from "fs/promises";
 import { join, extname } from "path";
 import { existsSync } from "fs";
-import { createModel } from "../../model.js";
-import { loadConfig } from "../../config.js";
+import { createModel } from "../model.js";
+import { loadConfig } from "../config.js";
 
 const EXT_TO_MIME: Record<string, string> = {
   ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,8 @@ import { globTool } from "./glob.js";
 import { grepTool } from "./grep.js";
 import { webfetchTool } from "./webfetch.js";
 import { websearchTool } from "./websearch.js";
+import { pdfTool } from "./pdf.js";
+import { imageTool } from "./image.js";
 import { kernTool } from "./kern.js";
 import { messageTool } from "./message.js";
 
@@ -22,6 +24,8 @@ export const allTools = {
   grep: grepTool,
   webfetch: webfetchTool,
   websearch: websearchTool,
+  pdf: pdfTool,
+  image: imageTool,
   kern: kernTool,
   message: messageTool,
 };

--- a/src/tools/pdf.ts
+++ b/src/tools/pdf.ts
@@ -1,8 +1,8 @@
 import { tool, generateText } from "ai";
 import { z } from "zod";
 import { readFile } from "fs/promises";
-import { createModel } from "../../model.js";
-import { loadConfig } from "../../config.js";
+import { createModel } from "../model.js";
+import { loadConfig } from "../config.js";
 
 /**
  * Parse a pages string like "1", "1-5", "1,3,7-9" into sorted unique 0-based indices.

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -114,7 +114,7 @@ kern also ships with bundled skills that appear in the catalog automatically. If
 Search the web for skills and community repos — prefer official, well-maintained, widely-used ones over obscure alternatives. Install with `npx skills` with `-a universal -y`.
 
 ### Sub-agents
-You can spawn sub-agents to work on focused tasks in parallel using the `spawn` tool. Each sub-agent runs its own LLM loop with a read-only toolset (`read`, `glob`, `grep`, `webfetch`, `websearch`).
+You can spawn sub-agents to work on focused tasks in parallel using the `spawn` tool. Each sub-agent runs its own LLM loop with a read-only toolset (`read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`).
 
 - `spawn({ prompt })` returns immediately with a sub-agent ID. The child runs in the background.
 - When the child finishes, its result arrives as a new turn prefixed with `[subagent:<id> done]`.


### PR DESCRIPTION
Closes #262

## What

Move `pdf` and `image` out of the media plugin into core tools. They were living in `src/plugins/media/` by colocation — "stuff that touches non-text files" — but don't actually participate in any of the plugin's pipeline (attachment save, vision digest, mid-turn resolution, HTTP serving). They're stateless pure functions over a file path.

## Changes

- `git mv src/plugins/media/{pdf,image}.ts → src/tools/{pdf,image}.ts`
- Register in `allTools` and add to `read` / `write` / `full` tool scopes — `pdf`/`image` are read-shaped operations, they belong in `read`
- Drop `tools` and `toolDescriptions` fields from `mediaPlugin` — the plugin now owns only the attachment pipeline
- Add `pdf` and `image` to `SUBAGENT_TOOLS` allowlist and update the sub-agent system prompt
- Add core descriptions for `pdf`/`image` in the system prompt tool list (caught by Copilot review — they were dropping to the tool-name fallback after leaving `mediaPlugin.toolDescriptions`)

## Why

Two annoyances fixed:

1. **Sub-agents couldn't call them.** The sub-agent worker pulls from `allTools`, so plugin tools were unreachable. Sub-agents shipped advertising pdf/image access but had to be walked back to `read/glob/grep/webfetch/websearch` only. Now they're reachable.
2. **`toolScope` gating.** Any surface that wants to limit tools by scope (sub-agents, MCP-only setups, future skill filters) can reference core tools without needing plugin initialization.

Recall correctly stays in the plugin — it has state, lifecycle hooks, and disable flag. pdf/image have none of those.

## Scope

- 2 file moves (history preserved)
- 3 lines added to `src/tools/index.ts`
- 3 lines added across the scope presets in `src/config.ts`
- Dropped 8 lines from `src/plugins/media/plugin.ts`
- 2 lines + 1 system prompt string in `src/plugins/subagents/worker.ts`
- Doc updates: `docs/tools.md` (no change — already in the main list), `docs/subagents.md` (added to allowed tools table), `docs/media.md` (rewrote "Tools" section to point at `tools.md`), `templates/KERN.md` (sub-agent section tool list updated), CHANGELOG

## Behavior changes

- **Sub-agents gain `pdf`/`image` access.** Previously plugin tools were outside the sub-agent allowlist; now they're in. A sub-agent can now ingest an image or extract PDF text on its own. Matches what the `spawn` tool description already advertised.
- **Tool-scope gating applies.** `pdf`/`image` are now in the `read`/`write`/`full` scopes (all three). Any agent running on these scopes keeps identical access. No existing agent loses capability — the three shipped scopes all include them.
- Tool schemas, file resolution, and model calls are byte-identical to before.

## Risk

Low. Schemas unchanged, call sites unchanged, build clean.
