### PR TITLE
fix: recognize trailing NO_REPLY across all interfaces (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## next
 
 ### Fixes
-- **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — the sentinel is now recognized whenever the reply text ends with `NO_REPLY`, not only when the whole message is exactly `NO_REPLY`. Models routinely wrap the sentinel with explanatory prose (`"… notes are up to date.\n\nNO_REPLY"`); those replies were leaking as visible messages on Telegram, Slack, Matrix, and the web UI. Suppression is now consistent across all interfaces and the TUI via a single `isNoReply()` helper. Inline mentions of `NO_REPLY` in prose or backticks still pass through.
+- **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — replies ending with `NO_REPLY` (e.g. `"…notes are up to date.\n\nNO_REPLY"`) are now suppressed on Telegram, Slack, Matrix, web UI, and TUI. Previously only exact-match `NO_REPLY` was caught.
 
 ## v0.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## next
+
+### Fixes
+- **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — the sentinel is now recognized whenever the reply text ends with `NO_REPLY`, not only when the whole message is exactly `NO_REPLY`. Models routinely wrap the sentinel with explanatory prose (`"… notes are up to date.\n\nNO_REPLY"`); those replies were leaking as visible messages on Telegram, Slack, Matrix, and the web UI. Suppression is now consistent across all interfaces and the TUI via a single `isNoReply()` helper. Inline mentions of `NO_REPLY` in prose or backticks still pass through.
+
 ## v0.31.0
 
 ### Features

--- a/src/interfaces/matrix.ts
+++ b/src/interfaces/matrix.ts
@@ -1,6 +1,7 @@
 import type { Interface, StartOptions } from "./types.js";
 import type { PairingManager } from "../pairing.js";
 import { log } from "../log.js";
+import { isNoReply } from "../util.js";
 
 /**
  * Matrix interface — long-polls /sync, accepts invites, replies via /send.
@@ -213,7 +214,7 @@ export class MatrixInterface implements Interface {
       await this.setTyping(roomId, false).catch(() => {});
 
       const reply = (response || "").trim();
-      if (!reply || reply === "NO_REPLY" || reply === "(no text response)") return;
+      if (isNoReply(reply)) return;
       await this.sendMessage(roomId, reply);
     } catch (err: any) {
       clearInterval(typingInterval);

--- a/src/interfaces/slack.ts
+++ b/src/interfaces/slack.ts
@@ -3,6 +3,7 @@ import { App as SlackApp } from "@slack/bolt";
 import type { Attachment, Interface, StartOptions } from "./types.js";
 import type { PairingManager } from "../pairing.js";
 import { log } from "../log.js";
+import { isNoReply } from "../util.js";
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -174,9 +175,9 @@ export class SlackInterface implements Interface {
           () => {}, // events handled by SSE broadcast in app.ts
         );
 
-        // NO_REPLY suppression
-        const clean = response?.trim() || "";
-        if (clean && clean !== "NO_REPLY" && clean !== "(no text response)") {
+        // NO_REPLY suppression — matches empty, "(no text response)", or any
+        // reply ending with NO_REPLY (model explaining then suppressing).
+        if (!isNoReply(response)) {
           await say(mdToSlack(response));
         }
       } catch (error: any) {

--- a/src/interfaces/telegram.ts
+++ b/src/interfaces/telegram.ts
@@ -2,6 +2,7 @@ import { Bot } from "grammy";
 import type { Attachment, Interface, StartOptions } from "./types.js";
 import type { PairingManager } from "../pairing.js";
 import { log } from "../log.js";
+import { isNoReply } from "../util.js";
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -315,7 +316,7 @@ export class TelegramInterface implements Interface {
         if (pendingNewMessage) await pendingNewMessage;
         // Final edit — overwrite tools with text on the last message
         const lastText = (currentText || response || "").trim();
-        if (lastText === "NO_REPLY" || lastText === "(no text response)") {
+        if (isNoReply(lastText)) {
           // Suppress — delete the placeholder message
           try { await ctx.api.deleteMessage(ctx.chat.id, activeMessageId); } catch {}
           // Delete any earlier placeholder too

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -4,6 +4,7 @@ import { render, Box, Text, Static, useInput, useApp, useStdout } from "ink";
 import Spinner from "ink-spinner";
 import type { ServerEvent } from "./server.js";
 import { findAgent } from "./registry.js";
+import { isNoReply } from "./util.js";
 
 // --- Types ---
 
@@ -199,7 +200,7 @@ function MessageView({ msg, width }: { msg: ChatMessage; width: number }) {
         </Box>
       );
     case "assistant": {
-      const isMuted = msg.text.trim() === "NO_REPLY" || msg.text.trim() === "(no text response)";
+      const isMuted = isNoReply(msg.text);
       return (
         <Box paddingLeft={3}>
           <Text color={isMuted ? undefined : "white"} dimColor={isMuted} italic={isMuted} wrap="wrap">
@@ -367,7 +368,7 @@ function RenderBlockView({ block, width }: { block: RenderBlock; width: number }
     case "toolGroup":
       return <ToolGroupView tools={block.tools} />;
     case "assistant": {
-      const isMuted = block.text.trim().endsWith("NO_REPLY") || block.text.trim().endsWith("(no text response)");
+      const isMuted = isNoReply(block.text);
       return (
         <Box paddingLeft={3}>
           <MarkdownText text={block.text} isMuted={isMuted} />
@@ -597,7 +598,7 @@ function App({ port, agentName, version, authToken }: TuiProps) {
         {streamingText && (
           <Box marginTop={1} paddingLeft={3}>
             {(() => {
-              const isMuted = streamingText.trim().endsWith("NO_REPLY") || streamingText.trim().endsWith("(no text response)");
+              const isMuted = isNoReply(streamingText);
               return <MarkdownText text={streamingText} isMuted={isMuted} />;
             })()}
           </Box>

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,30 @@
 import TurndownService from "turndown";
 
 /**
+ * True if an assistant reply should be suppressed from outbound interfaces.
+ *
+ * Matches:
+ *   - empty / whitespace-only text
+ *   - the sentinel `(no text response)` placeholder
+ *   - any reply whose trimmed text **ends with** `NO_REPLY`
+ *
+ * The trailing-match covers the common model pattern of writing explanatory
+ * prose then ending with `NO_REPLY` to signal "don't speak up." Inline mentions
+ * of NO_REPLY elsewhere in the message (backticks, prose, bullet points) still
+ * pass through, so agents can legitimately discuss the feature.
+ *
+ * Suppression is outbound-only — session JSONL keeps the full assistant text
+ * for context and trace.
+ */
+export function isNoReply(text: string | null | undefined): boolean {
+  if (!text) return true;
+  const t = text.trim();
+  if (!t) return true;
+  if (t === "(no text response)") return true;
+  return t.endsWith("NO_REPLY");
+}
+
+/**
  * Extract plain text from message content (string or array).
  * Used for embeddings, search, summaries — strips media parts.
  */

--- a/web/lib/messages.ts
+++ b/web/lib/messages.ts
@@ -5,6 +5,19 @@ import { getPlugins } from "../plugins/registry";
 
 let msgCounter = 0;
 
+/**
+ * True if an assistant reply should be rendered muted (the outbound interfaces
+ * have already suppressed it). Matches empty text, the "(no text response)"
+ * placeholder, or any text ending with NO_REPLY — mirrors src/util.ts#isNoReply.
+ */
+export function isNoReply(text: string | null | undefined): boolean {
+  if (!text) return true;
+  const t = text.trim();
+  if (!t) return true;
+  if (t === "(no text response)") return true;
+  return t.endsWith("NO_REPLY");
+}
+
 /** Ask plugins to convert a tool result to a custom message. Returns null if no plugin handles it. */
 function pluginToolResult(toolName: string, output: string): ChatMessage | null {
   for (const plugin of getPlugins()) {
@@ -291,18 +304,14 @@ export function analyzeMessage(msg: ChatMessage, agentName?: string): MessagePro
   const isHeartbeat = msg.role === "heartbeat";
   const isCommand = msg.role === "command";
   const isError = msg.role === "error";
-  const isNoReply = isAssistant && (
-    msg.text === "NO_REPLY" ||
-    msg.text === "(no text response)" ||
-    !msg.text?.trim()
-  );
+  const isNoReplyMsg = isAssistant && isNoReply(msg.text);
   const isEmoji = isUser && isEmojiOnly(msg.text);
   const isOutgoing = isAssistant && !!msg.meta?.startsWith("→");
   const channel = (isIncoming || isOutgoing) ? parseChannel(msg.meta) : undefined;
   const senderName = isUser ? "You" : isHeartbeat ? "heartbeat" : isIncoming ? (channel || "incoming") : (agentName || "Agent");
   const initials = senderName.charAt(0).toUpperCase();
 
-  return { msg, isUser, isAssistant, isIncoming, isHeartbeat, isCommand, isError, isNoReply, isEmoji, senderName, initials, channel };
+  return { msg, isUser, isAssistant, isIncoming, isHeartbeat, isCommand, isError, isNoReply: isNoReplyMsg, isEmoji, senderName, initials, channel };
 }
 
 // Compute continuation and tool-header flags for a message list


### PR DESCRIPTION
Fixes #273.

## What

Every interface was checking NO_REPLY with strict exact-match (`text === "NO_REPLY"`). Models frequently wrap the sentinel with explanatory prose, intending to suppress the reply entirely:

```
Nothing needs attention.

NO_REPLY
```

None of those matched, so they leaked as visible messages on Telegram, Slack, Matrix, and the web UI. The TUI had partial `endsWith` handling in 2 of 3 code paths, inconsistent with the rest.

## How

Single helper `isNoReply()` in `src/util.ts` (mirrored in `web/lib/messages.ts` since `web/` can't import from `src/`):

```ts
export function isNoReply(text: string | null | undefined): boolean {
  if (!text) return true;
  const t = text.trim();
  if (!t) return true;
  if (t === "(no text response)") return true;
  return t.endsWith("NO_REPLY");
}
```

Applied at every outbound suppression site:
- `src/interfaces/telegram.ts`
- `src/interfaces/slack.ts`
- `src/interfaces/matrix.ts`
- `src/tui.tsx` (3 render paths, now consolidated)
- `web/lib/messages.ts` (via `analyzeMessage`)

## Behavior

| Reply | Before | After |
|---|---|---|
| `"NO_REPLY"` | suppressed | suppressed |
| `"(no text response)"` | suppressed | suppressed |
| `"Notes are current.\n\nNO_REPLY"` | **leaked everywhere except TUI** | suppressed |
| `"NO_REPLY\nNO_REPLY"` | leaked | suppressed |
| `"NO_REPLY\n\nactual commentary"` | leaked | still sends (commentary wins) |
| `"Found a `NO_REPLY` leak"` | sent | sent |
| `"- Bug: NO_REPLY leak"` | sent | sent |

Session JSONL keeps the full assistant text either way — suppression is outbound-only, so recall and context stay unaffected.

## Testing

11-case smoke test against real leaks harvested from a live `atlas` session, all green. Full build passes.