### PR TITLE
docs: document system-generated envelopes, add interface reference table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - **Local-timezone envelope** ([#268](https://github.com/oguzbilgic/kern-ai/issues/268)) — the `time:` field the agent reads is now in local time with UTC offset (e.g. `2026-04-20T20:08:45-07:00`) instead of UTC. Defaults to host timezone; override with the new `timezone` config field (IANA string).
+- **Envelope reference docs** — `docs/interfaces.md` now covers system-generated envelopes (heartbeat, sub-agent announce) alongside human interfaces and includes a reference table of all current `interface`/`channel` values. `docs/architecture.md` frames the envelope as the core multi-channel contract. `docs/tools.md` sub-agent envelope example updated to match the canonical bracketed form.
 
 ### Fixes
 - **NO_REPLY leaks through interfaces** ([#273](https://github.com/oguzbilgic/kern-ai/issues/273)) — replies ending with `NO_REPLY` (e.g. `"…notes are up to date.\n\nNO_REPLY"`) are now suppressed on Telegram, Slack, Matrix, web UI, and TUI. Previously only exact-match `NO_REPLY` was caught.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,10 @@ These run inside the agent process itself — not separate services.
 
 All inject messages into the same queue as TUI and web. The agent doesn't know or care which interface a message came from — it sees metadata tags like `[via telegram, user: oguz]`. See [docs/interfaces.md § Metadata contract](interfaces.md#metadata-contract) for the full metadata surfaces (text prefix, internal message object, SSE events) and per-interface field mappings.
 
+### The envelope is the contract
+
+Every message reaching the model — from humans on any interface, from heartbeat timers, from sub-agent announces — is prefixed with the same metadata envelope: `[via <interface>, <channel>, user: <id>, time: <iso8601>]`. This uniformity is what makes multi-channel unification work: the agent reads one message stream, decides based on envelope metadata who's talking and how to respond, and trusts the runtime to route replies back to the right place. New interfaces and internal message sources just need to produce valid envelopes; everything downstream is already wired.
+
 ## Service management
 
 `kern install` creates systemd user services for agents, the web server, and the proxy. This gives you:

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -10,7 +10,7 @@ All messages include context metadata prepended to the text:
 [via <interface>, <channel>, user: <id>, time: <iso8601>]
 ```
 
-Examples:
+Examples from human interfaces:
 
 ```
 [via telegram, telegram:12345, user: 8105113489, time: 2026-04-06T14:30:00-07:00]
@@ -20,9 +20,31 @@ Examples:
 [via tui, tui, user: tui, time: 2026-04-06T14:30:00-07:00]
 ```
 
+Examples from system-generated messages (heartbeats, sub-agent announces):
+
+```
+[via system, heartbeat, user: system, time: 2026-04-20T14:30:00-07:00]
+[via subagent, subagent:sa_a1b2c3d4e5f6, user: subagent, time: 2026-04-20T22:20:38-07:00]
+```
+
 The `time:` field is ISO 8601 in the host's local timezone with UTC offset. Override with the `timezone` config field (see [config](config.md)). Storage (logs, recall, session metadata) stays UTC regardless.
 
 The agent sees who's talking, from which channel, and when — and adapts behavior accordingly via instructions in `KERN.md`.
+
+### Interface reference
+
+| `interface` | Typical `channel` | Source | Origin |
+|-------------|-------------------|--------|--------|
+| `telegram` | `telegram:<chatId>` | `src/interfaces/telegram.ts` | Telegram user |
+| `slack` | `#channel-name` or `slack:<Dxxx>` | `src/interfaces/slack.ts` | Slack user |
+| `matrix` | `matrix:<roomId>` | `src/interfaces/matrix.ts` | Matrix user |
+| `cli` | `cli` | `src/interfaces/cli.ts` | CLI invocation |
+| `web` | `web` | HTTP POST to `/message` | Web UI user |
+| `tui` | `tui` | HTTP POST to `/message` | TUI client |
+| `system` | `heartbeat` | `src/app.ts` runtime timer | Heartbeat injection |
+| `subagent` | `subagent:<id>` | Sub-agent completion | Sub-agent announce |
+
+The set is extensible — plugins and future interfaces can introduce new values. The envelope format is the stable contract; specific `interface`/`channel` values depend on what's loaded at runtime.
 
 ## Metadata contract
 
@@ -58,7 +80,7 @@ Messages enter the runtime via two paths:
 | `attachments` | `Attachment[]` | no | Base64-encoded attachments |
 | `connectionId` | `string` | no | SSE connection ID to exclude from the echo broadcast |
 
-The runtime itself also synthesizes `interface: "system"` for heartbeat messages (`src/app.ts`).
+The runtime itself also synthesizes messages for internal injections: `interface: "system"` for heartbeats and `interface: "subagent"` for sub-agent announces (both in `src/app.ts`).
 
 ### Surface 3 — SSE broadcast events
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -142,7 +142,7 @@ spawn({ prompt: "Research Node.js 22 crypto changes and summarize breaking chang
 - `prompt` — the task for the sub-agent (self-contained — child starts with no context about your current work)
 - `maxSteps` — max reasoning steps (default 20, max 50)
 
-When the child finishes, its result arrives as a new turn from `via subagent, subagent:<id>`. The envelope identifies the source; the body is the child's final answer (no extra header on success). Failed or cancelled sub-agents prefix the body with a `[subagent:<id> failed, 12s]` style line so the outcome is visible. You can spawn multiple sub-agents in parallel and synthesize their results as they arrive.
+When the child finishes, its result arrives as a new turn with metadata like `[via subagent, subagent:<id>, user: subagent, time: <iso8601>]`. The envelope identifies the source; the body is the child's final answer (no extra header on success). Failed sub-agents prefix the body with a `[subagent:<id> failed, 12s]` style line so the outcome is visible; cancelled sub-agents emit only the header line with no body. You can spawn multiple sub-agents in parallel and synthesize their results as they arrive.
 
 Sub-agents run with a read-only toolset: `read`, `glob`, `grep`, `webfetch`, `websearch`, `pdf`, `image`. They cannot run shell commands, edit files, call plugin tools, or spawn further sub-agents.
 


### PR DESCRIPTION
Documents system-generated envelopes (heartbeat, sub-agent) alongside human interfaces and adds a reference table so readers don't have to grep source to discover every envelope shape.

## Motivation

`docs/interfaces.md` has good coverage for telegram/slack/matrix/web/tui envelopes, but system-generated envelopes — heartbeat injections (`[via system, heartbeat, ...]`) and sub-agent announces (`[via subagent, subagent:<id>, ...]`) — aren't documented anywhere. Both are real envelopes the model sees, surfaced tonight while debugging sub-agent reply routing.

Decoupled from #277 intentionally — the envelope *format* is stable; how replies are *routed* is a separate concern that may or may not be solved with `originChannel`.

## Changes

- **`docs/interfaces.md`** — second examples block for system-generated envelopes; new reference table enumerating current `interface`/`channel` values with their source and origin; note on extensibility. Metadata-contract section now mentions sub-agent alongside heartbeat as runtime-synthesized.
- **`docs/architecture.md`** — short paragraph framing the envelope as the core multi-channel contract and why uniformity matters.
- **`docs/tools.md`** — sub-agent envelope example was drifted (unbracketed shorthand `via subagent, subagent:<id>`). Updated to the canonical bracketed form used everywhere else. Clarifies cancelled announces emit header only, no body.
- **`CHANGELOG.md`** — Improvements entry under `next`.

Docs only — no code, no behavior change.
