### PR TITLE
refactor: move CLI command files into src/cli/ (#260)

### DIFF
--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { basename, resolve, join } from "path";
 import { existsSync } from "fs";
-import { findAgent, registerAgent, isProcessRunning, readPid, removePidFile } from "./registry.js";
+import { findAgent, registerAgent, isProcessRunning, readPid, removePidFile } from "../registry.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -4,7 +4,7 @@ import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { join } from "path";
 import { openSync } from "fs";
-import { findAgent, loadRegistry, registerAgent, readAgentInfo, readPid, writePidFile, removePidFile, isProcessRunning } from "./registry.js";
+import { findAgent, loadRegistry, registerAgent, readAgentInfo, readPid, writePidFile, removePidFile, isProcessRunning } from "../registry.js";
 import { isServiceInstalled } from "./install.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -3,8 +3,8 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { mkdir, writeFile } from "fs/promises";
 import { homedir } from "os";
-import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
-import { log } from "./log.js";
+import { findAgent, loadRegistry, readAgentInfo } from "../registry.js";
+import { log } from "../log.js";
 
 interface OpenCodeMessage {
   id: string;

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -2,10 +2,10 @@ import { mkdir, writeFile, readFile } from "fs/promises";
 import { join, resolve, basename } from "path";
 import { existsSync } from "fs";
 import { input, select, password } from "@inquirer/prompts";
-import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "./registry.js";
+import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "../registry.js";
 import { startAgent } from "./daemon.js";
-import type { KernConfig } from "./config.js";
-import { log } from "./log.js";
+import type { KernConfig } from "../config.js";
+import { log } from "../log.js";
 
 // Fallback models used when live fetch fails (e.g. no network, bad key)
 const FALLBACK_MODELS: Record<string, { name: string; value: string }[]> = {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -3,7 +3,7 @@ import { existsSync } from "fs";
 import { mkdir, writeFile, unlink, readFile } from "fs/promises";
 import { join, basename } from "path";
 import { homedir } from "os";
-import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "./registry.js";
+import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "../registry.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;

--- a/src/cli/proxy-daemon.ts
+++ b/src/cli/proxy-daemon.ts
@@ -3,8 +3,8 @@ import { readFile, writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync, openSync } from "fs";
 import { homedir } from "os";
-import { isProcessRunning } from "./registry.js";
-import { loadGlobalConfig } from "./global-config.js";
+import { isProcessRunning } from "../registry.js";
+import { loadGlobalConfig, getProxyToken } from "../global-config.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -12,8 +12,8 @@ const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
 const KERN_DIR = join(homedir(), ".kern");
-const PID_FILE = join(KERN_DIR, "web.pid");
-const LOG_FILE = join(KERN_DIR, "web.log");
+const PID_FILE = join(KERN_DIR, "proxy.pid");
+const LOG_FILE = join(KERN_DIR, "proxy.log");
 
 async function readPid(): Promise<number | null> {
   if (!existsSync(PID_FILE)) return null;
@@ -25,22 +25,23 @@ async function readPid(): Promise<number | null> {
   }
 }
 
-export async function webStart(): Promise<void> {
+export async function proxyStart(): Promise<void> {
   const config = await loadGlobalConfig();
-  const port = config.web_port;
+  const port = config.proxy_port;
+  const token = await getProxyToken();
 
   const pid = await readPid();
   if (pid && isProcessRunning(pid)) {
-    console.log(`\n  ${green("●")} ${bold("web")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}\n`);
+    console.log(`\n  ${green("●")} ${bold("proxy")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}?token=${token}\n`);
     return;
   }
 
   await mkdir(KERN_DIR, { recursive: true });
   const logFd = openSync(LOG_FILE, "a");
-  const webEntry = join(import.meta.dirname, "web.js");
+  const proxyEntry = join(import.meta.dirname, "proxy.js");
 
-  const child = spawn("node", ["--no-deprecation", webEntry], {
+  const child = spawn("node", ["--no-deprecation", proxyEntry], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
   });
@@ -52,11 +53,11 @@ export async function webStart(): Promise<void> {
   await new Promise((r) => setTimeout(r, 1000));
 
   if (isProcessRunning(newPid)) {
-    console.log(`\n  ${green("●")} ${bold("web")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}\n`);
+    console.log(`\n  ${green("●")} ${bold("proxy")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}?token=${token}\n`);
   } else {
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("web")} failed to start\n`);
+    console.log(`\n  ${red("●")} ${bold("proxy")} failed to start\n`);
     try {
       const log = await readFile(LOG_FILE, "utf-8");
       const lines = log.trim().split("\n").slice(-5);
@@ -67,10 +68,10 @@ export async function webStart(): Promise<void> {
   }
 }
 
-export async function webStop(): Promise<void> {
+export async function proxyStop(): Promise<void> {
   const pid = await readPid();
   if (!pid || !isProcessRunning(pid)) {
-    console.log(`\n  ${dim("●")} ${bold("web")} not running\n`);
+    console.log(`\n  ${dim("●")} ${bold("proxy")} not running\n`);
     try { await unlink(PID_FILE); } catch {}
     return;
   }
@@ -78,16 +79,16 @@ export async function webStop(): Promise<void> {
   try {
     process.kill(pid, "SIGTERM");
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("web")} stopped ${dim(`(was pid ${pid})`)}\n`);
+    console.log(`\n  ${red("●")} ${bold("proxy")} stopped ${dim(`(was pid ${pid})`)}\n`);
   } catch (e: any) {
-    console.error(`  Failed to stop web: ${e.message}`);
+    console.error(`  Failed to stop proxy: ${e.message}`);
   }
 }
 
-export async function webStatus(): Promise<void> {
+export async function proxyStatus(): Promise<void> {
   const config = await loadGlobalConfig();
-  const { getWebServiceStatus } = await import("./install.js");
-  const installStatus = getWebServiceStatus();
+  const { getProxyServiceStatus } = await import("./install.js");
+  const installStatus = getProxyServiceStatus();
 
   const pid = await readPid();
   const pidRunning = pid && isProcessRunning(pid);
@@ -95,12 +96,18 @@ export async function webStatus(): Promise<void> {
   const mode = installStatus ? "systemd" : pidRunning ? "daemon" : "—";
 
   if (running) {
-    console.log(`\n  ${green("●")} ${bold("web")} running ${dim(`(:${config.web_port})`)}`);
+    console.log(`\n  ${green("●")} ${bold("proxy")} running ${dim(`(:${config.proxy_port})`)}`);
   } else {
-    console.log(`\n  ${dim("●")} ${bold("web")} stopped`);
+    console.log(`\n  ${dim("●")} ${bold("proxy")} stopped`);
     if (pid) {
       try { await unlink(PID_FILE); } catch {}
     }
   }
   console.log(`    ${dim("mode:")} ${mode}\n`);
+}
+
+export async function proxyToken(): Promise<void> {
+  const config = await loadGlobalConfig();
+  const token = await getProxyToken();
+  console.log(`\n  → http://localhost:${config.proxy_port}?token=${token}\n`);
 }

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,6 +1,6 @@
-import { loadRegistry, readAgentInfo, isProcessRunning } from "./registry.js";
+import { loadRegistry, readAgentInfo, isProcessRunning } from "../registry.js";
 import { getServiceStatus, getWebServiceStatus } from "./install.js";
-import { loadGlobalConfig } from "./global-config.js";
+import { loadGlobalConfig } from "../global-config.js";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join, basename } from "path";

--- a/src/cli/tui.tsx
+++ b/src/cli/tui.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from "react";
 import { render, Box, Text, Static, useInput, useApp, useStdout } from "ink";
 // @ts-ignore
 import Spinner from "ink-spinner";
-import type { ServerEvent } from "./server.js";
-import { findAgent } from "./registry.js";
+import type { ServerEvent } from "../server.js";
+import { findAgent } from "../registry.js";
 
 // --- Types ---
 
@@ -523,7 +523,7 @@ function App({ port, agentName, version, authToken }: TuiProps) {
         }
         if (!aborted) {
           setConnected(false);
-          import("./registry.js").then(async ({ findAgent, isProcessRunning }) => {
+          import("../registry.js").then(async ({ findAgent, isProcessRunning }) => {
             const agent = await findAgent(agentName);
             if (agent?.port && agent.port !== currentPort && agent.pid && isProcessRunning(agent.pid)) {
               setCurrentPort(agent.port);
@@ -535,7 +535,7 @@ function App({ port, agentName, version, authToken }: TuiProps) {
       } catch {
         if (!aborted) {
           setConnected(false);
-          import("./registry.js").then(async ({ findAgent, isProcessRunning }) => {
+          import("../registry.js").then(async ({ findAgent, isProcessRunning }) => {
             const agent = await findAgent(agentName);
             if (agent?.port && agent.port !== currentPort && agent.pid && isProcessRunning(agent.pid)) {
               setCurrentPort(agent.port);

--- a/src/cli/web-daemon.ts
+++ b/src/cli/web-daemon.ts
@@ -3,8 +3,8 @@ import { readFile, writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync, openSync } from "fs";
 import { homedir } from "os";
-import { isProcessRunning } from "./registry.js";
-import { loadGlobalConfig, getProxyToken } from "./global-config.js";
+import { isProcessRunning } from "../registry.js";
+import { loadGlobalConfig } from "../global-config.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -12,8 +12,8 @@ const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
 const KERN_DIR = join(homedir(), ".kern");
-const PID_FILE = join(KERN_DIR, "proxy.pid");
-const LOG_FILE = join(KERN_DIR, "proxy.log");
+const PID_FILE = join(KERN_DIR, "web.pid");
+const LOG_FILE = join(KERN_DIR, "web.log");
 
 async function readPid(): Promise<number | null> {
   if (!existsSync(PID_FILE)) return null;
@@ -25,23 +25,22 @@ async function readPid(): Promise<number | null> {
   }
 }
 
-export async function proxyStart(): Promise<void> {
+export async function webStart(): Promise<void> {
   const config = await loadGlobalConfig();
-  const port = config.proxy_port;
-  const token = await getProxyToken();
+  const port = config.web_port;
 
   const pid = await readPid();
   if (pid && isProcessRunning(pid)) {
-    console.log(`\n  ${green("●")} ${bold("proxy")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    console.log(`\n  ${green("●")} ${bold("web")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}\n`);
     return;
   }
 
   await mkdir(KERN_DIR, { recursive: true });
   const logFd = openSync(LOG_FILE, "a");
-  const proxyEntry = join(import.meta.dirname, "proxy.js");
+  const webEntry = join(import.meta.dirname, "web.js");
 
-  const child = spawn("node", ["--no-deprecation", proxyEntry], {
+  const child = spawn("node", ["--no-deprecation", webEntry], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
   });
@@ -53,11 +52,11 @@ export async function proxyStart(): Promise<void> {
   await new Promise((r) => setTimeout(r, 1000));
 
   if (isProcessRunning(newPid)) {
-    console.log(`\n  ${green("●")} ${bold("proxy")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    console.log(`\n  ${green("●")} ${bold("web")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}\n`);
   } else {
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("proxy")} failed to start\n`);
+    console.log(`\n  ${red("●")} ${bold("web")} failed to start\n`);
     try {
       const log = await readFile(LOG_FILE, "utf-8");
       const lines = log.trim().split("\n").slice(-5);
@@ -68,10 +67,10 @@ export async function proxyStart(): Promise<void> {
   }
 }
 
-export async function proxyStop(): Promise<void> {
+export async function webStop(): Promise<void> {
   const pid = await readPid();
   if (!pid || !isProcessRunning(pid)) {
-    console.log(`\n  ${dim("●")} ${bold("proxy")} not running\n`);
+    console.log(`\n  ${dim("●")} ${bold("web")} not running\n`);
     try { await unlink(PID_FILE); } catch {}
     return;
   }
@@ -79,16 +78,16 @@ export async function proxyStop(): Promise<void> {
   try {
     process.kill(pid, "SIGTERM");
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("proxy")} stopped ${dim(`(was pid ${pid})`)}\n`);
+    console.log(`\n  ${red("●")} ${bold("web")} stopped ${dim(`(was pid ${pid})`)}\n`);
   } catch (e: any) {
-    console.error(`  Failed to stop proxy: ${e.message}`);
+    console.error(`  Failed to stop web: ${e.message}`);
   }
 }
 
-export async function proxyStatus(): Promise<void> {
+export async function webStatus(): Promise<void> {
   const config = await loadGlobalConfig();
-  const { getProxyServiceStatus } = await import("./install.js");
-  const installStatus = getProxyServiceStatus();
+  const { getWebServiceStatus } = await import("./install.js");
+  const installStatus = getWebServiceStatus();
 
   const pid = await readPid();
   const pidRunning = pid && isProcessRunning(pid);
@@ -96,18 +95,12 @@ export async function proxyStatus(): Promise<void> {
   const mode = installStatus ? "systemd" : pidRunning ? "daemon" : "—";
 
   if (running) {
-    console.log(`\n  ${green("●")} ${bold("proxy")} running ${dim(`(:${config.proxy_port})`)}`);
+    console.log(`\n  ${green("●")} ${bold("web")} running ${dim(`(:${config.web_port})`)}`);
   } else {
-    console.log(`\n  ${dim("●")} ${bold("proxy")} stopped`);
+    console.log(`\n  ${dim("●")} ${bold("web")} stopped`);
     if (pid) {
       try { await unlink(PID_FILE); } catch {}
     }
   }
   console.log(`    ${dim("mode:")} ${mode}\n`);
-}
-
-export async function proxyToken(): Promise<void> {
-  const config = await loadGlobalConfig();
-  const token = await getProxyToken();
-  console.log(`\n  → http://localhost:${config.proxy_port}?token=${token}\n`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@
 import { resolve, basename } from "path";
 import { existsSync } from "fs";
 import { startApp } from "./app.js";
-import { runInit } from "./init.js";
-import { showStatus } from "./status.js";
-import { startAgent, stopAgent } from "./daemon.js";
+import { runInit } from "./cli/init.js";
+import { showStatus } from "./cli/status.js";
+import { startAgent, stopAgent } from "./cli/daemon.js";
 import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
 import { readFile } from "fs/promises";
 import { join } from "path";
@@ -114,7 +114,7 @@ async function main() {
 
   if (cmd === "start") {
     if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./install.js");
+      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
       if (isServiceInstalled(args[1])) {
         const ok = serviceControl("start", args[1]);
         if (!ok) {
@@ -130,7 +130,7 @@ async function main() {
 
   if (cmd === "stop") {
     if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./install.js");
+      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
       if (isServiceInstalled(args[1])) {
         const ok = serviceControl("stop", args[1]);
         if (!ok) {
@@ -146,7 +146,7 @@ async function main() {
 
   if (cmd === "restart") {
     if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./install.js");
+      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
       if (isServiceInstalled(args[1])) {
         const ok = serviceControl("restart", args[1]);
         if (!ok) {
@@ -163,13 +163,13 @@ async function main() {
   }
 
   if (cmd === "install") {
-    const { install } = await import("./install.js");
+    const { install } = await import("./cli/install.js");
     await install(args[1]);
     process.exit(0);
   }
 
   if (cmd === "uninstall") {
-    const { uninstall } = await import("./install.js");
+    const { uninstall } = await import("./cli/install.js");
     await uninstall(args[1]);
     process.exit(0);
   }
@@ -181,14 +181,14 @@ async function main() {
       process.exit(1);
     }
     const { removeAgent, findAgent, isProcessRunning } = await import("./registry.js");
-    const { stopAgent } = await import("./daemon.js");
+    const { stopAgent } = await import("./cli/daemon.js");
     const agent = findAgent(name);
     if (!agent) {
       console.error(`Agent not found: ${name}`);
       process.exit(1);
     }
     // Uninstall systemd service if installed
-    const { isServiceInstalled, uninstall } = await import("./install.js");
+    const { isServiceInstalled, uninstall } = await import("./cli/install.js");
     if (isServiceInstalled(name)) {
       await uninstall(name);
     }
@@ -262,7 +262,7 @@ async function main() {
   if (cmd === "import") {
     const source = args[1]; // "opencode"
     if (source === "opencode") {
-      const { importOpenCode } = await import("./import.js");
+      const { importOpenCode } = await import("./cli/import.js");
       await importOpenCode(args.slice(2));
     } else {
       console.error("Usage: kern import opencode [--project <path>] [--session <title|latest>] [--agent <name>]");
@@ -297,21 +297,21 @@ async function main() {
   }
 
   if (cmd === "backup") {
-    const { backupAgent } = await import("./backup.js");
+    const { backupAgent } = await import("./cli/backup.js");
     await backupAgent(args[1]);
     return;
   }
 
   if (cmd === "restore") {
-    const { restoreAgent } = await import("./backup.js");
+    const { restoreAgent } = await import("./cli/backup.js");
     await restoreAgent(args[1]);
     return;
   }
 
   if (cmd === "tui") {
-    const { connectTui } = await import("./tui.js");
+    const { connectTui } = await import("./cli/tui.js");
     const { findAgent, loadRegistry, readAgentInfo, isProcessRunning } = await import("./registry.js");
-    const { startAgent } = await import("./daemon.js");
+    const { startAgent } = await import("./cli/daemon.js");
 
     let agentName = args[1];
 
@@ -362,7 +362,7 @@ async function main() {
     const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
 
     if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
-      const { scaffoldAgent, API_KEY_ENV } = await import("./init.js");
+      const { scaffoldAgent, API_KEY_ENV } = await import("./cli/init.js");
       const name = process.env.KERN_NAME || basename(agentDir);
       const provider = process.env.KERN_PROVIDER || "openrouter";
       const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
@@ -382,9 +382,9 @@ async function main() {
 
   if (cmd === "web") {
     const subcmd = args[1];
-    const { webStart, webStop, webStatus } = await import("./web-daemon.js");
+    const { webStart, webStop, webStatus } = await import("./cli/web-daemon.js");
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      const { getWebServiceStatus } = await import("./install.js");
+      const { getWebServiceStatus } = await import("./cli/install.js");
       if (getWebServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
         spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
@@ -407,9 +407,9 @@ async function main() {
 
   if (cmd === "proxy") {
     const subcmd = args[1];
-    const { proxyStart, proxyStop, proxyStatus, proxyToken } = await import("./proxy-daemon.js");
+    const { proxyStart, proxyStop, proxyStatus, proxyToken } = await import("./cli/proxy-daemon.js");
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      const { getProxyServiceStatus } = await import("./install.js");
+      const { getProxyServiceStatus } = await import("./cli/install.js");
       if (getProxyServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
         spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });


### PR DESCRIPTION
Closes #260

## What

Move the nine one-shot CLI command modules into `src/cli/`.

```
src/init.ts          → src/cli/init.ts
src/status.ts        → src/cli/status.ts
src/install.ts       → src/cli/install.ts
src/backup.ts        → src/cli/backup.ts
src/import.ts        → src/cli/import.ts
src/daemon.ts        → src/cli/daemon.ts
src/web-daemon.ts    → src/cli/web-daemon.ts
src/proxy-daemon.ts  → src/cli/proxy-daemon.ts
src/tui.tsx          → src/cli/tui.tsx
```

Stay at `src/` root:
- `index.ts` — binary entrypoint (`package.json` `bin` field)
- `app.ts`, `web.ts`, `proxy.ts` — long-running server processes, not CLI commands
- All runtime/shared: `runtime`, `context`, `session`, `memory`, `registry`, `model`, `config`, `log`, `util`, `server`, `pairing`, `kernel`, `segments`, `queue`, `global-config`

## Why

`src/` was 30 files flat. Hard to scan. Runtime modules sat next to one-shot CLI handlers with no visible grouping. `plugins/`, `tools/`, `interfaces/` already had their own folders; CLI was the obvious next grouping.

After: `src/` is 19 files + 4 folders (`cli`, `plugins`, `tools`, `interfaces`). Easier to orient.

## Scope

- 9 `git mv` (history preserved)
- Import rewrites inside moved files: `./registry.js` → `../registry.js` etc. Cross-cli imports (init → daemon, daemon → install, status → install) stay relative `./`
- `src/index.ts` top-level imports + dynamic `import()` calls updated to `./cli/*`
- **38 insertions, 38 deletions** — perfectly symmetric, pure rename + path rewrite

## Risk

Low.

- `package.json` `bin` points to `dist/index.js` — unchanged
- `tsconfig.json` uses `src/**/*` glob — no file list to update
- Build clean (`npm run build`)
- Smoke tests pass: `kern --help`, `kern status` (exercises `loadRegistry`, `readAgentInfo`, `isProcessRunning`, `getServiceStatus`, `getWebServiceStatus`, `loadGlobalConfig`)
- No changelog entry (internal refactor, no user-visible change)
