### PR TITLE
refactor: command table for CLI (#265)

### DIFF
--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -136,18 +136,12 @@ export async function restoreAgent(tarFile?: string): Promise<void> {
 // --- CLI commands ---
 
 export const backupCommand: Command = {
-  name: "backup",
-  usage: "<name>",
-  description: "backup agent to .tar.gz",
   async handler(args) {
     await backupAgent(args[0]);
   },
 };
 
 export const restoreCommand: Command = {
-  name: "restore",
-  usage: "<file>",
-  description: "restore agent from backup",
   async handler(args) {
     await restoreAgent(args[0]);
   },

--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { basename, resolve, join } from "path";
 import { existsSync } from "fs";
-import { findAgent, registerAgent, isProcessRunning, readPid, removePidFile } from "./registry.js";
+import { findAgent, registerAgent, isProcessRunning, readPid, removePidFile } from "../registry.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;

--- a/src/cli/backup.ts
+++ b/src/cli/backup.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import { basename, resolve, join } from "path";
 import { existsSync } from "fs";
 import { findAgent, registerAgent, isProcessRunning, readPid, removePidFile } from "../registry.js";
+import type { Command } from "./commands.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -131,3 +132,23 @@ export async function restoreAgent(tarFile?: string): Promise<void> {
   console.log("");
   process.exit(0);
 }
+
+// --- CLI commands ---
+
+export const backupCommand: Command = {
+  name: "backup",
+  usage: "<name>",
+  description: "backup agent to .tar.gz",
+  async handler(args) {
+    await backupAgent(args[0]);
+  },
+};
+
+export const restoreCommand: Command = {
+  name: "restore",
+  usage: "<file>",
+  description: "restore agent from backup",
+  async handler(args) {
+    await restoreAgent(args[0]);
+  },
+};

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,445 +1,56 @@
-// Command table for the kern CLI.
+// Registry of kern CLI commands.
 //
-// Each command owns: its name (+ aliases), a one-line usage hint for help,
-// a short description, and a handler that receives the argv tail (everything
-// after the command name). Handlers lazy-import their deps so startup stays
-// fast — `kern status` should never load the TUI bundle.
+// Each command lives in its own file under src/cli/. Logic modules that
+// predate the command system (init, backup, install, tui, import, status)
+// export both their functions and their Command object from the same file.
+// New commands (start, stop, restart, remove, pair, logs, run, web, proxy)
+// are small files whose entire job is to wrap the relevant logic.
 
-import { resolve, basename, join } from "path";
-import { existsSync } from "fs";
-import { readFile } from "fs/promises";
-import { findAgent, loadRegistry, readAgentInfo } from "../registry.js";
-
-export type Command = {
+export interface Command {
   name: string;
   aliases?: string[];
-  usage?: string;        // e.g. "<name>" — rendered after the command name in help
-  description: string;   // one-line help text
-  hidden?: boolean;      // skip in help output
-  handler: (args: string[]) => Promise<void>;
-};
-
-// Resolve an agent directory from a name or path, or prompt if multiple exist.
-async function resolveAgentDir(nameOrPath?: string): Promise<string> {
-  if (nameOrPath) {
-    const agent = findAgent(nameOrPath);
-    if (agent) return agent.path;
-
-    const dir = resolve(nameOrPath);
-    if (existsSync(dir) && (existsSync(join(dir, ".kern")) || existsSync(join(dir, "AGENTS.md")))) {
-      return dir;
-    }
-
-    console.error(`Agent not found: ${nameOrPath}`);
-    process.exit(1);
-  }
-
-  const paths = await loadRegistry();
-  if (paths.length === 0) {
-    console.error("No agents registered. Run 'kern init <name>' first.");
-    process.exit(1);
-  }
-  if (paths.length === 1) return paths[0];
-
-  const { select } = await import("@inquirer/prompts");
-  const choices = paths.map((p) => {
-    const info = readAgentInfo(p);
-    return { name: info?.name || p, value: p };
-  });
-  return select({ message: "Select agent", choices });
+  usage?: string;
+  description: string;
+  hidden?: boolean;
+  handler(args: string[]): Promise<void> | void;
 }
 
-// Shared: try systemd first, fall back to direct daemon control.
-async function serviceOrDaemon(
-  action: "start" | "stop" | "restart",
-  name: string | undefined,
-): Promise<void> {
-  if (name) {
-    const { isServiceInstalled, serviceControl } = await import("./install.js");
-    if (isServiceInstalled(name)) {
-      const ok = serviceControl(action, name);
-      if (!ok) {
-        console.error(`Failed to ${action} service-managed agent: ${name}`);
-        process.exit(1);
-      }
-      return;
-    }
-  }
-  const { startAgent, stopAgent } = await import("./daemon.js");
-  if (action === "start") await startAgent(name);
-  else if (action === "stop") await stopAgent(name);
-  else {
-    await stopAgent(name);
-    await new Promise((r) => setTimeout(r, 500));
-    await startAgent(name);
-  }
-}
+import { initCommand } from "./init.js";
+import { listCommand } from "./status.js";
+import { startCommand } from "./start.js";
+import { stopCommand } from "./stop.js";
+import { restartCommand } from "./restart.js";
+import { removeCommand } from "./remove.js";
+import { pairCommand } from "./pair.js";
+import { backupCommand, restoreCommand } from "./backup.js";
+import { importCommand } from "./import.js";
+import { logsCommand } from "./logs.js";
+import { installCommand, uninstallCommand } from "./install.js";
+import { tuiCommand } from "./tui.js";
+import { runCommand } from "./run.js";
+import { webCommand } from "./web.js";
+import { proxyCommand } from "./proxy.js";
 
 export const commands: Command[] = [
-  {
-    name: "init",
-    usage: "<name>",
-    description: "create or configure an agent",
-    async handler(args) {
-      // Parse --flag value pairs and a positional target
-      const flags: Record<string, string> = {};
-      let target = args[0];
-      for (let i = 0; i < args.length; i++) {
-        if (args[i].startsWith("--") && i + 1 < args.length && !args[i + 1].startsWith("--")) {
-          flags[args[i].slice(2)] = args[i + 1];
-          i++;
-        } else if (!args[i].startsWith("--")) {
-          target = args[i];
-        }
-      }
-      const { runInit } = await import("./init.js");
-      await runInit(target, Object.keys(flags).length > 0 ? flags : undefined);
-    },
-  },
-
-  {
-    name: "list",
-    aliases: ["ls", "status"],
-    description: "show all agents",
-    async handler() {
-      const { showStatus } = await import("./status.js");
-      await showStatus();
-    },
-  },
-
-  {
-    name: "start",
-    usage: "[name|path]",
-    description: "start agents",
-    async handler(args) {
-      await serviceOrDaemon("start", args[0]);
-    },
-  },
-
-  {
-    name: "stop",
-    usage: "[name]",
-    description: "stop agents",
-    async handler(args) {
-      await serviceOrDaemon("stop", args[0]);
-    },
-  },
-
-  {
-    name: "restart",
-    usage: "[name]",
-    description: "restart agents",
-    async handler(args) {
-      await serviceOrDaemon("restart", args[0]);
-    },
-  },
-
-  {
-    name: "remove",
-    aliases: ["rm"],
-    usage: "<name>",
-    description: "unregister an agent",
-    async handler(args) {
-      const name = args[0];
-      if (!name) {
-        console.error("Usage: kern remove <name>");
-        process.exit(1);
-      }
-      const { removeAgent, isProcessRunning } = await import("../registry.js");
-      const agent = findAgent(name);
-      if (!agent) {
-        console.error(`Agent not found: ${name}`);
-        process.exit(1);
-      }
-      const { isServiceInstalled, uninstall } = await import("./install.js");
-      if (isServiceInstalled(name)) await uninstall(name);
-      if (agent.pid && isProcessRunning(agent.pid)) {
-        const { stopAgent } = await import("./daemon.js");
-        await stopAgent(name);
-      }
-      await removeAgent(name);
-      console.log(`  Removed ${name}`);
-    },
-  },
-
-  {
-    name: "pair",
-    usage: "<agent> <code>",
-    description: "approve a pairing code",
-    async handler(args) {
-      const [agentName, code] = args;
-      if (!agentName || !code) {
-        console.error("Usage: kern pair <agent> <code>");
-        process.exit(1);
-      }
-      const { PairingManager } = await import("../pairing.js");
-      const agent = findAgent(agentName);
-      if (!agent) {
-        console.error(`Agent not found: ${agentName}`);
-        process.exit(1);
-      }
-      const pairing = new PairingManager(agent.path);
-      await pairing.load();
-      const result = await pairing.pair(code);
-      if (result) {
-        console.log(`  Paired user ${result.userId} (${result.interface}) to ${agentName}`);
-      } else {
-        console.error(`  Invalid or expired code: ${code}`);
-        process.exit(1);
-      }
-    },
-  },
-
-  {
-    name: "backup",
-    usage: "<name>",
-    description: "backup agent to .tar.gz",
-    async handler(args) {
-      const { backupAgent } = await import("./backup.js");
-      await backupAgent(args[0]);
-    },
-  },
-
-  {
-    name: "restore",
-    usage: "<file>",
-    description: "restore agent from backup",
-    async handler(args) {
-      const { restoreAgent } = await import("./backup.js");
-      await restoreAgent(args[0]);
-    },
-  },
-
-  {
-    name: "import",
-    usage: "opencode <name>",
-    description: "import session from OpenCode",
-    async handler(args) {
-      const source = args[0];
-      if (source === "opencode") {
-        const { importOpenCode } = await import("./import.js");
-        await importOpenCode(args.slice(1));
-        return;
-      }
-      console.error("Usage: kern import opencode [--project <path>] [--session <title|latest>] [--agent <name>]");
-      process.exit(1);
-    },
-  },
-
-  {
-    name: "logs",
-    usage: "[name] [-f] [-n 50] [--level warn]",
-    description: "show agent logs",
-    async handler(args) {
-      let follow: boolean | null = null;
-      let lines = 50;
-      let level: string | null = null;
-      let nameArg: string | undefined;
-      for (let i = 0; i < args.length; i++) {
-        if (args[i] === "-f") follow = true;
-        else if (args[i] === "-n" && args[i + 1]) lines = parseInt(args[++i], 10) || 50;
-        else if (args[i] === "--level" && args[i + 1]) level = args[++i];
-        else if (!args[i].startsWith("-")) nameArg = args[i];
-      }
-
-      const agentDir = await resolveAgentDir(nameArg);
-      const logFile = join(agentDir, ".kern", "logs", "kern.log");
-      if (!existsSync(logFile)) {
-        console.error("No logs yet. Start the agent first.");
-        process.exit(1);
-      }
-
-      const LEVEL_FILTERS: Record<string, string[]> = {
-        debug: [],
-        info: [],
-        warn: ["WRN", "ERR"],
-        error: ["ERR"],
-      };
-      const filterLabels = level ? LEVEL_FILTERS[level] : null;
-      // Default: follow unless -n was specified
-      const shouldFollow = follow !== null ? follow : !args.some((a) => a === "-n");
-
-      if (shouldFollow) {
-        const { spawn } = await import("child_process");
-        if (!filterLabels || filterLabels.length === 0) {
-          const tail = spawn("tail", ["-f", "-n", String(lines), logFile], { stdio: "inherit" });
-          process.on("SIGINT", () => { tail.kill(); process.exit(0); });
-        } else {
-          const pattern = filterLabels.join("\\|");
-          const tail = spawn("sh", ["-c", `tail -f -n +1 "${logFile}" | grep --line-buffered "${pattern}"`], { stdio: "inherit" });
-          process.on("SIGINT", () => { tail.kill(); process.exit(0); });
-        }
-      } else {
-        const content = await readFile(logFile, "utf-8");
-        let allLines = content.trimEnd().split("\n");
-        if (filterLabels && filterLabels.length > 0) {
-          allLines = allLines.filter((l) => filterLabels.some((label) => l.includes(label)));
-        }
-        for (const line of allLines.slice(-lines)) process.stdout.write(line + "\n");
-      }
-    },
-  },
-
-  {
-    name: "install",
-    usage: "[name|--web|--proxy]",
-    description: "install systemd services",
-    async handler(args) {
-      const { install } = await import("./install.js");
-      await install(args[0]);
-    },
-  },
-
-  {
-    name: "uninstall",
-    usage: "[name]",
-    description: "remove systemd services",
-    async handler(args) {
-      const { uninstall } = await import("./install.js");
-      await uninstall(args[0]);
-    },
-  },
-
-  {
-    name: "tui",
-    usage: "[name]",
-    description: "interactive chat",
-    async handler(args) {
-      const { connectTui } = await import("./tui.js");
-      const { isProcessRunning } = await import("../registry.js");
-
-      let agentName = args[0];
-      if (!agentName) {
-        const paths = await loadRegistry();
-        if (paths.length === 0) {
-          console.error("No agents registered. Run 'kern init <name>' first.");
-          process.exit(1);
-        } else if (paths.length === 1) {
-          const info = readAgentInfo(paths[0]);
-          agentName = info?.name || paths[0];
-        } else {
-          const { select } = await import("@inquirer/prompts");
-          const choices = paths.map((p) => {
-            const info = readAgentInfo(p);
-            return { name: info?.name || p, value: info?.name || p };
-          });
-          agentName = await select({ message: "Select agent", choices });
-        }
-      }
-
-      let agent = findAgent(agentName);
-      if (!agent) {
-        console.error(`Agent not found: ${agentName}`);
-        process.exit(1);
-      }
-
-      if (!agent.pid || !isProcessRunning(agent.pid)) {
-        const { startAgent } = await import("./daemon.js");
-        await startAgent(agentName);
-        agent = findAgent(agentName);
-      }
-
-      if (!agent?.port) {
-        console.error(`Cannot determine port for ${agentName}. Is it running?`);
-        process.exit(1);
-      }
-
-      await connectTui(agent.port, agentName, agent.token || undefined);
-    },
-  },
-
-  {
-    name: "run",
-    usage: "[path] [--init-if-needed]",
-    description: "run an agent in the foreground (Docker, dev)",
-    hidden: true,
-    async handler(args) {
-      const initIfNeeded = args.includes("--init-if-needed");
-      const dirArg = args.filter((a) => a !== "--init-if-needed")[0];
-      const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
-
-      if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
-        const { scaffoldAgent, API_KEY_ENV } = await import("./init.js");
-        const name = process.env.KERN_NAME || basename(agentDir);
-        const provider = process.env.KERN_PROVIDER || "openrouter";
-        const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
-        await scaffoldAgent({
-          name, dir: agentDir, provider, envVar, skipStart: true,
-          model: process.env.KERN_MODEL || "anthropic/claude-opus-4.7",
-          apiKey: process.env[envVar] || "",
-          telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
-          slackBotToken: process.env.SLACK_BOT_TOKEN || "",
-          slackAppToken: process.env.SLACK_APP_TOKEN || "",
-        });
-      }
-
-      const { startApp } = await import("../app.js");
-      await startApp(agentDir);
-    },
-  },
-
-  {
-    name: "web",
-    usage: "<run|start|stop|status>",
-    description: "static web UI server",
-    async handler(args) {
-      const subcmd = args[0];
-      if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-        const { getWebServiceStatus } = await import("./install.js");
-        if (getWebServiceStatus() !== null) {
-          const { spawnSync } = await import("child_process");
-          spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
-          return;
-        }
-        const { webStart, webStop } = await import("./web-daemon.js");
-        if (subcmd === "start") await webStart();
-        else if (subcmd === "stop") await webStop();
-        else { await webStop(); await new Promise((r) => setTimeout(r, 500)); await webStart(); }
-      } else if (subcmd === "status") {
-        const { webStatus } = await import("./web-daemon.js");
-        await webStatus();
-      } else if (subcmd === "run") {
-        // Foreground mode for Docker
-        await import("../web.js");
-      } else {
-        console.error("Usage: kern web <run|start|stop|status>");
-        process.exit(1);
-      }
-    },
-  },
-
-  {
-    name: "proxy",
-    usage: "<start|stop|status|token>",
-    description: "authenticated proxy server",
-    async handler(args) {
-      const subcmd = args[0];
-      if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-        const { getProxyServiceStatus } = await import("./install.js");
-        if (getProxyServiceStatus() !== null) {
-          const { spawnSync } = await import("child_process");
-          spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });
-          return;
-        }
-        const { proxyStart, proxyStop } = await import("./proxy-daemon.js");
-        if (subcmd === "start") await proxyStart();
-        else if (subcmd === "stop") await proxyStop();
-        else { await proxyStop(); await new Promise((r) => setTimeout(r, 500)); await proxyStart(); }
-      } else if (subcmd === "status") {
-        const { proxyStatus } = await import("./proxy-daemon.js");
-        await proxyStatus();
-      } else if (subcmd === "token") {
-        const { proxyToken } = await import("./proxy-daemon.js");
-        await proxyToken();
-      } else {
-        console.error("Usage: kern proxy <start|stop|status|token>");
-        process.exit(1);
-      }
-    },
-  },
+  initCommand,
+  listCommand,
+  startCommand,
+  stopCommand,
+  restartCommand,
+  removeCommand,
+  pairCommand,
+  backupCommand,
+  restoreCommand,
+  importCommand,
+  logsCommand,
+  installCommand,
+  uninstallCommand,
+  tuiCommand,
+  runCommand,
+  webCommand,
+  proxyCommand,
 ];
 
