### PR TITLE
feat: local-timezone envelope for LLM, keep storage UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ### Fixes
 - **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — replies ending with `NO_REPLY` (e.g. `"…notes are up to date.\n\nNO_REPLY"`) are now suppressed on Telegram, Slack, Matrix, web UI, and TUI. Previously only exact-match `NO_REPLY` was caught.
-- **Recall `after`/`before` filters** ([#268](https://github.com/oguzbilgic/kern-ai/issues/268)) — now compares timestamps as dates instead of strings, which fixes mixed UTC-`Z` and offset rows sorting out of order.
 
 ## v0.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## next
 
 ### Improvements
-- **Local-timezone envelope** ([#268](https://github.com/oguzbilgic/kern-ai/issues/268)) — the `time:` field in the envelope the model reads is now in local time with UTC offset (e.g. `2026-04-20T20:08:45-07:00`) instead of UTC. Defaults to host timezone; override with the new `timezone` config field (IANA string). Storage everywhere else (logs, recall.db, session/pairing/subagent metadata) stays UTC.
+- **Local-timezone envelope** ([#268](https://github.com/oguzbilgic/kern-ai/issues/268)) — the `time:` field the agent reads is now in local time with UTC offset (e.g. `2026-04-20T20:08:45-07:00`) instead of UTC. Defaults to host timezone; override with the new `timezone` config field (IANA string).
 
 ### Fixes
 - **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — replies ending with `NO_REPLY` (e.g. `"…notes are up to date.\n\nNO_REPLY"`) are now suppressed on Telegram, Slack, Matrix, web UI, and TUI. Previously only exact-match `NO_REPLY` was caught.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## next
 
+### Improvements
+- **Local-timezone envelope** ([#268](https://github.com/oguzbilgic/kern-ai/issues/268)) — the `time:` field in the envelope the model reads is now in local time with UTC offset (e.g. `2026-04-20T20:08:45-07:00`) instead of UTC. Defaults to host timezone; override with the new `timezone` config field (IANA string). Storage everywhere else (logs, recall.db, session/pairing/subagent metadata) stays UTC.
+
 ### Fixes
 - **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — replies ending with `NO_REPLY` (e.g. `"…notes are up to date.\n\nNO_REPLY"`) are now suppressed on Telegram, Slack, Matrix, web UI, and TUI. Previously only exact-match `NO_REPLY` was caught.
+- **Recall `after`/`before` filters** ([#268](https://github.com/oguzbilgic/kern-ai/issues/268)) — now compares timestamps as dates instead of strings, which fixes mixed UTC-`Z` and offset rows sorting out of order.
 
 ## v0.31.0
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -26,6 +26,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 | `maxToolResultChars` | `20000` | Max characters per tool result in context. Oversized results are truncated in context only. Full results stay in session storage. Set to `0` to disable. |
 | `telegramTools` | `false` | Show tool call progress lines (⚙ bash, etc.) in Telegram messages. |
 | `heartbeatInterval` | `60` | Minutes between heartbeat prompts. Agent reviews notes, updates knowledge. 0 to disable. |
+| `timezone` | `""` | IANA timezone (e.g. `"America/Los_Angeles"`) used for the `time:` field in the envelope the model reads. Empty = autoresolve to host. Storage (logs, recall, session metadata) stays UTC regardless. |
 | `recall` | `true` | Enable recall and segments (embedding-based features). Set to `false` to disable. Requires an embedding API key. Session storage and notes summaries work regardless. |
 | `summaryBudget` | `0.75` | Fraction of `maxContextTokens` for compressed conversation summaries from segments. Cached via prompt caching, so effectively free for supported models. Set to `0` to disable. See [Context](context.md#conversation-summary). |
 | `autoRecall` | `false` | Automatically inject relevant old context before each turn. Requires recall enabled. |

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -13,12 +13,14 @@ All messages include context metadata prepended to the text:
 Examples:
 
 ```
-[via telegram, telegram:12345, user: 8105113489, time: 2026-04-06T21:30:00Z]
-[via slack, #engineering, user: U04ABC, time: 2026-04-06T21:30:00Z]
-[via matrix, matrix:!abc:example.com, user: @oguz:example.com, time: 2026-04-17T04:00:00Z]
-[via web, web, user: tui, time: 2026-04-06T21:30:00Z]
-[via tui, tui, user: tui, time: 2026-04-06T21:30:00Z]
+[via telegram, telegram:12345, user: 8105113489, time: 2026-04-06T14:30:00-07:00]
+[via slack, #engineering, user: U04ABC, time: 2026-04-06T14:30:00-07:00]
+[via matrix, matrix:!abc:example.com, user: @oguz:example.com, time: 2026-04-16T21:00:00-07:00]
+[via web, web, user: tui, time: 2026-04-06T14:30:00-07:00]
+[via tui, tui, user: tui, time: 2026-04-06T14:30:00-07:00]
 ```
+
+The `time:` field is ISO 8601 in the host's local timezone with UTC offset. Override with the `timezone` config field (see [config](config.md)). Storage (logs, recall, session metadata) stays UTC regardless.
 
 The agent sees who's talking, from which channel, and when — and adapts behavior accordingly via instructions in `KERN.md`.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import { MessageQueue } from "./queue.js";
 import { getStatusData as getStatusDataFn, setQueueStatusFn, setInterfaceStatusFn, setSegmentStatsFn, setPluginStatusFn, type InterfaceStatus } from "./tools/kern.js";
 import { plugins, type PluginContext } from "./plugins/index.js";
 import { setSubAgentAnnouncer, formatAnnounce } from "./plugins/subagents/plugin.js";
+import { formatLocalISO, resolveHostTimezone } from "./util.js";
 import { log } from "./log.js";
 
 let _pluginCtx: PluginContext | null = null;
@@ -133,6 +134,12 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   const agentName = config.name;
   process.chdir(agentDir);
 
+  // Resolve envelope timezone once. Config override (IANA string) wins, else
+  // autoresolve to host. Storage everywhere else stays UTC — this only affects
+  // the human-readable `time:` field the model reads in each envelope.
+  const envelopeTimezone = config.timezone || resolveHostTimezone();
+  log("kern", `envelope timezone: ${envelopeTimezone}`);
+
   // Initialize pairing
   const pairing = new PairingManager(agentDir);
   await pairing.load();
@@ -212,7 +219,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
 
   queue.setHandler(async (msg, getPendingMessages) => {
 
-    const time = new Date().toISOString();
+    const time = formatLocalISO(new Date(), envelopeTimezone);
     const context = `[via ${msg.interface}${msg.channel ? `, ${msg.channel}` : ""}, user: ${msg.userId}, time: ${time}]\n${msg.text}`;
 
     // Broadcast incoming to other clients.
@@ -235,7 +242,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
       const pending = getPendingMessages();
       return pending.map((p) => ({
         role: "user",
-        content: `[via ${p.interface}${p.channel ? `, ${p.channel}` : ""}, user: ${p.userId}, time: ${new Date().toISOString()}]\n${p.text}`,
+        content: `[via ${p.interface}${p.channel ? `, ${p.channel}` : ""}, user: ${p.userId}, time: ${formatLocalISO(new Date(), envelopeTimezone)}]\n${p.text}`,
       }));
     });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,11 @@ export interface KernConfig {
   // Runtime
   heartbeatInterval: number;
 
+  // Timezone — IANA zone used when rendering the `time:` field in the envelope
+  // the model reads. Empty string means autoresolve to host timezone. Storage
+  // everywhere else (logs, recall.db, session metadata) stays UTC.
+  timezone: string;
+
   // MCP — Model Context Protocol servers. Agent-local. See docs/mcp.md.
   mcpServers?: Record<string, McpServerConfig>;
 }
@@ -77,6 +82,7 @@ export const configDefaults: KernConfig = {
   mediaContext: 0,
   telegramTools: false,
   heartbeatInterval: 60,
+  timezone: "",
 };
 
 const FIELD_TYPES: Record<string, string> = {
@@ -96,6 +102,7 @@ const FIELD_TYPES: Record<string, string> = {
   mediaContext: "number",
   telegramTools: "boolean",
   heartbeatInterval: "number",
+  timezone: "string",
   mcpServers: "object",
 };
 

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -11,6 +11,14 @@ import type { KernConfig } from "../../config.js";
 
 const MAX_CHUNK_TOKENS = 1000; // rough token limit per chunk
 
+// Normalize an ISO8601 string (UTC `Z` or `±HH:MM` offset) to canonical UTC
+// `Z` form for storage. Ensures `recall.db` timestamp column is UTC-normalized
+// regardless of the envelope format the model saw.
+function toUTC(iso: string): string | null {
+  const ms = Date.parse(iso);
+  return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+}
+
 interface RecallResult {
   text: string;
   timestamp: string;
@@ -75,13 +83,12 @@ export class RecallIndex {
         const msgIndex = lastIndexed + i;
         const msgContent = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
 
-        // Extract timestamp from message metadata
+        // Extract timestamp from message metadata. Envelopes may be UTC (`...Z`,
+        // legacy) or offset (`...±HH:MM`, v0.32+). Normalize to UTC for storage.
         let timestamp: string | null = null;
         const textForTimestamp = typeof msg.content === "string" ? msg.content : extractText(msg.content);
-        // Match both UTC (`...Z`) and offset (`...±HH:MM`) ISO8601 — pre-v0.32
-        // sessions used UTC in envelopes, v0.32+ uses local tz with offset.
         const timeMatch = textForTimestamp.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:\d{2}))/);
-        if (timeMatch) timestamp = timeMatch[1];
+        if (timeMatch) timestamp = toUTC(timeMatch[1]);
 
         insertMsg.run(sessionId, msgIndex, msg.role, msgContent, timestamp);
       }
@@ -297,12 +304,12 @@ export class RecallIndex {
       const absTurnStart = absoluteOffset + turnStart;
       const absTurnEnd = absoluteOffset + turnEnd;
 
-      // Extract timestamp from message metadata
+      // Extract timestamp from message metadata (normalize to UTC for storage).
       let timestamp = "";
       for (let j = turnStart; j < turnEnd && !timestamp; j++) {
         const content = typeof messages[j].content === "string" ? messages[j].content as string : "";
         const timeMatch = content.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:\d{2}))/);
-        if (timeMatch) timestamp = timeMatch[1];
+        if (timeMatch) timestamp = toUTC(timeMatch[1]) || "";
       }
       // Fallback: interpolate from position in session
       if (!timestamp) {

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -78,7 +78,9 @@ export class RecallIndex {
         // Extract timestamp from message metadata
         let timestamp: string | null = null;
         const textForTimestamp = typeof msg.content === "string" ? msg.content : extractText(msg.content);
-        const timeMatch = textForTimestamp.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+Z)/);
+        // Match both UTC (`...Z`) and offset (`...±HH:MM`) ISO8601 — pre-v0.32
+        // sessions used UTC in envelopes, v0.32+ uses local tz with offset.
+        const timeMatch = textForTimestamp.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:\d{2}))/);
         if (timeMatch) timestamp = timeMatch[1];
 
         insertMsg.run(sessionId, msgIndex, msg.role, msgContent, timestamp);
@@ -299,7 +301,7 @@ export class RecallIndex {
       let timestamp = "";
       for (let j = turnStart; j < turnEnd && !timestamp; j++) {
         const content = typeof messages[j].content === "string" ? messages[j].content as string : "";
-        const timeMatch = content.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+Z)/);
+        const timeMatch = content.match(/time: (\d{4}-\d{2}-\d{2}T[\d:.]+(?:Z|[+-]\d{2}:\d{2}))/);
         if (timeMatch) timestamp = timeMatch[1];
       }
       // Fallback: interpolate from position in session

--- a/src/plugins/recall/tool.ts
+++ b/src/plugins/recall/tool.ts
@@ -65,14 +65,16 @@ export const recallTool = tool({
       if (args.query) {
         let results = await _recallIndex.search(args.query, (args.limit || 5) * 3); // fetch extra for filtering
         
-        // Apply date filters
+        // Apply date filters. Compare as Dates, not strings — mixed ISO8601
+        // formats (UTC `Z` vs offset `±HH:MM`) don't sort lexicographically
+        // even when they represent the same instant.
         if (args.after) {
-          const after = new Date(args.after).toISOString();
-          results = results.filter((r) => r.timestamp >= after);
+          const after = new Date(args.after).getTime();
+          results = results.filter((r) => !!r.timestamp && new Date(r.timestamp).getTime() >= after);
         }
         if (args.before) {
-          const before = new Date(args.before).toISOString();
-          results = results.filter((r) => r.timestamp <= before);
+          const before = new Date(args.before).getTime();
+          results = results.filter((r) => !!r.timestamp && new Date(r.timestamp).getTime() <= before);
         }
 
         // Filter out chunks already in context window

--- a/src/plugins/recall/tool.ts
+++ b/src/plugins/recall/tool.ts
@@ -65,16 +65,15 @@ export const recallTool = tool({
       if (args.query) {
         let results = await _recallIndex.search(args.query, (args.limit || 5) * 3); // fetch extra for filtering
         
-        // Apply date filters. Compare as Dates, not strings — mixed ISO8601
-        // formats (UTC `Z` vs offset `±HH:MM`) don't sort lexicographically
-        // even when they represent the same instant.
+        // Apply date filters. `recall.db` stores UTC-normalized timestamps, so
+        // lexicographic string comparison is correct.
         if (args.after) {
-          const after = new Date(args.after).getTime();
-          results = results.filter((r) => !!r.timestamp && new Date(r.timestamp).getTime() >= after);
+          const after = new Date(args.after).toISOString();
+          results = results.filter((r) => r.timestamp >= after);
         }
         if (args.before) {
-          const before = new Date(args.before).getTime();
-          results = results.filter((r) => !!r.timestamp && new Date(r.timestamp).getTime() <= before);
+          const before = new Date(args.before).toISOString();
+          results = results.filter((r) => r.timestamp <= before);
         }
 
         // Filter out chunks already in context window

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,9 +8,8 @@ import TurndownService from "turndown";
  *
  * If `timeZone` is omitted or unresolvable, falls back to UTC.
  *
- * Storage-adjacent callers: the output is still a valid ISO8601 string, so it
- * can be stored alongside legacy `Z` timestamps in the same TEXT column without
- * migration. String sort and `Date`-based comparison both work.
+ * Used for the envelope `time:` field the model reads. Storage elsewhere
+ * (logs, recall, session metadata) stays UTC.
  */
 export function formatLocalISO(d: Date = new Date(), timeZone?: string): string {
   const tz = timeZone || "UTC";

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,61 @@
 import TurndownService from "turndown";
 
 /**
+ * Format a Date as ISO8601 with the wall-clock time in a target IANA zone and
+ * its UTC offset. Unlike `toISOString()` (always UTC `Z`), this produces strings
+ * the model can read at a glance like "2026-04-20T20:08:45-07:00" while
+ * remaining machine-parseable by `new Date()` and regex-friendly.
+ *
+ * If `timeZone` is omitted or unresolvable, falls back to UTC.
+ *
+ * Storage-adjacent callers: the output is still a valid ISO8601 string, so it
+ * can be stored alongside legacy `Z` timestamps in the same TEXT column without
+ * migration. String sort and `Date`-based comparison both work.
+ */
+export function formatLocalISO(d: Date = new Date(), timeZone?: string): string {
+  const tz = timeZone || "UTC";
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit",
+      hour12: false,
+    }).formatToParts(d);
+    const get = (t: string) => parts.find((p) => p.type === t)!.value;
+    const year = get("year");
+    const month = get("month");
+    const day = get("day");
+    // Intl renders midnight as "24" in hour12:false — normalize.
+    let hour = get("hour");
+    if (hour === "24") hour = "00";
+    const minute = get("minute");
+    const second = get("second");
+    const offRaw = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      timeZoneName: "longOffset",
+    }).formatToParts(d).find((p) => p.type === "timeZoneName")!.value;
+    // longOffset yields "GMT-07:00" or bare "GMT" for UTC.
+    const offset = offRaw === "GMT" ? "+00:00" : offRaw.replace("GMT", "");
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}${offset}`;
+  } catch {
+    return d.toISOString();
+  }
+}
+
+/**
+ * Resolve the host's IANA timezone at runtime. Returns `"UTC"` if the
+ * environment cannot resolve a named zone.
+ */
+export function resolveHostTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+
+/**
  * True if an assistant reply should be suppressed from outbound interfaces.
  *
  * Matches:

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -23,7 +23,7 @@ You have no built-in memory between sessions. This repo is how you become statef
 - Commit and push incrementally. Don't batch unrelated changes.
 - If a file operation could overwrite existing content (rename, move), check git status first.
 - Update today's daily note with what was done, decisions made, and any new open items.
-- Use the operator's timezone (specified in `IDENTITY.md`) to determine today's date for daily notes.
+- Use the `time:` field in the incoming message envelope to determine today's date — it's already in local time.
 - Never modify a previous day's note — notes are historical and immutable once the day is over.
 
 ## Memory Structure

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -23,7 +23,7 @@ You have no built-in memory between sessions. This repo is how you become statef
 - Commit and push incrementally. Don't batch unrelated changes.
 - If a file operation could overwrite existing content (rename, move), check git status first.
 - Update today's daily note with what was done, decisions made, and any new open items.
-- Use the `time:` field in the incoming message envelope to determine today's date — it's already in local time (host timezone by default, or the `timezone` field in `.kern/config.json`).
+- Use the `time:` field in the incoming message envelope to determine today's date — it's already in local time.
 - Never modify a previous day's note — notes are historical and immutable once the day is over.
 
 ## Memory Structure

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -23,7 +23,7 @@ You have no built-in memory between sessions. This repo is how you become statef
 - Commit and push incrementally. Don't batch unrelated changes.
 - If a file operation could overwrite existing content (rename, move), check git status first.
 - Update today's daily note with what was done, decisions made, and any new open items.
-- Use the `time:` field in the incoming message envelope to determine today's date — it's already in local time.
+- Use the `time:` field in the incoming message envelope to determine today's date — it's already in local time (host timezone by default, or the `timezone` field in `.kern/config.json`).
 - Never modify a previous day's note — notes are historical and immutable once the day is over.
 
 ## Memory Structure

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -13,7 +13,7 @@ Messages include context metadata:
 
 Every message includes metadata. The same person may reach you from different channels (e.g. telegram and tui). Pay attention to who is talking — different users may have different relationships with you.
 
-The `time:` field is in local time with UTC offset (host timezone by default, or the `timezone` field in config). Storage stays UTC.
+The `time:` field is in local time with UTC offset (host timezone by default, or the `timezone` field in config).
 
 `USERS.md` is auto-injected into your system prompt — it's your notes on users and channels you've encountered. Paired users, Slack channel members, Telegram contacts — anyone you've interacted with.
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -13,7 +13,7 @@ Messages include context metadata:
 
 Every message includes metadata. The same person may reach you from different channels (e.g. telegram and tui). Pay attention to who is talking — different users may have different relationships with you.
 
-The `time:` field is in local time with UTC offset (host timezone by default, or the `timezone` field in `.kern/config.json`). Storage stays UTC.
+The `time:` field is in local time with UTC offset (host timezone by default, or the `timezone` field in config). Storage stays UTC.
 
 `USERS.md` is auto-injected into your system prompt — it's your notes on users and channels you've encountered. Paired users, Slack channel members, Telegram contacts — anyone you've interacted with.
 

--- a/templates/KERN.md
+++ b/templates/KERN.md
@@ -9,9 +9,11 @@ You are running on kern (npm: kern-ai). You can understand and configure yoursel
 
 ### Who's talking
 Messages include context metadata:
-`[via <interface>, <channel>, user: <id>]`
+`[via <interface>, <channel>, user: <id>, time: <iso8601>]`
 
 Every message includes metadata. The same person may reach you from different channels (e.g. telegram and tui). Pay attention to who is talking — different users may have different relationships with you.
+
+The `time:` field is in local time with UTC offset (host timezone by default, or the `timezone` field in `.kern/config.json`). Storage stays UTC.
 
 `USERS.md` is auto-injected into your system prompt — it's your notes on users and channels you've encountered. Paired users, Slack channel members, Telegram contacts — anyone you've interacted with.
 


### PR DESCRIPTION
Closes #268.

## What

The `time:` field in each message envelope the model reads is now in local time with UTC offset:

```
[via web, web, user: tui, time: 2026-04-20T20:08:45-07:00]
```

instead of UTC `Z`:

```
[via web, web, user: tui, time: 2026-04-21T03:08:45.762Z]
```

Defaults to host timezone via `Intl.DateTimeFormat`. Override with a new optional `timezone` config field (IANA string).

## Why

The model reads the envelope to answer questions like "what day is it?" and "when did this happen?". Giving it local time directly removes the prompt-layer timezone-conversion tax and works uniformly across weak and frontier models. Matches how OpenClaw frames its envelopes.

## Storage: unchanged invariant

- `session.jsonl` — no schema change; only the rendered envelope text differs
- `recall.db` — no schema change. `messages.timestamp` is still TEXT, still **UTC `...Z`** for every row. Recall normalizes the ingested envelope string to UTC on the way in, so legacy rows and new rows share one format
- `semantic_segments` — no schema change
- Logs, backups, session/pairing/subagent/media metadata, filesystem mtimes — all still UTC

No migration, no drop/recreate, no rewrites.

## Files

- `src/util.ts` — add `formatLocalISO()` and `resolveHostTimezone()` helpers
- `src/config.ts` — add optional `timezone` field (default `""` = autoresolve)
- `src/app.ts` — resolve `envelopeTimezone` once at startup, apply to both envelope builders (incoming message + same-channel injections)
- `src/plugins/recall/recall.ts` — widen timestamp regex to match both `Z` and `±HH:MM` suffix; normalize to UTC on ingest so the `recall.db` timestamp column stays canonical
- `templates/AGENTS.md` — point at the envelope `time:` field for daily-note dating
- `templates/KERN.md` — document envelope `time:` format + config override in the runtime context the model sees
- `docs/config.md` — document `timezone` field
- `CHANGELOG.md`

## Testing

- Build clean
- `formatLocalISO` round-trip tested across UTC, LA, NYC, Tokyo; bad zone falls back to `toISOString()`
- Regex tested against both old and new envelope formats; matches both
- `toUTC()` normalization tested: offset → UTC, UTC idempotent, no-ms legacy → UTC, garbage → null, lex sort preserves chronology
- Confirmed no other call sites parse the envelope `time:` field (grepped)