### PR TITLE
Support OPENAI_BASE_URL for the openai provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next
 
+### Improvements
+- **`OPENAI_BASE_URL` support for the openai provider** ([#289](https://github.com/oguzbilgic/kern-ai/issues/289)) — set `OPENAI_BASE_URL` in `.kern/.env` to route the `openai` provider to any OpenAI-compatible endpoint (Azure OpenAI, LiteLLM, local proxies). When set, requests use the Chat Completions API for broad gateway compatibility. Defaults unchanged when unset.
+
 ## v0.31.1
 
 ### Improvements

--- a/docs/config.md
+++ b/docs/config.md
@@ -89,7 +89,7 @@ Secrets. Gitignored. Never committed.
 
 ```
 OPENROUTER_API_KEY=sk-or-...
-OPENAI_BASE_URL=https://api.openai.com/v1
+# OPENAI_BASE_URL=https://my-litellm-gateway.example.com/v1  # optional: route openai provider to a compatible endpoint
 OLLAMA_BASE_URL=http://localhost:11434
 SEARXNG_URL=http://searxng:8080
 JINA_API_KEY=jina_...

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,7 +45,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 
 - **openrouter** — routes to cheapest provider. Model IDs like `anthropic/claude-opus-4.7`. Uses OpenAI-compatible chat completions API.
 - **anthropic** — direct Anthropic API. Model IDs like `claude-opus-4-7`.
-- **openai** — OpenAI or Azure. Model IDs like `gpt-4o`.
+- **openai** — OpenAI or any OpenAI-compatible endpoint. Model IDs like `gpt-4o`. Set `OPENAI_BASE_URL` in `.env` to route to Azure OpenAI, LiteLLM, or other compatible gateways (default: `https://api.openai.com/v1`). With a custom base URL, requests use the Chat Completions API.
 - **ollama** — local Ollama server. Model IDs match Ollama model names like `gemma4:31b`. Set `OLLAMA_BASE_URL` in `.env` for remote servers (default: `http://localhost:11434`).
 
 ### Summary model
@@ -89,6 +89,7 @@ Secrets. Gitignored. Never committed.
 
 ```
 OPENROUTER_API_KEY=sk-or-...
+OPENAI_BASE_URL=https://api.openai.com/v1
 OLLAMA_BASE_URL=http://localhost:11434
 SEARXNG_URL=http://searxng:8080
 JINA_API_KEY=jina_...

--- a/src/model.ts
+++ b/src/model.ts
@@ -4,6 +4,12 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { embed } from "ai";
 import type { KernConfig } from "./config.js";
 
+/** Normalized OPENAI_BASE_URL — trimmed, trailing slashes stripped, undefined if unset/empty. */
+function openaiBaseURL(): string | undefined {
+  const raw = process.env.OPENAI_BASE_URL?.trim().replace(/\/+$/, "");
+  return raw || undefined;
+}
+
 const OPENROUTER_HEADERS = {
   "HTTP-Referer": "https://github.com/oguzbilgic/kern-ai",
   "X-Title": "Kern Agent",
@@ -18,9 +24,7 @@ const OPENROUTER_HEADERS = {
 function createOpenAIClient(provider: string) {
   switch (provider) {
     case "openai":
-      return createOpenAI({
-        baseURL: process.env.OPENAI_BASE_URL || undefined,
-      });
+      return createOpenAI({ baseURL: openaiBaseURL() });
     case "ollama": {
       const base = (process.env.OLLAMA_BASE_URL || "http://localhost:11434").replace(/\/+$/, "");
       return createOpenAI({
@@ -130,13 +134,12 @@ export function createModel(config: KernConfig): any {
       return openai.chat(config.model);
     }
     case "openai": {
-      const openai = createOpenAI({
-        baseURL: process.env.OPENAI_BASE_URL || undefined,
-      });
+      const baseURL = openaiBaseURL();
+      const openai = createOpenAI({ baseURL });
       // Custom OpenAI-compatible endpoints (Azure, LiteLLM, local proxies)
       // typically only support the Chat Completions API, not the Responses API
       // that the default openai() factory picks for newer models
-      if (process.env.OPENAI_BASE_URL) return openai.chat(config.model);
+      if (baseURL) return openai.chat(config.model);
       return openai(config.model);
     }
     case "ollama": {

--- a/src/model.ts
+++ b/src/model.ts
@@ -18,7 +18,9 @@ const OPENROUTER_HEADERS = {
 function createOpenAIClient(provider: string) {
   switch (provider) {
     case "openai":
-      return createOpenAI();
+      return createOpenAI({
+        baseURL: process.env.OPENAI_BASE_URL || undefined,
+      });
     case "ollama": {
       const base = (process.env.OLLAMA_BASE_URL || "http://localhost:11434").replace(/\/+$/, "");
       return createOpenAI({
@@ -128,7 +130,13 @@ export function createModel(config: KernConfig): any {
       return openai.chat(config.model);
     }
     case "openai": {
-      const openai = createOpenAI();
+      const openai = createOpenAI({
+        baseURL: process.env.OPENAI_BASE_URL || undefined,
+      });
+      // Custom OpenAI-compatible endpoints (Azure, LiteLLM, local proxies)
+      // typically only support the Chat Completions API, not the Responses API
+      // that the default openai() factory picks for newer models
+      if (process.env.OPENAI_BASE_URL) return openai.chat(config.model);
       return openai(config.model);
     }
     case "ollama": {


### PR DESCRIPTION
Closes #289

## What
The `openai` provider always routed to `api.openai.com` — `createOpenAI()` was called with no options in both `createModel()` and `createOpenAIClient()`. This made it impossible to use OpenAI-compatible endpoints (Azure OpenAI, LiteLLM, OneAPI, local proxies) with `provider: "openai"`.

## Changes
- `createModel()` and `createOpenAIClient()` now pass `baseURL: process.env.OPENAI_BASE_URL || undefined` — mirrors the existing `OLLAMA_BASE_URL` pattern
- When `OPENAI_BASE_URL` is set, `createModel()` uses `openai.chat()` (Chat Completions API) instead of the default `openai()` factory, which picks the Responses API for newer models — most compatible gateways don't support the Responses API (same reasoning as the existing OpenRouter path)
- Docs: `docs/config.md` provider section + `.env` example
- Changelog entry under `next`

## Behavior
- `OPENAI_BASE_URL` unset → identical to before (default base URL, default API selection)
- `OPENAI_BASE_URL` set → all openai-provider chat, summary, and embedding requests route to the custom endpoint

## Tested
- Build clean
- Verified via `dist/model.js`: with `OPENAI_BASE_URL=http://127.0.0.1:9999/v1`, model request URLs resolve to the custom base; embedding model creation works; unset env var preserves defaults