### PR TITLE
Fix prompt cache thrashing: trim boundary hysteresis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - **Disable thinking on Ollama auxiliary calls** — `think: false` now also applies to summarization and media digest, preventing empty summaries and missing image descriptions on thinking models.
 
 ### Fixes
-- **Prompt cache thrashing on long sessions** ([#295](https://github.com/oguzbilgic/kern-ai/issues/295)) — the trim boundary advanced every turn on tool-heavy sessions, rewriting the full ~100k+ token cache prefix at 1.25× input price per message. The boundary is now sticky (hysteresis): it holds until the message window exceeds the budget by 20%, then jumps forward in one step to 70% of budget. One cache write per jump instead of one per turn — roughly 10× cheaper per message on active large sessions.
+- **Prompt cache thrashing on long sessions** ([#295](https://github.com/oguzbilgic/kern-ai/issues/295)) — the trim boundary advanced every turn on tool-heavy sessions, rewriting the full ~100k+ token cache prefix at 1.25× input price per message. The boundary is now sticky (hysteresis): it holds until the message window reaches the configured budget, then jumps forward in one step to 60% of budget — the budget remains a hard ceiling. One cache write per jump instead of one per turn — roughly 10× cheaper per message on active large sessions.
 - **Pin `unpdf` to exact 1.6.2** ([#285](https://github.com/oguzbilgic/kern-ai/issues/285)) — unpdf 1.6.0 broke the `pdf` tool on Node 22; pinning prevents untested upstream releases from breaking fresh installs.
 
 ## v0.31.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Disable thinking on Ollama auxiliary calls** — `think: false` now also applies to summarization and media digest, preventing empty summaries and missing image descriptions on thinking models.
 
 ### Fixes
+- **Prompt cache thrashing on long sessions** ([#295](https://github.com/oguzbilgic/kern-ai/issues/295)) — the trim boundary advanced every turn on tool-heavy sessions, rewriting the full ~100k+ token cache prefix at 1.25× input price per message. The boundary is now sticky (hysteresis): it holds until the message window exceeds the budget by 20%, then jumps forward in one step to 70% of budget. One cache write per jump instead of one per turn — roughly 10× cheaper per message on active large sessions.
 - **Pin `unpdf` to exact 1.6.2** ([#285](https://github.com/oguzbilgic/kern-ai/issues/285)) — unpdf 1.6.0 broke the `pdf` tool on Node 22; pinning prevents untested upstream releases from breaking fresh installs.
 
 ## v0.31.1

--- a/src/context.ts
+++ b/src/context.ts
@@ -195,8 +195,10 @@ const TRIM_SNAP = 20;
 // budget × LOW. Between jumps the message prefix is byte-identical across
 // turns, so prompt caching gets near-100% hits instead of rewriting the full
 // prefix every turn as the boundary creeps forward.
-const TRIM_HIGH_WATERMARK = 1.2;
-const TRIM_LOW_WATERMARK = 0.7;
+// HIGH is 1.0 so the configured budget is a true ceiling — the hysteresis band
+// sits *below* the budget rather than overshooting it.
+const TRIM_HIGH_WATERMARK = 1.0;
+const TRIM_LOW_WATERMARK = 0.6;
 
 // sessionId → held cut index (absolute index into the session messages array).
 // In-memory only: after a restart the first turn pays one full cache write and

--- a/src/context.ts
+++ b/src/context.ts
@@ -190,14 +190,36 @@ interface TrimOptions {
 
 const TRIM_SNAP = 20;
 
+// Trim hysteresis watermarks (#295). The boundary is held until the window
+// after it exceeds budget × HIGH, then jumps forward so the window shrinks to
+// budget × LOW. Between jumps the message prefix is byte-identical across
+// turns, so prompt caching gets near-100% hits instead of rewriting the full
+// prefix every turn as the boundary creeps forward.
+const TRIM_HIGH_WATERMARK = 1.2;
+const TRIM_LOW_WATERMARK = 0.7;
+
+// sessionId → held cut index (absolute index into the session messages array).
+// In-memory only: after a restart the first turn pays one full cache write and
+// re-establishes the boundary.
+const heldTrimBoundaries = new Map<string, number>();
+
+/** Test-only: reset hysteresis state between test cases. */
+export function clearTrimBoundaries(): void {
+  heldTrimBoundaries.clear();
+}
+
 /**
  * Trim oldest messages to fit within a token budget.
  *
  * The cut point is always a user message (turn boundary) to avoid orphaning
  * tool_result blocks. When segment data is available, the cut point is snapped
- * to a stable position (L0 segment edge or round-20 boundary) so the message
- * window prefix stays byte-identical across consecutive turns — critical for
- * prompt caching.
+ * to a stable position (L0 segment edge or round-20 boundary).
+ *
+ * The cut point is sticky (hysteresis): once chosen it is reused verbatim on
+ * subsequent calls until the resulting window exceeds the high watermark, at
+ * which point it jumps forward to bring the window down to the low watermark.
+ * This keeps the message window prefix byte-identical across many consecutive
+ * turns — critical for prompt caching (#295).
  */
 function trimToTokenBudget({ messages, maxTokens, segmentIndex, sessionId }: TrimOptions): { messages: ModelMessage[]; trimmedCount: number } {
   if (maxTokens <= 0) return { messages, trimmedCount: 0 };
@@ -209,10 +231,25 @@ function trimToTokenBudget({ messages, maxTokens, segmentIndex, sessionId }: Tri
   }
   if (total <= maxTokens) return { messages, trimmedCount: 0 };
 
-  // Find initial cut point from the front
+  // Hysteresis hold: reuse the previous boundary while the window after it
+  // still fits under the high watermark. Prefix stays stable → cache hits.
+  const held = sessionId ? heldTrimBoundaries.get(sessionId) : undefined;
+  if (held !== undefined && held > 0 && held < messages.length - 1 && messages[held]?.role === "user") {
+    let windowTotal = 0;
+    for (let i = held; i < messages.length; i++) {
+      windowTotal += getMsgSize(messages[i]);
+    }
+    if (windowTotal <= maxTokens * TRIM_HIGH_WATERMARK) {
+      return { messages: messages.slice(held), trimmedCount: held };
+    }
+  }
+
+  // Jump: find a fresh cut point targeting the low watermark so the boundary
+  // stays put for many turns before the next jump.
+  const targetTokens = Math.max(1, Math.round(maxTokens * TRIM_LOW_WATERMARK));
   let cutTotal = total;
   let cutIndex = 0;
-  while (cutIndex < messages.length - 1 && cutTotal > maxTokens) {
+  while (cutIndex < messages.length - 1 && cutTotal > targetTokens) {
     cutTotal -= getMsgSize(messages[cutIndex]);
     cutIndex++;
   }
@@ -256,6 +293,14 @@ function trimToTokenBudget({ messages, maxTokens, segmentIndex, sessionId }: Tri
         cutIndex = safeSnap;
       }
     }
+  }
+
+  if (sessionId && cutIndex > 0) {
+    const prev = heldTrimBoundaries.get(sessionId);
+    if (prev !== cutIndex) {
+      log("context", `trim boundary jump: ${prev ?? "none"} → ${cutIndex} (${messages.length - cutIndex} msgs in window, budget ${maxTokens})`);
+    }
+    heldTrimBoundaries.set(sessionId, cutIndex);
   }
 
   return { messages: messages.slice(cutIndex), trimmedCount: cutIndex };


### PR DESCRIPTION
Fixes #295

## Problem

On long, tool-heavy sessions the trim boundary advances **every turn** (each turn appends 20–30 messages, the session sits at the token budget, so `trimToTokenBudget` recomputes a new cut point each call). When the boundary moves, both the message-window prefix and the injected conversation summary change, invalidating the entire ~125k-token cache prefix — a full cache write at 1.25× input price (~$2.30/turn at Opus-class pricing) even for turns seconds apart.

Observed on vega (74k-message session): two turns 3 minutes apart, both exactly 50% hit with `read == write` — system block survived, full message prefix rewritten.

## Fix

Make the cut point sticky with high/low watermarks:

- **Hold:** reuse the previous boundary verbatim while the window after it fits within `budget × 1.2`. Prefix stays byte-identical → near-100% cache hits. Summary range (`trimmedCount`) is also unchanged, so the summary block stays stable too.
- **Jump:** on watermark breach, compute a fresh cut targeting `budget × 0.7` (snapped to L0 segment / round-20 boundary and walked back to a user message, as before). One expensive cache write, then dozens of cheap turns.

State is an in-memory `Map<sessionId, cutIndex>` — after a restart the first turn pays one full write and re-establishes the boundary. Indices are absolute session-array positions, which are append-stable.

## Verification

Synthetic test (200-turn session, 10k budget, appending 2 msgs/turn for 30 turns):

```
turn1 trimmed: 360 (boundary established)
turn2 held: YES
jump at turn 25: 360 → 400 (window 6614 tokens)
30 turns: 29 holds, 1 jumps
```

Previous behavior would have moved the boundary on most of those turns.

## Notes

- Window now oscillates between 0.7× and 1.2× of the raw budget instead of pinning at 1.0× — peak context is slightly higher, average slightly lower.
- New `trim boundary jump` info log makes jump frequency observable.
- Complementary, out of scope: Anthropic `ttl: "1h"` for sparse conversations, cheaper heartbeat model (#81).