-// Lookup by name or alias.
 export function findCommand(name: string): Command | undefined {
   return commands.find((c) => c.name === name || c.aliases?.includes(name));
 }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -8,12 +8,9 @@
 // Each command file still exports a concrete `Command` object; the registry
 // here just knows its shape and where to find it.
 
+// A loaded command is just a handler. All help metadata lives in the
+// CommandEntry below — keeping it in one place prevents drift.
 export interface Command {
-  name: string;
-  aliases?: string[];
-  usage?: string;
-  description: string;
-  hidden?: boolean;
   handler(args: string[]): Promise<void> | void;
 }
 
@@ -90,7 +87,7 @@ export const commands: CommandEntry[] = [
   },
   {
     name: "logs",
-    usage: "[name] [-f] [-n 50] [--level warn]",
+    usage: "[name] [-f|--follow] [-n 50] [--level warn]",
     description: "show agent logs",
     load: async () => (await import("./logs.js")).logsCommand,
   },

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,10 +1,12 @@
 // Registry of kern CLI commands.
 //
-// Each command lives in its own file under src/cli/. Logic modules that
-// predate the command system (init, backup, install, tui, import, status)
-// export both their functions and their Command object from the same file.
-// New commands (start, stop, restart, remove, pair, logs, run, web, proxy)
-// are small files whose entire job is to wrap the relevant logic.
+// Entries are data-only: help metadata plus a `load()` thunk that imports
+// the command's implementation on demand. This keeps `kern --help`, `kern
+// list`, and unknown-command paths from pulling in React/Ink (`tui.tsx`),
+// @inquirer/prompts (`init.ts`), and other heavy deps they don't need.
+//
+// Each command file still exports a concrete `Command` object; the registry
+// here just knows its shape and where to find it.
 
 export interface Command {
   name: string;
@@ -15,42 +17,122 @@ export interface Command {
   handler(args: string[]): Promise<void> | void;
 }
 
-import { initCommand } from "./init.js";
-import { listCommand } from "./status.js";
-import { startCommand } from "./start.js";
-import { stopCommand } from "./stop.js";
-import { restartCommand } from "./restart.js";
-import { removeCommand } from "./remove.js";
-import { pairCommand } from "./pair.js";
-import { backupCommand, restoreCommand } from "./backup.js";
-import { importCommand } from "./import.js";
-import { logsCommand } from "./logs.js";
-import { installCommand, uninstallCommand } from "./install.js";
-import { tuiCommand } from "./tui.js";
-import { runCommand } from "./run.js";
-import { webCommand } from "./web.js";
-import { proxyCommand } from "./proxy.js";
+export interface CommandEntry {
+  name: string;
+  aliases?: string[];
+  usage?: string;
+  description: string;
+  hidden?: boolean;
+  load(): Promise<Command>;
+}
 
-export const commands: Command[] = [
-  initCommand,
-  listCommand,
-  startCommand,
-  stopCommand,
-  restartCommand,
-  removeCommand,
-  pairCommand,
-  backupCommand,
-  restoreCommand,
-  importCommand,
-  logsCommand,
-  installCommand,
-  uninstallCommand,
-  tuiCommand,
-  runCommand,
-  webCommand,
-  proxyCommand,
+export const commands: CommandEntry[] = [
+  {
+    name: "init",
+    usage: "<name>",
+    description: "create or configure an agent",
+    load: async () => (await import("./init.js")).initCommand,
+  },
+  {
+    name: "list",
+    aliases: ["ls", "status"],
+    description: "show all agents",
+    load: async () => (await import("./status.js")).listCommand,
+  },
+  {
+    name: "start",
+    usage: "[name|path]",
+    description: "start agents",
+    load: async () => (await import("./start.js")).startCommand,
+  },
+  {
+    name: "stop",
+    usage: "[name]",
+    description: "stop agents",
+    load: async () => (await import("./stop.js")).stopCommand,
+  },
+  {
+    name: "restart",
+    usage: "[name]",
+    description: "restart agents",
+    load: async () => (await import("./restart.js")).restartCommand,
+  },
+  {
+    name: "remove",
+    usage: "<name>",
+    aliases: ["rm"],
+    description: "unregister an agent",
+    load: async () => (await import("./remove.js")).removeCommand,
+  },
+  {
+    name: "pair",
+    usage: "<agent> <code>",
+    description: "approve a pairing code",
+    load: async () => (await import("./pair.js")).pairCommand,
+  },
+  {
+    name: "backup",
+    usage: "<name>",
+    description: "backup agent to .tar.gz",
+    load: async () => (await import("./backup.js")).backupCommand,
+  },
+  {
+    name: "restore",
+    usage: "<file>",
+    description: "restore agent from backup",
+    load: async () => (await import("./backup.js")).restoreCommand,
+  },
+  {
+    name: "import",
+    usage: "opencode <name>",
+    description: "import session from OpenCode",
+    load: async () => (await import("./import.js")).importCommand,
+  },
+  {
+    name: "logs",
+    usage: "[name] [-f] [-n 50] [--level warn]",
+    description: "show agent logs",
+    load: async () => (await import("./logs.js")).logsCommand,
+  },
+  {
+    name: "install",
+    usage: "[name|--web|--proxy]",
+    description: "install systemd services",
+    load: async () => (await import("./install.js")).installCommand,
+  },
+  {
+    name: "uninstall",
+    usage: "[name]",
+    description: "remove systemd services",
+    load: async () => (await import("./install.js")).uninstallCommand,
+  },
+  {
+    name: "tui",
+    usage: "[name]",
+    description: "interactive chat",
+    load: async () => (await import("./tui.js")).tuiCommand,
+  },
+  {
+    name: "run",
+    usage: "[path] [--init-if-needed]",
+    description: "run an agent in the foreground (Docker, dev)",
+    hidden: true,
+    load: async () => (await import("./run.js")).runCommand,
+  },
+  {
+    name: "web",
+    usage: "<run|start|stop|restart|status>",
+    description: "static web UI server",
+    load: async () => (await import("./web.js")).webCommand,
+  },
+  {
+    name: "proxy",
+    usage: "<start|stop|restart|status|token>",
+    description: "authenticated proxy server",
+    load: async () => (await import("./proxy.js")).proxyCommand,
+  },
 ];
 
-export function findCommand(name: string): Command | undefined {
+export function findCommand(name: string): CommandEntry | undefined {
   return commands.find((c) => c.name === name || c.aliases?.includes(name));
 }

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,445 @@
+// Command table for the kern CLI.
+//
+// Each command owns: its name (+ aliases), a one-line usage hint for help,
+// a short description, and a handler that receives the argv tail (everything
+// after the command name). Handlers lazy-import their deps so startup stays
+// fast — `kern status` should never load the TUI bundle.
+
+import { resolve, basename, join } from "path";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import { findAgent, loadRegistry, readAgentInfo } from "../registry.js";
+
+export type Command = {
+  name: string;
+  aliases?: string[];
+  usage?: string;        // e.g. "<name>" — rendered after the command name in help
+  description: string;   // one-line help text
+  hidden?: boolean;      // skip in help output
+  handler: (args: string[]) => Promise<void>;
+};
+
+// Resolve an agent directory from a name or path, or prompt if multiple exist.
+async function resolveAgentDir(nameOrPath?: string): Promise<string> {
+  if (nameOrPath) {
+    const agent = findAgent(nameOrPath);
+    if (agent) return agent.path;
+
+    const dir = resolve(nameOrPath);
+    if (existsSync(dir) && (existsSync(join(dir, ".kern")) || existsSync(join(dir, "AGENTS.md")))) {
+      return dir;
+    }
+
+    console.error(`Agent not found: ${nameOrPath}`);
+    process.exit(1);
+  }
+
+  const paths = await loadRegistry();
+  if (paths.length === 0) {
+    console.error("No agents registered. Run 'kern init <name>' first.");
+    process.exit(1);
+  }
+  if (paths.length === 1) return paths[0];
+
+  const { select } = await import("@inquirer/prompts");
+  const choices = paths.map((p) => {
+    const info = readAgentInfo(p);
+    return { name: info?.name || p, value: p };
+  });
+  return select({ message: "Select agent", choices });
+}
+
+// Shared: try systemd first, fall back to direct daemon control.
+async function serviceOrDaemon(
+  action: "start" | "stop" | "restart",
+  name: string | undefined,
+): Promise<void> {
+  if (name) {
+    const { isServiceInstalled, serviceControl } = await import("./install.js");
+    if (isServiceInstalled(name)) {
+      const ok = serviceControl(action, name);
+      if (!ok) {
+        console.error(`Failed to ${action} service-managed agent: ${name}`);
+        process.exit(1);
+      }
+      return;
+    }
+  }
+  const { startAgent, stopAgent } = await import("./daemon.js");
+  if (action === "start") await startAgent(name);
+  else if (action === "stop") await stopAgent(name);
+  else {
+    await stopAgent(name);
+    await new Promise((r) => setTimeout(r, 500));
+    await startAgent(name);
+  }
+}
+
+export const commands: Command[] = [
+  {
+    name: "init",
+    usage: "<name>",
+    description: "create or configure an agent",
+    async handler(args) {
+      // Parse --flag value pairs and a positional target
+      const flags: Record<string, string> = {};
+      let target = args[0];
+      for (let i = 0; i < args.length; i++) {
+        if (args[i].startsWith("--") && i + 1 < args.length && !args[i + 1].startsWith("--")) {
+          flags[args[i].slice(2)] = args[i + 1];
+          i++;
+        } else if (!args[i].startsWith("--")) {
+          target = args[i];
+        }
+      }
+      const { runInit } = await import("./init.js");
+      await runInit(target, Object.keys(flags).length > 0 ? flags : undefined);
+    },
+  },
+
+  {
+    name: "list",
+    aliases: ["ls", "status"],
+    description: "show all agents",
+    async handler() {
+      const { showStatus } = await import("./status.js");
+      await showStatus();
+    },
+  },
+
+  {
+    name: "start",
+    usage: "[name|path]",
+    description: "start agents",
+    async handler(args) {
+      await serviceOrDaemon("start", args[0]);
+    },
+  },
+
+  {
+    name: "stop",
+    usage: "[name]",
+    description: "stop agents",
+    async handler(args) {
+      await serviceOrDaemon("stop", args[0]);
+    },
+  },
+
+  {
+    name: "restart",
+    usage: "[name]",
+    description: "restart agents",
+    async handler(args) {
+      await serviceOrDaemon("restart", args[0]);
+    },
+  },
+
+  {
+    name: "remove",
+    aliases: ["rm"],
+    usage: "<name>",
+    description: "unregister an agent",
+    async handler(args) {
+      const name = args[0];
+      if (!name) {
+        console.error("Usage: kern remove <name>");
+        process.exit(1);
+      }
+      const { removeAgent, isProcessRunning } = await import("../registry.js");
+      const agent = findAgent(name);
+      if (!agent) {
+        console.error(`Agent not found: ${name}`);
+        process.exit(1);
+      }
+      const { isServiceInstalled, uninstall } = await import("./install.js");
+      if (isServiceInstalled(name)) await uninstall(name);
+      if (agent.pid && isProcessRunning(agent.pid)) {
+        const { stopAgent } = await import("./daemon.js");
+        await stopAgent(name);
+      }
+      await removeAgent(name);
+      console.log(`  Removed ${name}`);
+    },
+  },
+
+  {
+    name: "pair",
+    usage: "<agent> <code>",
+    description: "approve a pairing code",
+    async handler(args) {
+      const [agentName, code] = args;
+      if (!agentName || !code) {
+        console.error("Usage: kern pair <agent> <code>");
+        process.exit(1);
+      }
+      const { PairingManager } = await import("../pairing.js");
+      const agent = findAgent(agentName);
+      if (!agent) {
+        console.error(`Agent not found: ${agentName}`);
+        process.exit(1);
+      }
+      const pairing = new PairingManager(agent.path);
+      await pairing.load();
+      const result = await pairing.pair(code);
+      if (result) {
+        console.log(`  Paired user ${result.userId} (${result.interface}) to ${agentName}`);
+      } else {
+        console.error(`  Invalid or expired code: ${code}`);
+        process.exit(1);
+      }
+    },
+  },
+
+  {
+    name: "backup",
+    usage: "<name>",
+    description: "backup agent to .tar.gz",
+    async handler(args) {
+      const { backupAgent } = await import("./backup.js");
+      await backupAgent(args[0]);
+    },
+  },
+
+  {
+    name: "restore",
+    usage: "<file>",
+    description: "restore agent from backup",
+    async handler(args) {
+      const { restoreAgent } = await import("./backup.js");
+      await restoreAgent(args[0]);
+    },
+  },
+
+  {
+    name: "import",
+    usage: "opencode <name>",
+    description: "import session from OpenCode",
+    async handler(args) {
+      const source = args[0];
+      if (source === "opencode") {
+        const { importOpenCode } = await import("./import.js");
+        await importOpenCode(args.slice(1));
+        return;
+      }
+      console.error("Usage: kern import opencode [--project <path>] [--session <title|latest>] [--agent <name>]");
+      process.exit(1);
+    },
+  },
+
+  {
+    name: "logs",
+    usage: "[name] [-f] [-n 50] [--level warn]",
+    description: "show agent logs",
+    async handler(args) {
+      let follow: boolean | null = null;
+      let lines = 50;
+      let level: string | null = null;
+      let nameArg: string | undefined;
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === "-f") follow = true;
+        else if (args[i] === "-n" && args[i + 1]) lines = parseInt(args[++i], 10) || 50;
+        else if (args[i] === "--level" && args[i + 1]) level = args[++i];
+        else if (!args[i].startsWith("-")) nameArg = args[i];
+      }
+
+      const agentDir = await resolveAgentDir(nameArg);
+      const logFile = join(agentDir, ".kern", "logs", "kern.log");
+      if (!existsSync(logFile)) {
+        console.error("No logs yet. Start the agent first.");
+        process.exit(1);
+      }
+
+      const LEVEL_FILTERS: Record<string, string[]> = {
+        debug: [],
+        info: [],
+        warn: ["WRN", "ERR"],
+        error: ["ERR"],
+      };
+      const filterLabels = level ? LEVEL_FILTERS[level] : null;
+      // Default: follow unless -n was specified
+      const shouldFollow = follow !== null ? follow : !args.some((a) => a === "-n");
+
+      if (shouldFollow) {
+        const { spawn } = await import("child_process");
+        if (!filterLabels || filterLabels.length === 0) {
+          const tail = spawn("tail", ["-f", "-n", String(lines), logFile], { stdio: "inherit" });
+          process.on("SIGINT", () => { tail.kill(); process.exit(0); });
+        } else {
+          const pattern = filterLabels.join("\\|");
+          const tail = spawn("sh", ["-c", `tail -f -n +1 "${logFile}" | grep --line-buffered "${pattern}"`], { stdio: "inherit" });
+          process.on("SIGINT", () => { tail.kill(); process.exit(0); });
+        }
+      } else {
+        const content = await readFile(logFile, "utf-8");
+        let allLines = content.trimEnd().split("\n");
+        if (filterLabels && filterLabels.length > 0) {
+          allLines = allLines.filter((l) => filterLabels.some((label) => l.includes(label)));
+        }
+        for (const line of allLines.slice(-lines)) process.stdout.write(line + "\n");
+      }
+    },
+  },
+
+  {
+    name: "install",
+    usage: "[name|--web|--proxy]",
+    description: "install systemd services",
+    async handler(args) {
+      const { install } = await import("./install.js");
+      await install(args[0]);
+    },
+  },
+
+  {
+    name: "uninstall",
+    usage: "[name]",
+    description: "remove systemd services",
+    async handler(args) {
+      const { uninstall } = await import("./install.js");
+      await uninstall(args[0]);
+    },
+  },
+
+  {
+    name: "tui",
+    usage: "[name]",
+    description: "interactive chat",
+    async handler(args) {
+      const { connectTui } = await import("./tui.js");
+      const { isProcessRunning } = await import("../registry.js");
+
+      let agentName = args[0];
+      if (!agentName) {
+        const paths = await loadRegistry();
+        if (paths.length === 0) {
+          console.error("No agents registered. Run 'kern init <name>' first.");
+          process.exit(1);
+        } else if (paths.length === 1) {
+          const info = readAgentInfo(paths[0]);
+          agentName = info?.name || paths[0];
+        } else {
+          const { select } = await import("@inquirer/prompts");
+          const choices = paths.map((p) => {
+            const info = readAgentInfo(p);
+            return { name: info?.name || p, value: info?.name || p };
+          });
+          agentName = await select({ message: "Select agent", choices });
+        }
+      }
+
+      let agent = findAgent(agentName);
+      if (!agent) {
+        console.error(`Agent not found: ${agentName}`);
+        process.exit(1);
+      }
+
+      if (!agent.pid || !isProcessRunning(agent.pid)) {
+        const { startAgent } = await import("./daemon.js");
+        await startAgent(agentName);
+        agent = findAgent(agentName);
+      }
+
+      if (!agent?.port) {
+        console.error(`Cannot determine port for ${agentName}. Is it running?`);
+        process.exit(1);
+      }
+
+      await connectTui(agent.port, agentName, agent.token || undefined);
+    },
+  },
+
+  {
+    name: "run",
+    usage: "[path] [--init-if-needed]",
+    description: "run an agent in the foreground (Docker, dev)",
+    hidden: true,
+    async handler(args) {
+      const initIfNeeded = args.includes("--init-if-needed");
+      const dirArg = args.filter((a) => a !== "--init-if-needed")[0];
+      const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
+
+      if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
+        const { scaffoldAgent, API_KEY_ENV } = await import("./init.js");
+        const name = process.env.KERN_NAME || basename(agentDir);
+        const provider = process.env.KERN_PROVIDER || "openrouter";
+        const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
+        await scaffoldAgent({
+          name, dir: agentDir, provider, envVar, skipStart: true,
+          model: process.env.KERN_MODEL || "anthropic/claude-opus-4.7",
+          apiKey: process.env[envVar] || "",
+          telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
+          slackBotToken: process.env.SLACK_BOT_TOKEN || "",
+          slackAppToken: process.env.SLACK_APP_TOKEN || "",
+        });
+      }
+
+      const { startApp } = await import("../app.js");
+      await startApp(agentDir);
+    },
+  },
+
+  {
+    name: "web",
+    usage: "<run|start|stop|status>",
+    description: "static web UI server",
+    async handler(args) {
+      const subcmd = args[0];
+      if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
+        const { getWebServiceStatus } = await import("./install.js");
+        if (getWebServiceStatus() !== null) {
+          const { spawnSync } = await import("child_process");
+          spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
+          return;
+        }
+        const { webStart, webStop } = await import("./web-daemon.js");
+        if (subcmd === "start") await webStart();
+        else if (subcmd === "stop") await webStop();
+        else { await webStop(); await new Promise((r) => setTimeout(r, 500)); await webStart(); }
+      } else if (subcmd === "status") {
+        const { webStatus } = await import("./web-daemon.js");
+        await webStatus();
+      } else if (subcmd === "run") {
+        // Foreground mode for Docker
+        await import("../web.js");
+      } else {
+        console.error("Usage: kern web <run|start|stop|status>");
+        process.exit(1);
+      }
+    },
+  },
+
+  {
+    name: "proxy",
+    usage: "<start|stop|status|token>",
+    description: "authenticated proxy server",
+    async handler(args) {
+      const subcmd = args[0];
+      if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
+        const { getProxyServiceStatus } = await import("./install.js");
+        if (getProxyServiceStatus() !== null) {
+          const { spawnSync } = await import("child_process");
+          spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });
+          return;
+        }
+        const { proxyStart, proxyStop } = await import("./proxy-daemon.js");
+        if (subcmd === "start") await proxyStart();
+        else if (subcmd === "stop") await proxyStop();
+        else { await proxyStop(); await new Promise((r) => setTimeout(r, 500)); await proxyStart(); }
+      } else if (subcmd === "status") {
+        const { proxyStatus } = await import("./proxy-daemon.js");
+        await proxyStatus();
+      } else if (subcmd === "token") {
+        const { proxyToken } = await import("./proxy-daemon.js");
+        await proxyToken();
+      } else {
+        console.error("Usage: kern proxy <start|stop|status|token>");
+        process.exit(1);
+      }
+    },
+  },
+];
+
+// Lookup by name or alias.
+export function findCommand(name: string): Command | undefined {
+  return commands.find((c) => c.name === name || c.aliases?.includes(name));
+}

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -4,7 +4,7 @@ import { existsSync } from "fs";
 import { mkdir } from "fs/promises";
 import { join } from "path";
 import { openSync } from "fs";
