### PR TITLE
chore: bump to 0.31.1-next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## next
+
 ## v0.31.1
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kern-ai",
-  "version": "0.31.1",
+  "version": "0.31.1-next",
   "description": "Simple agent runtime. Persistent memory, tools, Telegram.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Post-release version bump. v0.31.1 is published to npm (`@latest`) and ghcr.io. Opens the next development cycle with an empty `## next` changelog section.