-import { findAgent, loadRegistry, registerAgent, readAgentInfo, readPid, writePidFile, removePidFile, isProcessRunning } from "./registry.js";
+import { findAgent, loadRegistry, registerAgent, readAgentInfo, readPid, writePidFile, removePidFile, isProcessRunning } from "../registry.js";
 import { isServiceInstalled } from "./install.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -1,0 +1,61 @@
+// Shared helpers for CLI command handlers.
+
+import { resolve, join } from "path";
+import { existsSync } from "fs";
+import { findAgent, loadRegistry, readAgentInfo } from "../registry.js";
+
+// Resolve an agent directory from a name or path, or prompt if multiple exist.
+export async function resolveAgentDir(nameOrPath?: string): Promise<string> {
+  if (nameOrPath) {
+    const agent = findAgent(nameOrPath);
+    if (agent) return agent.path;
+
+    const dir = resolve(nameOrPath);
+    if (existsSync(dir) && (existsSync(join(dir, ".kern")) || existsSync(join(dir, "AGENTS.md")))) {
+      return dir;
+    }
+
+    console.error(`Agent not found: ${nameOrPath}`);
+    process.exit(1);
+  }
+
+  const paths = await loadRegistry();
+  if (paths.length === 0) {
+    console.error("No agents registered. Run 'kern init <name>' first.");
+    process.exit(1);
+  }
+  if (paths.length === 1) return paths[0];
+
+  const { select } = await import("@inquirer/prompts");
+  const choices = paths.map((p) => {
+    const info = readAgentInfo(p);
+    return { name: info?.name || p, value: p };
+  });
+  return select({ message: "Select agent", choices });
+}
+
+// Try systemd first, fall back to direct daemon control.
+export async function serviceOrDaemon(
+  action: "start" | "stop" | "restart",
+  name: string | undefined,
+): Promise<void> {
+  if (name) {
+    const { isServiceInstalled, serviceControl } = await import("./install.js");
+    if (isServiceInstalled(name)) {
+      const ok = serviceControl(action, name);
+      if (!ok) {
+        console.error(`Failed to ${action} service-managed agent: ${name}`);
+        process.exit(1);
+      }
+      return;
+    }
+  }
+  const { startAgent, stopAgent } = await import("./daemon.js");
+  if (action === "start") await startAgent(name);
+  else if (action === "stop") await stopAgent(name);
+  else {
+    await stopAgent(name);
+    await new Promise((r) => setTimeout(r, 500));
+    await startAgent(name);
+  }
+}

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -3,8 +3,8 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { mkdir, writeFile } from "fs/promises";
 import { homedir } from "os";
-import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
-import { log } from "./log.js";
+import { findAgent, loadRegistry, readAgentInfo } from "../registry.js";
+import { log } from "../log.js";
 
 interface OpenCodeMessage {
   id: string;

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -5,6 +5,7 @@ import { mkdir, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { findAgent, loadRegistry, readAgentInfo } from "../registry.js";
 import { log } from "../log.js";
+import type { Command } from "./commands.js";
 
 interface OpenCodeMessage {
   id: string;
@@ -311,3 +312,20 @@ export async function importOpenCode(args: string[]): Promise<void> {
 
   process.exit(0);
 }
+
+// --- CLI command ---
+
+export const importCommand: Command = {
+  name: "import",
+  usage: "opencode <name>",
+  description: "import session from OpenCode",
+  async handler(args) {
+    const source = args[0];
+    if (source === "opencode") {
+      await importOpenCode(args.slice(1));
+      return;
+    }
+    console.error("Usage: kern import opencode [--project <path>] [--session <title|latest>] [--agent <name>]");
+    process.exit(1);
+  },
+};

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -316,9 +316,6 @@ export async function importOpenCode(args: string[]): Promise<void> {
 // --- CLI command ---
 
 export const importCommand: Command = {
-  name: "import",
-  usage: "opencode <name>",
-  description: "import session from OpenCode",
   async handler(args) {
     const source = args[0];
     if (source === "opencode") {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -2,10 +2,10 @@ import { mkdir, writeFile, readFile } from "fs/promises";
 import { join, resolve, basename } from "path";
 import { existsSync } from "fs";
 import { input, select, password } from "@inquirer/prompts";
-import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "./registry.js";
+import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "../registry.js";
 import { startAgent } from "./daemon.js";
-import type { KernConfig } from "./config.js";
-import { log } from "./log.js";
+import type { KernConfig } from "../config.js";
+import { log } from "../log.js";
 
 // Fallback models used when live fetch fails (e.g. no network, bad key)
 const FALLBACK_MODELS: Record<string, { name: string; value: string }[]> = {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -5,6 +5,7 @@ import { input, select, password } from "@inquirer/prompts";
 import { registerAgent, findAgent, isProcessRunning, readPid, removePidFile, assignPort } from "../registry.js";
 import { startAgent } from "./daemon.js";
 import type { KernConfig } from "../config.js";
+import type { Command } from "./commands.js";
 import { log } from "../log.js";
 
 // Fallback models used when live fetch fails (e.g. no network, bad key)
@@ -546,3 +547,25 @@ node_modules/
   }
 }
 
+
+// --- CLI command ---
+
+export const initCommand: Command = {
+  name: "init",
+  usage: "<name>",
+  description: "create or configure an agent",
+  async handler(args) {
+    // Parse --flag value pairs and a positional target
+    const flags: Record<string, string> = {};
+    let target = args[0];
+    for (let i = 0; i < args.length; i++) {
+      if (args[i].startsWith("--") && i + 1 < args.length && !args[i + 1].startsWith("--")) {
+        flags[args[i].slice(2)] = args[i + 1];
+        i++;
+      } else if (!args[i].startsWith("--")) {
+        target = args[i];
+      }
+    }
+    await runInit(target, Object.keys(flags).length > 0 ? flags : undefined);
+  },
+};

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -551,9 +551,6 @@ node_modules/
 // --- CLI command ---
 
 export const initCommand: Command = {
-  name: "init",
-  usage: "<name>",
-  description: "create or configure an agent",
   async handler(args) {
     // Parse --flag value pairs and a positional target
     const flags: Record<string, string> = {};

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -3,7 +3,7 @@ import { existsSync } from "fs";
 import { mkdir, writeFile, unlink, readFile } from "fs/promises";
 import { join, basename } from "path";
 import { homedir } from "os";
-import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "./registry.js";
+import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "../registry.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -4,6 +4,7 @@ import { mkdir, writeFile, unlink, readFile } from "fs/promises";
 import { join, basename } from "path";
 import { homedir } from "os";
 import { loadRegistry, findAgent, readAgentInfo, isProcessRunning, readPid, removePidFile } from "../registry.js";
+import type { Command } from "./commands.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -376,3 +377,23 @@ export async function uninstall(name?: string): Promise<void> {
   systemctl("daemon-reload");
   w("");
 }
+
+// --- CLI commands ---
+
+export const installCommand: Command = {
+  name: "install",
+  usage: "[name|--web|--proxy]",
+  description: "install systemd services",
+  async handler(args) {
+    await install(args[0]);
+  },
+};
+
+export const uninstallCommand: Command = {
+  name: "uninstall",
+  usage: "[name]",
+  description: "remove systemd services",
+  async handler(args) {
+    await uninstall(args[0]);
+  },
+};

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -381,18 +381,12 @@ export async function uninstall(name?: string): Promise<void> {
 // --- CLI commands ---
 
 export const installCommand: Command = {
-  name: "install",
-  usage: "[name|--web|--proxy]",
-  description: "install systemd services",
   async handler(args) {
     await install(args[0]);
   },
 };
 
 export const uninstallCommand: Command = {
-  name: "uninstall",
-  usage: "[name]",
-  description: "remove systemd services",
   async handler(args) {
     await uninstall(args[0]);
   },

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -13,9 +13,6 @@ const LEVEL_FILTERS: Record<string, string[]> = {
 };
 
 export const logsCommand: Command = {
-  name: "logs",
-  usage: "[name] [-f] [-n 50] [--level warn]",
-  description: "show agent logs",
   async handler(args) {
     let follow: boolean | null = null; // null = auto (follow unless -n)
     let lines = 50;

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,0 +1,71 @@
+import type { Command } from "./commands.js";
+import { resolveAgentDir } from "./helpers.js";
+
+const LEVELS = ["debug", "info", "warn", "error"];
+
+export const logsCommand: Command = {
+  name: "logs",
+  usage: "[name] [-f] [-n 50] [--level warn]",
+  description: "show agent logs",
+  async handler(args) {
+    let agentName: string | undefined;
+    let follow = false;
+    let lines = 50;
+    let minLevel = "info";
+
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg === "-f" || arg === "--follow") {
+        follow = true;
+      } else if (arg === "-n" && i + 1 < args.length) {
+        lines = parseInt(args[++i], 10) || 50;
+      } else if (arg === "--level" && i + 1 < args.length) {
+        minLevel = args[++i];
+      } else if (!arg.startsWith("-")) {
+        agentName = arg;
+      }
+    }
+
+    if (!LEVELS.includes(minLevel)) {
+      console.error(`Invalid level: ${minLevel}. Use: debug, info, warn, error`);
+      process.exit(1);
+    }
+
+    const agentPath = await resolveAgentDir(agentName);
+    const { join } = await import("path");
+    const { existsSync, createReadStream } = await import("fs");
+    const { createInterface } = await import("readline");
+    const logPath = join(agentPath, ".kern", "log.jsonl");
+
+    if (!existsSync(logPath)) {
+      console.error(`No logs yet: ${logPath}`);
+      process.exit(1);
+    }
+
+    const minIdx = LEVELS.indexOf(minLevel);
+    const formatLine = (line: string) => {
+      try {
+        const entry = JSON.parse(line);
+        if (LEVELS.indexOf(entry.level) < minIdx) return null;
+        const ts = entry.ts || new Date().toISOString();
+        const level = (entry.level || "info").toUpperCase().padEnd(5);
+        return `\x1b[2m${ts}\x1b[0m ${level} ${entry.msg || ""}`;
+      } catch {
+        return null;
+      }
+    };
+
+    const { execSync, spawn } = await import("child_process");
+    const tailArgs = ["-n", String(lines)];
+    if (follow) tailArgs.push("-f");
+    tailArgs.push(logPath);
+
+    const child = spawn("tail", tailArgs, { stdio: ["ignore", "pipe", "inherit"] });
+    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+    rl.on("line", (line) => {
+      const out = formatLine(line);
+      if (out) console.log(out);
+    });
+    await new Promise<void>((resolve) => child.on("close", () => resolve()));
+  },
+};

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -1,71 +1,65 @@
+import { readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join } from "path";
 import type { Command } from "./commands.js";
 import { resolveAgentDir } from "./helpers.js";
 
-const LEVELS = ["debug", "info", "warn", "error"];
+// Level → label set. `info`/`debug` show everything (info has no label).
+const LEVEL_FILTERS: Record<string, string[]> = {
+  debug: [],
+  info: [],
+  warn: ["WRN", "ERR"],
+  error: ["ERR"],
+};
 
 export const logsCommand: Command = {
   name: "logs",
   usage: "[name] [-f] [-n 50] [--level warn]",
   description: "show agent logs",
   async handler(args) {
-    let agentName: string | undefined;
-    let follow = false;
+    let follow: boolean | null = null; // null = auto (follow unless -n)
     let lines = 50;
-    let minLevel = "info";
+    let level: string | null = null;
+    let nameArg: string | undefined;
 
     for (let i = 0; i < args.length; i++) {
-      const arg = args[i];
-      if (arg === "-f" || arg === "--follow") {
-        follow = true;
-      } else if (arg === "-n" && i + 1 < args.length) {
-        lines = parseInt(args[++i], 10) || 50;
-      } else if (arg === "--level" && i + 1 < args.length) {
-        minLevel = args[++i];
-      } else if (!arg.startsWith("-")) {
-        agentName = arg;
-      }
+      const a = args[i];
+      if (a === "-f" || a === "--follow") follow = true;
+      else if (a === "-n" && args[i + 1]) lines = parseInt(args[++i], 10) || 50;
+      else if (a === "--level" && args[i + 1]) level = args[++i];
+      else if (!a.startsWith("-")) nameArg = a;
     }
 
-    if (!LEVELS.includes(minLevel)) {
-      console.error(`Invalid level: ${minLevel}. Use: debug, info, warn, error`);
+    const agentDir = await resolveAgentDir(nameArg);
+    const logFile = join(agentDir, ".kern", "logs", "kern.log");
+    if (!existsSync(logFile)) {
+      console.error("No logs yet. Start the agent first.");
       process.exit(1);
     }
 
-    const agentPath = await resolveAgentDir(agentName);
-    const { join } = await import("path");
-    const { existsSync, createReadStream } = await import("fs");
-    const { createInterface } = await import("readline");
-    const logPath = join(agentPath, ".kern", "log.jsonl");
+    const filterLabels = level ? LEVEL_FILTERS[level] : null;
+    // Default: follow unless -n was specified.
+    const shouldFollow = follow !== null ? follow : !args.some((a) => a === "-n");
 
-    if (!existsSync(logPath)) {
-      console.error(`No logs yet: ${logPath}`);
-      process.exit(1);
+    if (shouldFollow) {
+      const { spawn } = await import("child_process");
+      const proc = !filterLabels || filterLabels.length === 0
+        ? spawn("tail", ["-f", "-n", String(lines), logFile], { stdio: "inherit" })
+        : spawn(
+            "sh",
+            ["-c", `tail -f -n +1 "${logFile}" | grep --line-buffered "${filterLabels.join("\\|")}"`],
+            { stdio: "inherit" },
+          );
+      process.on("SIGINT", () => { proc.kill(); process.exit(0); });
+      return;
     }
 
-    const minIdx = LEVELS.indexOf(minLevel);
-    const formatLine = (line: string) => {
-      try {
-        const entry = JSON.parse(line);
-        if (LEVELS.indexOf(entry.level) < minIdx) return null;
-        const ts = entry.ts || new Date().toISOString();
-        const level = (entry.level || "info").toUpperCase().padEnd(5);
-        return `\x1b[2m${ts}\x1b[0m ${level} ${entry.msg || ""}`;
-      } catch {
-        return null;
-      }
-    };
-
-    const { execSync, spawn } = await import("child_process");
-    const tailArgs = ["-n", String(lines)];
-    if (follow) tailArgs.push("-f");
-    tailArgs.push(logPath);
-
-    const child = spawn("tail", tailArgs, { stdio: ["ignore", "pipe", "inherit"] });
-    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
-    rl.on("line", (line) => {
-      const out = formatLine(line);
-      if (out) console.log(out);
-    });
-    await new Promise<void>((resolve) => child.on("close", () => resolve()));
+    // One-shot: read last N (post-filter) lines.
+    const content = await readFile(logFile, "utf-8");
+    let all = content.trimEnd().split("\n");
+    if (filterLabels && filterLabels.length > 0) {
+      all = all.filter((l) => filterLabels.some((label) => l.includes(label)));
+    }
+    for (const line of all.slice(-lines)) process.stdout.write(line + "\n");
   },
 };

--- a/src/cli/logs.ts
+++ b/src/cli/logs.ts
@@ -43,14 +43,18 @@ export const logsCommand: Command = {
 
     if (shouldFollow) {
       const { spawn } = await import("child_process");
-      const proc = !filterLabels || filterLabels.length === 0
-        ? spawn("tail", ["-f", "-n", String(lines), logFile], { stdio: "inherit" })
-        : spawn(
-            "sh",
-            ["-c", `tail -f -n +1 "${logFile}" | grep --line-buffered "${filterLabels.join("\\|")}"`],
-            { stdio: "inherit" },
-          );
-      process.on("SIGINT", () => { proc.kill(); process.exit(0); });
+      if (!filterLabels || filterLabels.length === 0) {
+        const tail = spawn("tail", ["-f", "-n", String(lines), logFile], { stdio: "inherit" });
+        process.on("SIGINT", () => { tail.kill(); process.exit(0); });
+      } else {
+        // Pipe tail → grep without going through a shell, so the agent
+        // directory path is never interpolated into a command string.
+        const tail = spawn("tail", ["-f", "-n", String(lines), logFile], { stdio: ["ignore", "pipe", "inherit"] });
+        const grep = spawn("grep", ["--line-buffered", "-E", filterLabels.join("|")], {
+          stdio: [tail.stdout!, "inherit", "inherit"],
+        });
+        process.on("SIGINT", () => { tail.kill(); grep.kill(); process.exit(0); });
+      }
       return;
     }
 

--- a/src/cli/pair.ts
+++ b/src/cli/pair.ts
@@ -1,0 +1,30 @@
+import type { Command } from "./commands.js";
+import { findAgent } from "../registry.js";
+
+export const pairCommand: Command = {
+  name: "pair",
+  usage: "<agent> <code>",
+  description: "approve a pairing code",
+  async handler(args) {
+    const [agentName, code] = args;
+    if (!agentName || !code) {
+      console.error("Usage: kern pair <agent> <code>");
+      process.exit(1);
+    }
+    const { PairingManager } = await import("../pairing.js");
+    const agent = findAgent(agentName);
+    if (!agent) {
+      console.error(`Agent not found: ${agentName}`);
+      process.exit(1);
+    }
+    const pairing = new PairingManager(agent.path);
+    await pairing.load();
+    const result = await pairing.pair(code);
+    if (result) {
+      console.log(`  Paired user ${result.userId} (${result.interface}) to ${agentName}`);
+    } else {
+      console.error(`  Invalid or expired code: ${code}`);
+      process.exit(1);
+    }
+  },
+};

--- a/src/cli/pair.ts
+++ b/src/cli/pair.ts
@@ -2,9 +2,6 @@ import type { Command } from "./commands.js";
 import { findAgent } from "../registry.js";
 
 export const pairCommand: Command = {
-  name: "pair",
-  usage: "<agent> <code>",
-  description: "approve a pairing code",
   async handler(args) {
     const [agentName, code] = args;
     if (!agentName || !code) {

--- a/src/cli/proxy-daemon.ts
+++ b/src/cli/proxy-daemon.ts
@@ -3,8 +3,8 @@ import { readFile, writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync, openSync } from "fs";
 import { homedir } from "os";
-import { isProcessRunning } from "./registry.js";
-import { loadGlobalConfig } from "./global-config.js";
+import { isProcessRunning } from "../registry.js";
+import { loadGlobalConfig, getProxyToken } from "../global-config.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -12,8 +12,8 @@ const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
 const KERN_DIR = join(homedir(), ".kern");
-const PID_FILE = join(KERN_DIR, "web.pid");
-const LOG_FILE = join(KERN_DIR, "web.log");
+const PID_FILE = join(KERN_DIR, "proxy.pid");
+const LOG_FILE = join(KERN_DIR, "proxy.log");
 
 async function readPid(): Promise<number | null> {
   if (!existsSync(PID_FILE)) return null;
@@ -25,22 +25,23 @@ async function readPid(): Promise<number | null> {
   }
 }
 
-export async function webStart(): Promise<void> {
+export async function proxyStart(): Promise<void> {
   const config = await loadGlobalConfig();
-  const port = config.web_port;
+  const port = config.proxy_port;
+  const token = await getProxyToken();
 
   const pid = await readPid();
   if (pid && isProcessRunning(pid)) {
-    console.log(`\n  ${green("●")} ${bold("web")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}\n`);
+    console.log(`\n  ${green("●")} ${bold("proxy")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}?token=${token}\n`);
     return;
   }
 
   await mkdir(KERN_DIR, { recursive: true });
   const logFd = openSync(LOG_FILE, "a");
-  const webEntry = join(import.meta.dirname, "web.js");
+  const proxyEntry = join(import.meta.dirname, "proxy.js");
 
-  const child = spawn("node", ["--no-deprecation", webEntry], {
+  const child = spawn("node", ["--no-deprecation", proxyEntry], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
   });
@@ -52,11 +53,11 @@ export async function webStart(): Promise<void> {
   await new Promise((r) => setTimeout(r, 1000));
 
   if (isProcessRunning(newPid)) {
-    console.log(`\n  ${green("●")} ${bold("web")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}\n`);
+    console.log(`\n  ${green("●")} ${bold("proxy")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}?token=${token}\n`);
   } else {
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("web")} failed to start\n`);
+    console.log(`\n  ${red("●")} ${bold("proxy")} failed to start\n`);
     try {
       const log = await readFile(LOG_FILE, "utf-8");
       const lines = log.trim().split("\n").slice(-5);
@@ -67,10 +68,10 @@ export async function webStart(): Promise<void> {
   }
 }
 
-export async function webStop(): Promise<void> {
+export async function proxyStop(): Promise<void> {
   const pid = await readPid();
   if (!pid || !isProcessRunning(pid)) {
-    console.log(`\n  ${dim("●")} ${bold("web")} not running\n`);
+    console.log(`\n  ${dim("●")} ${bold("proxy")} not running\n`);
     try { await unlink(PID_FILE); } catch {}
     return;
   }
@@ -78,16 +79,16 @@ export async function webStop(): Promise<void> {
   try {
     process.kill(pid, "SIGTERM");
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("web")} stopped ${dim(`(was pid ${pid})`)}\n`);
+    console.log(`\n  ${red("●")} ${bold("proxy")} stopped ${dim(`(was pid ${pid})`)}\n`);
   } catch (e: any) {
-    console.error(`  Failed to stop web: ${e.message}`);
+    console.error(`  Failed to stop proxy: ${e.message}`);
   }
 }
 
-export async function webStatus(): Promise<void> {
+export async function proxyStatus(): Promise<void> {
   const config = await loadGlobalConfig();
-  const { getWebServiceStatus } = await import("./install.js");
-  const installStatus = getWebServiceStatus();
+  const { getProxyServiceStatus } = await import("./install.js");
+  const installStatus = getProxyServiceStatus();
 
   const pid = await readPid();
   const pidRunning = pid && isProcessRunning(pid);
@@ -95,12 +96,18 @@ export async function webStatus(): Promise<void> {
   const mode = installStatus ? "systemd" : pidRunning ? "daemon" : "—";
 
   if (running) {
-    console.log(`\n  ${green("●")} ${bold("web")} running ${dim(`(:${config.web_port})`)}`);
+    console.log(`\n  ${green("●")} ${bold("proxy")} running ${dim(`(:${config.proxy_port})`)}`);
   } else {
-    console.log(`\n  ${dim("●")} ${bold("web")} stopped`);
+    console.log(`\n  ${dim("●")} ${bold("proxy")} stopped`);
     if (pid) {
       try { await unlink(PID_FILE); } catch {}
     }
   }
   console.log(`    ${dim("mode:")} ${mode}\n`);
+}
+
+export async function proxyToken(): Promise<void> {
+  const config = await loadGlobalConfig();
+  const token = await getProxyToken();
+  console.log(`\n  → http://localhost:${config.proxy_port}?token=${token}\n`);
 }

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -10,7 +10,12 @@ export const proxyCommand: Command = {
       const { getProxyServiceStatus } = await import("./install.js");
       if (getProxyServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
-        spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });
+        const result = spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "inherit" });
+        if (result.error) {
+          console.error("systemctl failed:", result.error.message);
+          process.exit(1);
+        }
+        if (result.status !== 0) process.exit(result.status ?? 1);
         return;
       }
       const { proxyStart, proxyStop } = await import("./proxy-daemon.js");

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -1,0 +1,31 @@
+import type { Command } from "./commands.js";
+
+export const proxyCommand: Command = {
+  name: "proxy",
+  usage: "<start|stop|status|token>",
+  description: "authenticated proxy server",
+  async handler(args) {
+    const subcmd = args[0];
+    if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
+      const { getProxyServiceStatus } = await import("./install.js");
+      if (getProxyServiceStatus() !== null) {
+        const { spawnSync } = await import("child_process");
+        spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });
+        return;
+      }
+      const { proxyStart, proxyStop } = await import("./proxy-daemon.js");
+      if (subcmd === "start") await proxyStart();
+      else if (subcmd === "stop") await proxyStop();
+      else { await proxyStop(); await new Promise((r) => setTimeout(r, 500)); await proxyStart(); }
+    } else if (subcmd === "status") {
+      const { proxyStatus } = await import("./proxy-daemon.js");
+      await proxyStatus();
+    } else if (subcmd === "token") {
+      const { proxyToken } = await import("./proxy-daemon.js");
+      await proxyToken();
+    } else {
+      console.error("Usage: kern proxy <start|stop|status|token>");
+      process.exit(1);
+    }
+  },
+};

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -1,9 +1,6 @@
 import type { Command } from "./commands.js";
 
 export const proxyCommand: Command = {
-  name: "proxy",
-  usage: "<start|stop|restart|status|token>",
-  description: "authenticated proxy server",
   async handler(args) {
     const subcmd = args[0];
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -2,7 +2,7 @@ import type { Command } from "./commands.js";
 
 export const proxyCommand: Command = {
   name: "proxy",
-  usage: "<start|stop|status|token>",
+  usage: "<start|stop|restart|status|token>",
   description: "authenticated proxy server",
   async handler(args) {
     const subcmd = args[0];
@@ -24,7 +24,7 @@ export const proxyCommand: Command = {
       const { proxyToken } = await import("./proxy-daemon.js");
       await proxyToken();
     } else {
-      console.error("Usage: kern proxy <start|stop|status|token>");
+      console.error("Usage: kern proxy <start|stop|restart|status|token>");
       process.exit(1);
     }
   },

--- a/src/cli/remove.ts
+++ b/src/cli/remove.ts
@@ -1,0 +1,30 @@
+import type { Command } from "./commands.js";
+import { findAgent } from "../registry.js";
+
+export const removeCommand: Command = {
+  name: "remove",
+  aliases: ["rm"],
+  usage: "<name>",
+  description: "unregister an agent",
+  async handler(args) {
+    const name = args[0];
+    if (!name) {
+      console.error("Usage: kern remove <name>");
+      process.exit(1);
+    }
+    const { removeAgent, isProcessRunning } = await import("../registry.js");
+    const agent = findAgent(name);
+    if (!agent) {
+      console.error(`Agent not found: ${name}`);
+      process.exit(1);
+    }
+    const { isServiceInstalled, uninstall } = await import("./install.js");
+    if (isServiceInstalled(name)) await uninstall(name);
+    if (agent.pid && isProcessRunning(agent.pid)) {
+      const { stopAgent } = await import("./daemon.js");
+      await stopAgent(name);
+    }
+    await removeAgent(name);
+    console.log(`  Removed ${name}`);
+  },
+};

--- a/src/cli/remove.ts
+++ b/src/cli/remove.ts
@@ -2,10 +2,6 @@ import type { Command } from "./commands.js";
 import { findAgent } from "../registry.js";
 
 export const removeCommand: Command = {
-  name: "remove",
-  aliases: ["rm"],
-  usage: "<name>",
-  description: "unregister an agent",
   async handler(args) {
     const name = args[0];
     if (!name) {

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -2,9 +2,6 @@ import type { Command } from "./commands.js";
 import { serviceOrDaemon } from "./helpers.js";
 
 export const restartCommand: Command = {
-  name: "restart",
-  usage: "[name]",
-  description: "restart agents",
   async handler(args) {
     await serviceOrDaemon("restart", args[0]);
   },

--- a/src/cli/restart.ts
+++ b/src/cli/restart.ts
@@ -1,0 +1,11 @@
+import type { Command } from "./commands.js";
+import { serviceOrDaemon } from "./helpers.js";
+
+export const restartCommand: Command = {
+  name: "restart",
+  usage: "[name]",
+  description: "restart agents",
+  async handler(args) {
+    await serviceOrDaemon("restart", args[0]);
+  },
+};

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,0 +1,34 @@
+import type { Command } from "./commands.js";
+import { resolve, join, basename } from "path";
+import { existsSync } from "fs";
+import { resolveAgentDir } from "./helpers.js";
+
+export const runCommand: Command = {
+  name: "run",
+  usage: "[path] [--init-if-needed]",
+  description: "run an agent in the foreground (Docker, dev)",
+  hidden: true,
+  async handler(args) {
+    const initIfNeeded = args.includes("--init-if-needed");
+    const dirArg = args.filter((a) => a !== "--init-if-needed")[0];
+    const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
+
+    if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
+      const { scaffoldAgent, API_KEY_ENV } = await import("./init.js");
+      const name = process.env.KERN_NAME || basename(agentDir);
+      const provider = process.env.KERN_PROVIDER || "openrouter";
+      const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
+      await scaffoldAgent({
+        name, dir: agentDir, provider, envVar, skipStart: true,
+        model: process.env.KERN_MODEL || "anthropic/claude-opus-4.7",
+        apiKey: process.env[envVar] || "",
+        telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
+        slackBotToken: process.env.SLACK_BOT_TOKEN || "",
+        slackAppToken: process.env.SLACK_APP_TOKEN || "",
+      });
+    }
+
+    const { startApp } = await import("../app.js");
+    await startApp(agentDir);
+  },
+};

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -4,10 +4,6 @@ import { existsSync } from "fs";
 import { resolveAgentDir } from "./helpers.js";
 
 export const runCommand: Command = {
-  name: "run",
-  usage: "[path] [--init-if-needed]",
-  description: "run an agent in the foreground (Docker, dev)",
-  hidden: true,
   async handler(args) {
     const initIfNeeded = args.includes("--init-if-needed");
     const dirArg = args.filter((a) => a !== "--init-if-needed")[0];

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -2,9 +2,6 @@ import type { Command } from "./commands.js";
 import { serviceOrDaemon } from "./helpers.js";
 
 export const startCommand: Command = {
-  name: "start",
-  usage: "[name|path]",
-  description: "start agents",
   async handler(args) {
     await serviceOrDaemon("start", args[0]);
   },

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,0 +1,11 @@
+import type { Command } from "./commands.js";
+import { serviceOrDaemon } from "./helpers.js";
+
+export const startCommand: Command = {
+  name: "start",
+  usage: "[name|path]",
+  description: "start agents",
+  async handler(args) {
+    await serviceOrDaemon("start", args[0]);
+  },
+};

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,6 +1,6 @@
-import { loadRegistry, readAgentInfo, isProcessRunning } from "./registry.js";
+import { loadRegistry, readAgentInfo, isProcessRunning } from "../registry.js";
 import { getServiceStatus, getWebServiceStatus } from "./install.js";
-import { loadGlobalConfig } from "./global-config.js";
+import { loadGlobalConfig } from "../global-config.js";
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join, basename } from "path";

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -131,9 +131,6 @@ export async function showStatus(): Promise<void> {
 // --- CLI command ---
 
 export const listCommand: Command = {
-  name: "list",
-  aliases: ["ls", "status"],
-  description: "show all agents",
   async handler() {
     await showStatus();
   },

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -5,6 +5,7 @@ import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join, basename } from "path";
 import { homedir } from "os";
+import type { Command } from "./commands.js";
 
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
@@ -126,3 +127,14 @@ export async function showStatus(): Promise<void> {
     } catch {}
   }
 }
+
+// --- CLI command ---
+
+export const listCommand: Command = {
+  name: "list",
+  aliases: ["ls", "status"],
+  description: "show all agents",
+  async handler() {
+    await showStatus();
+  },
+};

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -1,0 +1,11 @@
+import type { Command } from "./commands.js";
+import { serviceOrDaemon } from "./helpers.js";
+
+export const stopCommand: Command = {
+  name: "stop",
+  usage: "[name]",
+  description: "stop agents",
+  async handler(args) {
+    await serviceOrDaemon("stop", args[0]);
+  },
+};

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -2,9 +2,6 @@ import type { Command } from "./commands.js";
 import { serviceOrDaemon } from "./helpers.js";
 
 export const stopCommand: Command = {
-  name: "stop",
-  usage: "[name]",
-  description: "stop agents",
   async handler(args) {
     await serviceOrDaemon("stop", args[0]);
   },

--- a/src/cli/tui.tsx
+++ b/src/cli/tui.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from "react";
 import { render, Box, Text, Static, useInput, useApp, useStdout } from "ink";
 // @ts-ignore
 import Spinner from "ink-spinner";
-import type { ServerEvent } from "./server.js";
-import { findAgent } from "./registry.js";
+import type { ServerEvent } from "../server.js";
+import { findAgent } from "../registry.js";
 
 // --- Types ---
 
@@ -523,7 +523,7 @@ function App({ port, agentName, version, authToken }: TuiProps) {
         }
         if (!aborted) {
           setConnected(false);
-          import("./registry.js").then(async ({ findAgent, isProcessRunning }) => {
+          import("../registry.js").then(async ({ findAgent, isProcessRunning }) => {
             const agent = await findAgent(agentName);
             if (agent?.port && agent.port !== currentPort && agent.pid && isProcessRunning(agent.pid)) {
               setCurrentPort(agent.port);
@@ -535,7 +535,7 @@ function App({ port, agentName, version, authToken }: TuiProps) {
       } catch {
         if (!aborted) {
           setConnected(false);
-          import("./registry.js").then(async ({ findAgent, isProcessRunning }) => {
+          import("../registry.js").then(async ({ findAgent, isProcessRunning }) => {
             const agent = await findAgent(agentName);
             if (agent?.port && agent.port !== currentPort && agent.pid && isProcessRunning(agent.pid)) {
               setCurrentPort(agent.port);

--- a/src/cli/tui.tsx
+++ b/src/cli/tui.tsx
@@ -666,9 +666,6 @@ export async function connectTui(port: number, agentName: string, authToken?: st
 // --- CLI command ---
 
 export const tuiCommand: Command = {
-  name: "tui",
-  usage: "[name]",
-  description: "interactive chat",
   async handler(args) {
     let agentName = args[0];
     if (!agentName) {

--- a/src/cli/tui.tsx
+++ b/src/cli/tui.tsx
@@ -3,7 +3,8 @@ import { render, Box, Text, Static, useInput, useApp, useStdout } from "ink";
 // @ts-ignore
 import Spinner from "ink-spinner";
 import type { ServerEvent } from "../server.js";
-import { findAgent } from "../registry.js";
+import { findAgent, loadRegistry, readAgentInfo, isProcessRunning } from "../registry.js";
+import type { Command } from "./commands.js";
 
 // --- Types ---
 
@@ -661,3 +662,50 @@ export async function connectTui(port: number, agentName: string, authToken?: st
   process.stdout.write(`\n  ${bold("kern")} ${dim("v" + version)} · ${agentName}${model ? " · " + model : ""} · ${dim("running")}\n\n`);
   process.exit(0);
 }
+
+// --- CLI command ---
+
+export const tuiCommand: Command = {
+  name: "tui",
+  usage: "[name]",
+  description: "interactive chat",
+  async handler(args) {
+    let agentName = args[0];
+    if (!agentName) {
+      const paths = await loadRegistry();
+      if (paths.length === 0) {
+        console.error("No agents registered. Run 'kern init <name>' first.");
+        process.exit(1);
+      } else if (paths.length === 1) {
+        const info = readAgentInfo(paths[0]);
+        agentName = info?.name || paths[0];
+      } else {
+        const { select } = await import("@inquirer/prompts");
+        const choices = paths.map((p) => {
+          const info = readAgentInfo(p);
+          return { name: info?.name || p, value: info?.name || p };
+        });
+        agentName = await select({ message: "Select agent", choices });
+      }
+    }
+
+    let agent = findAgent(agentName);
+    if (!agent) {
+      console.error(`Agent not found: ${agentName}`);
+      process.exit(1);
+    }
+
+    if (!agent.pid || !isProcessRunning(agent.pid)) {
+      const { startAgent } = await import("./daemon.js");
+      await startAgent(agentName);
+      agent = findAgent(agentName);
+    }
+
+    if (!agent?.port) {
+      console.error(`Cannot determine port for ${agentName}. Is it running?`);
+      process.exit(1);
+    }
+
+    await connectTui(agent.port, agentName, agent.token || undefined);
+  },
+};

--- a/src/cli/web-daemon.ts
+++ b/src/cli/web-daemon.ts
@@ -3,8 +3,8 @@ import { readFile, writeFile, unlink, mkdir } from "fs/promises";
 import { join } from "path";
 import { existsSync, openSync } from "fs";
 import { homedir } from "os";
-import { isProcessRunning } from "./registry.js";
-import { loadGlobalConfig, getProxyToken } from "./global-config.js";
+import { isProcessRunning } from "../registry.js";
+import { loadGlobalConfig } from "../global-config.js";
 
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
 const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
@@ -12,8 +12,8 @@ const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
 const KERN_DIR = join(homedir(), ".kern");
-const PID_FILE = join(KERN_DIR, "proxy.pid");
-const LOG_FILE = join(KERN_DIR, "proxy.log");
+const PID_FILE = join(KERN_DIR, "web.pid");
+const LOG_FILE = join(KERN_DIR, "web.log");
 
 async function readPid(): Promise<number | null> {
   if (!existsSync(PID_FILE)) return null;
@@ -25,23 +25,22 @@ async function readPid(): Promise<number | null> {
   }
 }
 
-export async function proxyStart(): Promise<void> {
+export async function webStart(): Promise<void> {
   const config = await loadGlobalConfig();
-  const port = config.proxy_port;
-  const token = await getProxyToken();
+  const port = config.web_port;
 
   const pid = await readPid();
   if (pid && isProcessRunning(pid)) {
-    console.log(`\n  ${green("●")} ${bold("proxy")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    console.log(`\n  ${green("●")} ${bold("web")} already running ${dim(`(pid ${pid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}\n`);
     return;
   }
 
   await mkdir(KERN_DIR, { recursive: true });
   const logFd = openSync(LOG_FILE, "a");
-  const proxyEntry = join(import.meta.dirname, "proxy.js");
+  const webEntry = join(import.meta.dirname, "web.js");
 
-  const child = spawn("node", ["--no-deprecation", proxyEntry], {
+  const child = spawn("node", ["--no-deprecation", webEntry], {
     detached: true,
     stdio: ["ignore", logFd, logFd],
   });
@@ -53,11 +52,11 @@ export async function proxyStart(): Promise<void> {
   await new Promise((r) => setTimeout(r, 1000));
 
   if (isProcessRunning(newPid)) {
-    console.log(`\n  ${green("●")} ${bold("proxy")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
-    console.log(`  → http://localhost:${port}?token=${token}\n`);
+    console.log(`\n  ${green("●")} ${bold("web")} started ${dim(`(pid ${newPid}, port ${port})`)}`);
+    console.log(`  → http://localhost:${port}\n`);
   } else {
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("proxy")} failed to start\n`);
+    console.log(`\n  ${red("●")} ${bold("web")} failed to start\n`);
     try {
       const log = await readFile(LOG_FILE, "utf-8");
       const lines = log.trim().split("\n").slice(-5);
@@ -68,10 +67,10 @@ export async function proxyStart(): Promise<void> {
   }
 }
 
-export async function proxyStop(): Promise<void> {
+export async function webStop(): Promise<void> {
   const pid = await readPid();
   if (!pid || !isProcessRunning(pid)) {
-    console.log(`\n  ${dim("●")} ${bold("proxy")} not running\n`);
+    console.log(`\n  ${dim("●")} ${bold("web")} not running\n`);
     try { await unlink(PID_FILE); } catch {}
     return;
   }
@@ -79,16 +78,16 @@ export async function proxyStop(): Promise<void> {
   try {
     process.kill(pid, "SIGTERM");
     try { await unlink(PID_FILE); } catch {}
-    console.log(`\n  ${red("●")} ${bold("proxy")} stopped ${dim(`(was pid ${pid})`)}\n`);
+    console.log(`\n  ${red("●")} ${bold("web")} stopped ${dim(`(was pid ${pid})`)}\n`);
   } catch (e: any) {
-    console.error(`  Failed to stop proxy: ${e.message}`);
+    console.error(`  Failed to stop web: ${e.message}`);
   }
 }
 
-export async function proxyStatus(): Promise<void> {
+export async function webStatus(): Promise<void> {
   const config = await loadGlobalConfig();
-  const { getProxyServiceStatus } = await import("./install.js");
-  const installStatus = getProxyServiceStatus();
+  const { getWebServiceStatus } = await import("./install.js");
+  const installStatus = getWebServiceStatus();
 
   const pid = await readPid();
   const pidRunning = pid && isProcessRunning(pid);
@@ -96,18 +95,12 @@ export async function proxyStatus(): Promise<void> {
   const mode = installStatus ? "systemd" : pidRunning ? "daemon" : "—";
 
   if (running) {
-    console.log(`\n  ${green("●")} ${bold("proxy")} running ${dim(`(:${config.proxy_port})`)}`);
+    console.log(`\n  ${green("●")} ${bold("web")} running ${dim(`(:${config.web_port})`)}`);
   } else {
-    console.log(`\n  ${dim("●")} ${bold("proxy")} stopped`);
+    console.log(`\n  ${dim("●")} ${bold("web")} stopped`);
     if (pid) {
       try { await unlink(PID_FILE); } catch {}
     }
   }
   console.log(`    ${dim("mode:")} ${mode}\n`);
-}
-
-export async function proxyToken(): Promise<void> {
-  const config = await loadGlobalConfig();
-  const token = await getProxyToken();
-  console.log(`\n  → http://localhost:${config.proxy_port}?token=${token}\n`);
 }

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -10,7 +10,12 @@ export const webCommand: Command = {
       const { getWebServiceStatus } = await import("./install.js");
       if (getWebServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
-        spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
+        const result = spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "inherit" });
+        if (result.error) {
+          console.error("systemctl failed:", result.error.message);
+          process.exit(1);
+        }
+        if (result.status !== 0) process.exit(result.status ?? 1);
         return;
       }
       const { webStart, webStop } = await import("./web-daemon.js");

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -1,0 +1,31 @@
+import type { Command } from "./commands.js";
+
+export const webCommand: Command = {
+  name: "web",
+  usage: "<run|start|stop|status>",
+  description: "static web UI server",
+  async handler(args) {
+    const subcmd = args[0];
+    if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
+      const { getWebServiceStatus } = await import("./install.js");
+      if (getWebServiceStatus() !== null) {
+        const { spawnSync } = await import("child_process");
+        spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
+        return;
+      }
+      const { webStart, webStop } = await import("./web-daemon.js");
+      if (subcmd === "start") await webStart();
+      else if (subcmd === "stop") await webStop();
+      else { await webStop(); await new Promise((r) => setTimeout(r, 500)); await webStart(); }
+    } else if (subcmd === "status") {
+      const { webStatus } = await import("./web-daemon.js");
+      await webStatus();
+    } else if (subcmd === "run") {
+      // Foreground mode for Docker
+      await import("../web.js");
+    } else {
+      console.error("Usage: kern web <run|start|stop|status>");
+      process.exit(1);
+    }
+  },
+};

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -2,7 +2,7 @@ import type { Command } from "./commands.js";
 
 export const webCommand: Command = {
   name: "web",
-  usage: "<run|start|stop|status>",
+  usage: "<run|start|stop|restart|status>",
   description: "static web UI server",
   async handler(args) {
     const subcmd = args[0];
@@ -24,7 +24,7 @@ export const webCommand: Command = {
       // Foreground mode for Docker
       await import("../web.js");
     } else {
-      console.error("Usage: kern web <run|start|stop|status>");
+      console.error("Usage: kern web <run|start|stop|restart|status>");
       process.exit(1);
     }
   },

--- a/src/cli/web.ts
+++ b/src/cli/web.ts
@@ -1,9 +1,6 @@
 import type { Command } from "./commands.js";
 
 export const webCommand: Command = {
-  name: "web",
-  usage: "<run|start|stop|restart|status>",
-  description: "static web UI server",
   async handler(args) {
     const subcmd = args[0];
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,9 @@ async function main() {
 
   const impl = await command.load();
   await impl.handler(args.slice(1));
-  process.exit(0);
+  // Don't force exit: long-running commands (logs -f, web run, proxy run)
+  // keep handles open and need Node to stay alive until they close. Short
+  // commands have no open handles and exit naturally.
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,8 @@ async function main() {
     process.exit(1);
   }
 
-  await command.handler(args.slice(1));
+  const impl = await command.load();
+  await impl.handler(args.slice(1));
   process.exit(0);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env -S node --no-deprecation
 
-import { resolve, basename } from "path";
-import { existsSync } from "fs";
-import { startApp } from "./app.js";
-import { runInit } from "./cli/init.js";
-import { showStatus } from "./cli/status.js";
-import { startAgent, stopAgent } from "./cli/daemon.js";
-import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
+// kern CLI entrypoint.
+//
+// This is intentionally thin: parse argv, look up the command in the table
+// declared in src/cli/commands.ts, run its handler. Help text is generated
+// from the same table, so it can't drift.
+
 import { readFile } from "fs/promises";
 import { join } from "path";
+import { commands, findCommand } from "./cli/commands.js";
 
 const args = process.argv.slice(2);
 const cmd = args[0];
@@ -31,58 +31,20 @@ async function showHelp() {
   w(`  ${dim("One agent. One folder. One continuous conversation.")}`);
   w("");
   w(`  ${yellow("Commands")}`);
-  w(`    ${cyan("kern init")} ${dim("<name>")}            create or configure an agent`);
-  w(`    ${cyan("kern start")} ${dim("[name|path]")}      start agents`);
-  w(`    ${cyan("kern stop")} ${dim("[name]")}            stop agents`);
-  w(`    ${cyan("kern restart")} ${dim("[name]")}         restart agents`);
-  w(`    ${cyan("kern list")}                   show all agents`);
-  w(`    ${cyan("kern remove")} ${dim("<name>")}          unregister an agent`);
-  w(`    ${cyan("kern pair")} ${dim("<agent> <code>")}    approve a pairing code`);
-  w(`    ${cyan("kern backup")} ${dim("<name>")}          backup agent to .tar.gz`);
-  w(`    ${cyan("kern import")} ${dim("opencode <name>")}  import session from OpenCode`);
-  w(`    ${cyan("kern restore")} ${dim("<file>")}         restore agent from backup`);
-  w(`    ${cyan("kern logs")} ${dim("[name] [-f] [-n 50] [--level warn]")}  show agent logs`);
-  w(`    ${cyan("kern install")} ${dim("[name|--web|--proxy]")} install systemd services`);
-  w(`    ${cyan("kern uninstall")} ${dim("[name]")}        remove systemd services`);
-  w(`    ${cyan("kern tui")} ${dim("[name]")}             interactive chat`);
-  w(`    ${cyan("kern web")} ${dim("<run|start|stop|status>")}     static web UI server`);
-  w(`    ${cyan("kern proxy")} ${dim("<start|stop|status|token>")} authenticated proxy server`);
-  w("");
-}
 
-async function resolveAgentDir(nameOrPath?: string): Promise<string> {
-  if (nameOrPath) {
-    // Check registry
-    const agent = findAgent(nameOrPath);
-    if (agent) return agent.path;
+  // Compute padding so the descriptions line up.
+  const visible = commands.filter((c) => !c.hidden);
+  const left = visible.map((c) => `kern ${c.name}${c.usage ? " " + c.usage : ""}`);
+  const maxWidth = Math.max(...left.map((s) => s.length));
 
-    // Check path
-    const dir = resolve(nameOrPath);
-    if (existsSync(dir) && (existsSync(join(dir, ".kern")) || existsSync(join(dir, "AGENTS.md")))) {
-      return dir;
-    }
-
-    console.error(`Agent not found: ${nameOrPath}`);
-    process.exit(1);
-  }
-
-  // No arg — auto-select
-  const paths = await loadRegistry();
-  if (paths.length === 0) {
-    console.error("No agents registered. Run 'kern init <name>' first.");
-    process.exit(1);
-  }
-  if (paths.length === 1) {
-    return paths[0];
-  }
-
-  // Multiple agents — prompt to select
-  const { select } = await import("@inquirer/prompts");
-  const choices = paths.map((p) => {
-    const info = readAgentInfo(p);
-    return { name: info?.name || p, value: p };
+  visible.forEach((c, i) => {
+    const name = cyan("kern " + c.name);
+    const usage = c.usage ? " " + dim(c.usage) : "";
+    // Pad based on uncolored length so alignment is correct.
+    const pad = " ".repeat(Math.max(2, maxWidth - left[i].length + 2));
+    w(`    ${name}${usage}${pad}${c.description}`);
   });
-  return select({ message: "Select agent", choices });
+  w("");
 }
 
 async function main() {
@@ -91,347 +53,15 @@ async function main() {
     process.exit(0);
   }
 
-  if (cmd === "init") {
-    // Parse flags for non-interactive mode
-    const flags: Record<string, string> = {};
-    let initTarget = args[1];
-    for (let i = 1; i < args.length; i++) {
-      if (args[i].startsWith("--") && i + 1 < args.length && !args[i + 1].startsWith("--")) {
-        flags[args[i].slice(2)] = args[i + 1];
-        i++;
-      } else if (!args[i].startsWith("--")) {
-        initTarget = args[i];
-      }
-    }
-    await runInit(initTarget, Object.keys(flags).length > 0 ? flags : undefined);
-    return;
+  const command = findCommand(cmd);
+  if (!command) {
+    console.error(`Unknown command: ${cmd}`);
+    await showHelp();
+    process.exit(1);
   }
 
-  if (cmd === "list" || cmd === "ls" || cmd === "status") {
-    await showStatus();
-    process.exit(0);
-  }
-
-  if (cmd === "start") {
-    if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
-      if (isServiceInstalled(args[1])) {
-        const ok = serviceControl("start", args[1]);
-        if (!ok) {
-          console.error(`Failed to start service-managed agent: ${args[1]}`);
-          process.exit(1);
-        }
-        process.exit(0);
-      }
-    }
-    await startAgent(args[1]);
-    process.exit(0);
-  }
-
-  if (cmd === "stop") {
-    if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
-      if (isServiceInstalled(args[1])) {
-        const ok = serviceControl("stop", args[1]);
-        if (!ok) {
-          console.error(`Failed to stop service-managed agent: ${args[1]}`);
-          process.exit(1);
-        }
-        process.exit(0);
-      }
-    }
-    await stopAgent(args[1]);
-    process.exit(0);
-  }
-
-  if (cmd === "restart") {
-    if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
-      if (isServiceInstalled(args[1])) {
-        const ok = serviceControl("restart", args[1]);
-        if (!ok) {
-          console.error(`Failed to restart service-managed agent: ${args[1]}`);
-          process.exit(1);
-        }
-        process.exit(0);
-      }
-    }
-    await stopAgent(args[1]);
-    await new Promise((r) => setTimeout(r, 500));
-    await startAgent(args[1]);
-    process.exit(0);
-  }
-
-  if (cmd === "install") {
-    const { install } = await import("./cli/install.js");
-    await install(args[1]);
-    process.exit(0);
-  }
-
-  if (cmd === "uninstall") {
-    const { uninstall } = await import("./cli/install.js");
-    await uninstall(args[1]);
-    process.exit(0);
-  }
-
-  if (cmd === "remove" || cmd === "rm") {
-    const name = args[1];
-    if (!name) {
-      console.error("Usage: kern remove <name>");
-      process.exit(1);
-    }
-    const { removeAgent, findAgent, isProcessRunning } = await import("./registry.js");
-    const { stopAgent } = await import("./cli/daemon.js");
-    const agent = findAgent(name);
-    if (!agent) {
-      console.error(`Agent not found: ${name}`);
-      process.exit(1);
-    }
-    // Uninstall systemd service if installed
-    const { isServiceInstalled, uninstall } = await import("./cli/install.js");
-    if (isServiceInstalled(name)) {
-      await uninstall(name);
-    }
-    if (agent.pid && isProcessRunning(agent.pid)) {
-      await stopAgent(name);
-    }
-    await removeAgent(name);
-    console.log(`  Removed ${name}`);
-    process.exit(0);
-  }
-
-  if (cmd === "logs") {
-    // Parse flags: -f (follow), -n <count>, --level <level>
-    let follow: boolean | null = null;  // null = auto (follow unless -n)
-    let lines = 50;
-    let level: string | null = null;
-    let nameArg: string | undefined;
-    const logArgs = args.slice(1);
-    for (let i = 0; i < logArgs.length; i++) {
-      if (logArgs[i] === "-f") { follow = true; }
-      else if (logArgs[i] === "-n" && logArgs[i + 1]) { lines = parseInt(logArgs[++i], 10) || 50; }
-      else if (logArgs[i] === "--level" && logArgs[i + 1]) { level = logArgs[++i]; }
-      else if (!logArgs[i].startsWith("-")) { nameArg = logArgs[i]; }
-    }
-
-    const agentDir = await resolveAgentDir(nameArg);
-    const logFile = join(agentDir, ".kern", "logs", "kern.log");
-    if (!existsSync(logFile)) {
-      console.error("No logs yet. Start the agent first.");
-      process.exit(1);
-    }
-
-    // Level filtering: map level to minimum set of labels to show
-    const LEVEL_FILTERS: Record<string, string[]> = {
-      debug: [],           // show all (no filtering)
-      info: [],            // show all (info has no label)
-      warn: ["WRN", "ERR"],
-      error: ["ERR"],
-    };
-    const filterLabels = level ? LEVEL_FILTERS[level] : null;
-
-    // Default: follow unless -n was specified
-    const shouldFollow = follow !== null ? follow : !logArgs.some(a => a === "-n");
-
-    if (shouldFollow) {
-      const { spawn } = await import("child_process");
-      if (!filterLabels || filterLabels.length === 0) {
-        const tail = spawn("tail", ["-f", `-n`, String(lines), logFile], { stdio: "inherit" });
-        process.on("SIGINT", () => { tail.kill(); process.exit(0); });
-      } else {
-        // tail + grep
-        const pattern = filterLabels.join("\\|");
-        const tail = spawn("sh", ["-c", `tail -f -n +1 "${logFile}" | grep --line-buffered "${pattern}"`], { stdio: "inherit" });
-        process.on("SIGINT", () => { tail.kill(); process.exit(0); });
-      }
-    } else {
-      // Read last N lines, optionally filter
-      const content = await readFile(logFile, "utf-8");
-      let allLines = content.trimEnd().split("\n");
-      if (filterLabels && filterLabels.length > 0) {
-        allLines = allLines.filter(l => filterLabels.some(label => l.includes(label)));
-      }
-      const output = allLines.slice(-lines);
-      for (const line of output) {
-        process.stdout.write(line + "\n");
-      }
-    }
-    return;
-  }
-
-  if (cmd === "import") {
-    const source = args[1]; // "opencode"
-    if (source === "opencode") {
-      const { importOpenCode } = await import("./cli/import.js");
-      await importOpenCode(args.slice(2));
-    } else {
-      console.error("Usage: kern import opencode [--project <path>] [--session <title|latest>] [--agent <name>]");
-      process.exit(1);
-    }
-    return;
-  }
-
-  if (cmd === "pair") {
-    const agentName = args[1];
-    const code = args[2];
-    if (!agentName || !code) {
-      console.error("Usage: kern pair <agent> <code>");
-      process.exit(1);
-    }
-    const { findAgent } = await import("./registry.js");
-    const { PairingManager } = await import("./pairing.js");
-    const agent = findAgent(agentName);
-    if (!agent) {
-      console.error(`Agent not found: ${agentName}`);
-      process.exit(1);
-    }
-    const pairing = new PairingManager(agent.path);
-    await pairing.load();
-    const result = await pairing.pair(code);
-    if (result) {
-      console.log(`  Paired user ${result.userId} (${result.interface}) to ${agentName}`);
-    } else {
-      console.error(`  Invalid or expired code: ${code}`);
-    }
-    process.exit(0);
-  }
-
-  if (cmd === "backup") {
-    const { backupAgent } = await import("./cli/backup.js");
-    await backupAgent(args[1]);
-    return;
-  }
-
-  if (cmd === "restore") {
-    const { restoreAgent } = await import("./cli/backup.js");
-    await restoreAgent(args[1]);
-    return;
-  }
-
-  if (cmd === "tui") {
-    const { connectTui } = await import("./cli/tui.js");
-    const { findAgent, loadRegistry, readAgentInfo, isProcessRunning } = await import("./registry.js");
-    const { startAgent } = await import("./cli/daemon.js");
-
-    let agentName = args[1];
-
-    // Auto-select if no arg
-    if (!agentName) {
-      const paths = await loadRegistry();
-      if (paths.length === 0) {
-        console.error("No agents registered. Run 'kern init <name>' first.");
-        process.exit(1);
-      } else if (paths.length === 1) {
-        const info = readAgentInfo(paths[0]);
-        agentName = info?.name || paths[0];
-      } else {
-        const { select } = await import("@inquirer/prompts");
-        const choices = paths.map((p) => {
-          const info = readAgentInfo(p);
-          return { name: info?.name || p, value: info?.name || p };
-        });
-        agentName = await select({ message: "Select agent", choices });
-      }
-    }
-
-    // Check if running, auto-start if not
-    let agent = findAgent(agentName);
-    if (!agent) {
-      console.error(`Agent not found: ${agentName}`);
-      process.exit(1);
-    }
-
-    if (!agent.pid || !isProcessRunning(agent.pid)) {
-      await startAgent(agentName);
-      // Reload to get the port
-      agent = findAgent(agentName);
-    }
-
-    if (!agent?.port) {
-      console.error(`Cannot determine port for ${agentName}. Is it running?`);
-      process.exit(1);
-    }
-
-    await connectTui(agent.port, agentName, agent.token || undefined);
-    return;
-  }
-
-  if (cmd === "run") {
-    const initIfNeeded = args.includes("--init-if-needed");
-    const dirArg = args.filter((a: string) => a !== "--init-if-needed")[1];
-    const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
-
-    if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
-      const { scaffoldAgent, API_KEY_ENV } = await import("./cli/init.js");
-      const name = process.env.KERN_NAME || basename(agentDir);
-      const provider = process.env.KERN_PROVIDER || "openrouter";
-      const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
-      await scaffoldAgent({
-        name, dir: agentDir, provider, envVar, skipStart: true,
-        model: process.env.KERN_MODEL || "anthropic/claude-opus-4.7",
-        apiKey: process.env[envVar] || "",
-        telegramToken: process.env.TELEGRAM_BOT_TOKEN || "",
-        slackBotToken: process.env.SLACK_BOT_TOKEN || "",
-        slackAppToken: process.env.SLACK_APP_TOKEN || "",
-      });
-    }
-
-    await startApp(agentDir);
-    return;
-  }
-
-  if (cmd === "web") {
-    const subcmd = args[1];
-    const { webStart, webStop, webStatus } = await import("./cli/web-daemon.js");
-    if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      const { getWebServiceStatus } = await import("./cli/install.js");
-      if (getWebServiceStatus() !== null) {
-        const { spawnSync } = await import("child_process");
-        spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
-        return;
-      }
-      if (subcmd === "start") await webStart();
-      else if (subcmd === "stop") await webStop();
-      else { await webStop(); await new Promise(r => setTimeout(r, 500)); await webStart(); }
-    } else if (subcmd === "status") {
-      await webStatus();
-    } else if (subcmd === "run") {
-      // Run web server in foreground (for Docker)
-      await import("./web.js");
-    } else {
-      console.error("Usage: kern web <run|start|stop|status>");
-      process.exit(1);
-    }
-    return;
-  }
-
-  if (cmd === "proxy") {
-    const subcmd = args[1];
-    const { proxyStart, proxyStop, proxyStatus, proxyToken } = await import("./cli/proxy-daemon.js");
-    if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      const { getProxyServiceStatus } = await import("./cli/install.js");
-      if (getProxyServiceStatus() !== null) {
-        const { spawnSync } = await import("child_process");
-        spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });
-        return;
-      }
-      if (subcmd === "start") await proxyStart();
-      else if (subcmd === "stop") await proxyStop();
-      else { await proxyStop(); await new Promise(r => setTimeout(r, 500)); await proxyStart(); }
-    } else if (subcmd === "status") {
-      await proxyStatus();
-    } else if (subcmd === "token") {
-      await proxyToken();
-    } else {
-      console.error("Usage: kern proxy <start|stop|status|token>");
-      process.exit(1);
-    }
-    return;
-  }
-
-  console.error(`Unknown command: ${cmd}`);
-  await showHelp();
-  process.exit(1);
+  await command.handler(args.slice(1));
+  process.exit(0);
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@
 import { resolve, basename } from "path";
 import { existsSync } from "fs";
 import { startApp } from "./app.js";
-import { runInit } from "./init.js";
-import { showStatus } from "./status.js";
-import { startAgent, stopAgent } from "./daemon.js";
+import { runInit } from "./cli/init.js";
+import { showStatus } from "./cli/status.js";
+import { startAgent, stopAgent } from "./cli/daemon.js";
 import { findAgent, loadRegistry, readAgentInfo } from "./registry.js";
 import { readFile } from "fs/promises";
 import { join } from "path";
@@ -114,7 +114,7 @@ async function main() {
 
   if (cmd === "start") {
     if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./install.js");
+      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
       if (isServiceInstalled(args[1])) {
         const ok = serviceControl("start", args[1]);
         if (!ok) {
@@ -130,7 +130,7 @@ async function main() {
 
   if (cmd === "stop") {
     if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./install.js");
+      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
       if (isServiceInstalled(args[1])) {
         const ok = serviceControl("stop", args[1]);
         if (!ok) {
@@ -146,7 +146,7 @@ async function main() {
 
   if (cmd === "restart") {
     if (args[1]) {
-      const { isServiceInstalled, serviceControl } = await import("./install.js");
+      const { isServiceInstalled, serviceControl } = await import("./cli/install.js");
       if (isServiceInstalled(args[1])) {
         const ok = serviceControl("restart", args[1]);
         if (!ok) {
@@ -163,13 +163,13 @@ async function main() {
   }
 
   if (cmd === "install") {
-    const { install } = await import("./install.js");
+    const { install } = await import("./cli/install.js");
     await install(args[1]);
     process.exit(0);
   }
 
   if (cmd === "uninstall") {
-    const { uninstall } = await import("./install.js");
+    const { uninstall } = await import("./cli/install.js");
     await uninstall(args[1]);
     process.exit(0);
   }
@@ -181,14 +181,14 @@ async function main() {
       process.exit(1);
     }
     const { removeAgent, findAgent, isProcessRunning } = await import("./registry.js");
-    const { stopAgent } = await import("./daemon.js");
+    const { stopAgent } = await import("./cli/daemon.js");
     const agent = findAgent(name);
     if (!agent) {
       console.error(`Agent not found: ${name}`);
       process.exit(1);
     }
     // Uninstall systemd service if installed
-    const { isServiceInstalled, uninstall } = await import("./install.js");
+    const { isServiceInstalled, uninstall } = await import("./cli/install.js");
     if (isServiceInstalled(name)) {
       await uninstall(name);
     }
@@ -262,7 +262,7 @@ async function main() {
   if (cmd === "import") {
     const source = args[1]; // "opencode"
     if (source === "opencode") {
-      const { importOpenCode } = await import("./import.js");
+      const { importOpenCode } = await import("./cli/import.js");
       await importOpenCode(args.slice(2));
     } else {
       console.error("Usage: kern import opencode [--project <path>] [--session <title|latest>] [--agent <name>]");
@@ -297,21 +297,21 @@ async function main() {
   }
 
   if (cmd === "backup") {
-    const { backupAgent } = await import("./backup.js");
+    const { backupAgent } = await import("./cli/backup.js");
     await backupAgent(args[1]);
     return;
   }
 
   if (cmd === "restore") {
-    const { restoreAgent } = await import("./backup.js");
+    const { restoreAgent } = await import("./cli/backup.js");
     await restoreAgent(args[1]);
     return;
   }
 
   if (cmd === "tui") {
-    const { connectTui } = await import("./tui.js");
+    const { connectTui } = await import("./cli/tui.js");
     const { findAgent, loadRegistry, readAgentInfo, isProcessRunning } = await import("./registry.js");
-    const { startAgent } = await import("./daemon.js");
+    const { startAgent } = await import("./cli/daemon.js");
 
     let agentName = args[1];
 
@@ -362,7 +362,7 @@ async function main() {
     const agentDir = initIfNeeded ? resolve(dirArg || ".") : await resolveAgentDir(dirArg);
 
     if (initIfNeeded && !existsSync(join(agentDir, ".kern", "config.json"))) {
-      const { scaffoldAgent, API_KEY_ENV } = await import("./init.js");
+      const { scaffoldAgent, API_KEY_ENV } = await import("./cli/init.js");
       const name = process.env.KERN_NAME || basename(agentDir);
       const provider = process.env.KERN_PROVIDER || "openrouter";
       const envVar = API_KEY_ENV[provider] || "OPENROUTER_API_KEY";
@@ -382,9 +382,9 @@ async function main() {
 
   if (cmd === "web") {
     const subcmd = args[1];
-    const { webStart, webStop, webStatus } = await import("./web-daemon.js");
+    const { webStart, webStop, webStatus } = await import("./cli/web-daemon.js");
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      const { getWebServiceStatus } = await import("./install.js");
+      const { getWebServiceStatus } = await import("./cli/install.js");
       if (getWebServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
         spawnSync("systemctl", ["--user", subcmd, "kern-web"], { stdio: "pipe" });
@@ -407,9 +407,9 @@ async function main() {
 
   if (cmd === "proxy") {
     const subcmd = args[1];
-    const { proxyStart, proxyStop, proxyStatus, proxyToken } = await import("./proxy-daemon.js");
+    const { proxyStart, proxyStop, proxyStatus, proxyToken } = await import("./cli/proxy-daemon.js");
     if (subcmd === "start" || subcmd === "stop" || subcmd === "restart") {
-      const { getProxyServiceStatus } = await import("./install.js");
+      const { getProxyServiceStatus } = await import("./cli/install.js");
       if (getProxyServiceStatus() !== null) {
         const { spawnSync } = await import("child_process");
         spawnSync("systemctl", ["--user", subcmd, "kern-proxy"], { stdio: "pipe" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,9 +62,9 @@ async function main() {
 
   const impl = await command.load();
   await impl.handler(args.slice(1));
-  // Don't force exit: long-running commands (logs -f, web run, proxy run)
-  // keep handles open and need Node to stay alive until they close. Short
-  // commands have no open handles and exit naturally.
+  // Don't force exit: long-running commands (for example, logs -f and
+  // web run) keep handles open and need Node to stay alive until they
+  // close. Short commands have no open handles and exit naturally.
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Closes #265

## What

Replace the `if (cmd === "x")` dispatch in `src/index.ts` with a data-driven
command table. Each command is its own file, flat in `src/cli/`.

### Before

- `src/index.ts` (440 lines): hand-rolled `if`-chain plus a separate literal
  for help text that could drift from the dispatcher.
- No single place a command declared itself.

### After

- `src/index.ts` (~70 lines): argv parse, table lookup, dispatch, generated help.
- `src/cli/commands.ts`: `Command` type (just `{ handler }`), `CommandEntry`
  (metadata + `load()` thunk), registry array, `findCommand`.
- One `*Command` per `src/cli/` file. For logic files that predate the command
  system (`init`, `backup`, `install`, `tui`, `import`, `status`), the command
  export lives at the bottom of the same file — the CLI wrapper sits next to
  what it wraps. For commands without a prior logic file (`start`, `stop`,
  `restart`, `remove`, `pair`, `logs`, `run`, `web`, `proxy`), one small flat
  file each.
- `src/cli/helpers.ts`: `resolveAgentDir` and `serviceOrDaemon` shared between
  commands.

No subfolder. No separate `command.ts`. Registry owns all help metadata (name,
usage, description, aliases, hidden). Loaded `Command` is handler-only.

### Lazy loading

Each registry entry ships a `load()` thunk; the matched command's module is
imported on demand. Keeps `kern --help`, `kern list`, and unknown-command
paths from pulling in React/Ink (tui.tsx) or @inquirer/prompts (init.ts).

Cold-start timings on vega (after build):
- `kern --help`: ~27ms (dispatcher + registry only)
- `kern list`: ~66ms (dispatcher + registry + status module)
- `kern init`: ~540ms (loads React/Ink + inquirer)

Before this PR, every command paid the full import cost (~550ms).

## Behaviour changes

Most of this is a pure refactor, but three intentional fixes landed during
review that are worth calling out:

1. **`logs -f` actually follows now.** The old dispatcher and the first pass
   of this PR ended `main()` with an unconditional `process.exit(0)`, which
   killed the spawned `tail` immediately. Removed the forced exit: Node exits
   naturally when the handler's handles close. Short commands still exit
   cleanly; long-running ones (`logs -f`, `web run`) stay alive.
2. **`pair` with an invalid/expired code now exits 1.** Used to print an
   error and return 0, which was misleading for scripts.
3. **`kern web start|stop|restart` and `kern proxy start|stop|restart` now
   forward systemd's stdio and exit status.** Before, systemctl failures were
   silent and the CLI reported success. Now you see the failure and get a
   non-zero exit code.

All three are "was silently broken, now isn't" — no existing invocation that
previously worked should behave differently.

Security fix landed during review: `logs --level <x> -f` previously built a
shell pipeline with `sh -c` and interpolated the agent directory path into
the command string. Replaced with a two-process argv spawn: `tail -f -n ... <path>`
piped to `grep --line-buffered -E <pattern>`. No shell, no interpolation.

## Smoke test

```
kern --help                 # 17 visible commands, aligned, run hidden
kern list / ls / status     # aliases
kern web status / kern web junk
kern proxy junk
kern pair                   # usage error, exits 1
kern remove                 # usage error, exits 1
kern bogusxyz               # unknown + help, exits 1
kern logs <agent>           # default follow, stays alive on SIGINT
kern logs <agent> -n 50     # one-shot, exits 0
```

Help is generated from the table and auto-aligned by computed usage width,
so it cannot drift from the dispatcher.

## Side benefits

- Deduplicated the systemd-or-daemon pattern (`serviceOrDaemon`) that
  `start`/`stop`/`restart` used to inline three times.
- Plugin-contributed CLI commands slot in later by concatenating arrays.
- `Command` type is now just `{ handler }` — metadata lives in the registry
  only, removing the drift surface between table entries and loaded modules.

## Not in this PR

- Merging `daemon.ts` / `web-daemon.ts` / `proxy-daemon.ts` into shared
  lifecycle code.
- Renaming `import.ts` (collides with the JS keyword but only at module
  level; no runtime issue).
- Plugin-contributed commands.
