### PR TITLE
feat: kern scripts recover-session — rebuild session from recall.db (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **`subAgentModel` config field** ([#287](https://github.com/oguzbilgic/kern-ai/issues/287)) — run spawned sub-agents on a cheaper model than the parent. Empty = inherit. The `spawn` tool also accepts a per-child `model` override.
 
 ### Improvements
-- **`kern scripts recover-session`** ([#301](https://github.com/oguzbilgic/kern-ai/issues/301)) — rebuild a session `.jsonl` from `recall.db` when the session file is lost or truncated (e.g. a crash mid-write). recall.db stores every message losslessly, so the conversation is recoverable. Reuses the original session ID and writes to the current directory. New `kern scripts <name>` command group for recovery/utility tooling.
+- **`kern scripts recover-session`** ([#301](https://github.com/oguzbilgic/kern-ai/issues/301)) — rebuild a lost or truncated session `.jsonl` from `recall.db`. New `kern scripts <name>` command group.
 - **`OPENAI_BASE_URL` support** ([#289](https://github.com/oguzbilgic/kern-ai/issues/289)) — route the `openai` provider to any OpenAI-compatible endpoint (Azure, LiteLLM, local proxies) via `.kern/.env`.
 - **Refreshed model defaults** — default model is now `anthropic/claude-opus-4.8`; init fallback lists updated for all providers; Anthropic media vision fallback bumped to `claude-sonnet-4-6`.
 - **Disable thinking on Ollama auxiliary calls** — `think: false` now also applies to summarization and media digest, preventing empty summaries and missing image descriptions on thinking models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **`subAgentModel` config field** ([#287](https://github.com/oguzbilgic/kern-ai/issues/287)) — run spawned sub-agents on a cheaper model than the parent. Empty = inherit. The `spawn` tool also accepts a per-child `model` override.
 
 ### Improvements
+- **`kern scripts recover-session`** ([#301](https://github.com/oguzbilgic/kern-ai/issues/301)) — rebuild a session `.jsonl` from `recall.db` when the session file is lost or truncated (e.g. a crash mid-write). recall.db stores every message losslessly, so the conversation is recoverable. Reuses the original session ID and writes to the current directory. New `kern scripts <name>` command group for recovery/utility tooling.
 - **`OPENAI_BASE_URL` support** ([#289](https://github.com/oguzbilgic/kern-ai/issues/289)) — route the `openai` provider to any OpenAI-compatible endpoint (Azure, LiteLLM, local proxies) via `.kern/.env`.
 - **Refreshed model defaults** — default model is now `anthropic/claude-opus-4.8`; init fallback lists updated for all providers; Anthropic media vision fallback bumped to `claude-sonnet-4-6`.
 - **Disable thinking on Ollama auxiliary calls** — `think: false` now also applies to summarization and media digest, preventing empty summaries and missing image descriptions on thinking models.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -228,6 +228,26 @@ scp /tmp/<uuid>.jsonl dockerhost:~/agent/.kern/sessions/       # install remotel
 
 Tested against lossless-claw v0.9.1. Older LCM DBs may fall through to flat message content or error on missing columns.
 
+## kern scripts recover-session
+
+Rebuild a session `.jsonl` from `recall.db` when the session file is lost or truncated (e.g. a process killed mid-write leaves a 0-byte file, crash-looping the agent on startup). recall.db stores every message losslessly, so the conversation is recoverable.
+
+- Reads any `recall.db` path you give it (read-only — never writes to the DB)
+- `--list` prints all sessions in the DB with message counts and date ranges
+- Recovers the session with the most messages by default; pass `--session <id>` to target another
+- Reuses the original session ID, so the output is a drop-in replacement
+- Writes `<session-id>.jsonl` to the current working directory
+
+```bash
+cd /tmp
+kern scripts recover-session /path/to/recall.db --list             # list sessions
+kern scripts recover-session /path/to/recall.db                    # largest session
+kern scripts recover-session /path/to/recall.db --session <id>     # specific session
+mv /tmp/<session-id>.jsonl <agent>/.kern/sessions/                 # install, then restart kern
+```
+
+recall.db only holds messages indexed at turn-finish, so the final turn or two before a crash may be missing — everything indexed is exact. The command warns if message indexes have gaps.
+
 ## Slash commands
 
 Type these in any channel (TUI, Web, Telegram, Slack). Handled by the runtime at the queue level — never sent to the LLM. Instant, zero tokens. Results are broadcast to all connected clients via SSE.

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ async function showHelp() {
   w(`    ${cyan("kern backup")} ${dim("<name>")}          backup agent to .tar.gz`);
   w(`    ${cyan("kern import")} ${dim("opencode <name>")}         import session from OpenCode`);
   w(`    ${cyan("kern import")} ${dim("openclaw-lcm <lcm.db>")}   import session from OpenClaw LCM`);
+  w(`    ${cyan("kern scripts")} ${dim("recover-session <recall.db>")}  rebuild a session from recall.db`);
   w(`    ${cyan("kern restore")} ${dim("<file>")}         restore agent from backup`);
   w(`    ${cyan("kern logs")} ${dim("[name] [-f] [-n 50] [--level warn]")}  show agent logs`);
   w(`    ${cyan("kern install")} ${dim("[name|--web|--proxy]")} install systemd services`);
@@ -272,6 +273,19 @@ async function main() {
       console.error("Usage:");
       console.error("  kern import opencode [--project <path>] [--session <title|latest>]");
       console.error("  kern import openclaw-lcm <lcm.db> [--conversation <id>] [--list]");
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (cmd === "scripts") {
+    const name = args[1]; // "recover-session"
+    if (name === "recover-session") {
+      const { recoverSession } = await import("./scripts/recover-session.js");
+      await recoverSession(args.slice(2));
+    } else {
+      console.error("Usage:");
+      console.error("  kern scripts recover-session <recall.db> [--list] [--session <id>]");
       process.exit(1);
     }
     return;

--- a/src/scripts/recover-session.ts
+++ b/src/scripts/recover-session.ts
@@ -1,0 +1,179 @@
+import Database from "better-sqlite3";
+import { existsSync } from "fs";
+import { writeFile } from "fs/promises";
+import { join, resolve } from "path";
+
+interface MsgRow {
+  msg_index: number;
+  role: string;
+  content: string;
+  timestamp: string | null;
+}
+
+interface SessionSummary {
+  session_id: string;
+  count: number;
+  minIndex: number;
+  maxIndex: number;
+  firstTs: string | null;
+  lastTs: string | null;
+}
+
+function summarizeSessions(db: Database.Database): SessionSummary[] {
+  const rows = db
+    .prepare(
+      `SELECT session_id,
+              COUNT(*) AS count,
+              MIN(msg_index) AS minIndex,
+              MAX(msg_index) AS maxIndex,
+              MIN(timestamp) AS firstTs,
+              MAX(timestamp) AS lastTs
+       FROM messages
+       GROUP BY session_id
+       ORDER BY count DESC`
+    )
+    .all() as SessionSummary[];
+  return rows;
+}
+
+/**
+ * Reverse the recall.db content serialization (recall.ts stores
+ * `typeof content === "string" ? content : JSON.stringify(content)`).
+ * Structured content (tool calls, multi-part) round-trips via JSON.parse;
+ * plain text stays a string.
+ */
+function reviveContent(raw: string): unknown {
+  const t = raw.trimStart();
+  if (t.startsWith("[") || t.startsWith("{")) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // Corrupt structured content — keep the raw string rather than fail.
+      return raw;
+    }
+  }
+  return raw;
+}
+
+export async function recoverSession(args: string[]): Promise<void> {
+  // args[0] = subcommand name already consumed by dispatcher? No — caller passes
+  // everything after "scripts recover-session". So args[0] is the db path.
+  const positional: string[] = [];
+  let list = false;
+  let sessionArg: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--list") list = true;
+    else if (a === "--session") sessionArg = args[++i];
+    else positional.push(a);
+  }
+
+  const dbArg = positional[0];
+  if (!dbArg) {
+    console.error("Usage: kern scripts recover-session <recall.db> [--list] [--session <id>]");
+    process.exit(1);
+  }
+
+  const dbPath = resolve(dbArg);
+  if (!existsSync(dbPath)) {
+    console.error(`recall.db not found at ${dbPath}`);
+    process.exit(1);
+  }
+
+  const db = new Database(dbPath, { readonly: true });
+
+  // Verify the messages table exists.
+  const hasTable = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'")
+    .get();
+  if (!hasTable) {
+    console.error(`No 'messages' table in ${dbPath} — not a recall database?`);
+    process.exit(1);
+  }
+
+  const sessions = summarizeSessions(db);
+  if (sessions.length === 0) {
+    console.error("No messages found in recall.db — nothing to recover.");
+    process.exit(1);
+  }
+
+  if (list) {
+    console.log(`Sessions in ${dbPath}:`);
+    console.log("");
+    for (const s of sessions) {
+      const range = `${s.firstTs ?? "?"} → ${s.lastTs ?? "?"}`;
+      console.log(`  ${s.session_id}`);
+      console.log(`    ${s.count} messages (index ${s.minIndex}–${s.maxIndex})   ${range}`);
+    }
+    console.log("");
+    return;
+  }
+
+  // Pick the session: explicit --session, else the one with the most messages.
+  let target: SessionSummary | undefined;
+  if (sessionArg) {
+    target = sessions.find((s) => s.session_id === sessionArg);
+    if (!target) {
+      console.error(`Session ${sessionArg} not found in recall.db. Use --list to see available sessions.`);
+      process.exit(1);
+    }
+  } else {
+    target = sessions[0]; // most messages (sorted DESC)
+  }
+
+  const sessionId = target.session_id;
+
+  const rows = db
+    .prepare(
+      "SELECT msg_index, role, content, timestamp FROM messages WHERE session_id = ? ORDER BY msg_index ASC"
+    )
+    .all(sessionId) as MsgRow[];
+
+  // Gap detection.
+  const gaps: Array<[number, number]> = [];
+  for (let i = 1; i < rows.length; i++) {
+    const prev = rows[i - 1].msg_index;
+    const cur = rows[i].msg_index;
+    if (cur !== prev + 1) gaps.push([prev, cur]);
+  }
+
+  const firstTs = rows.find((r) => r.timestamp)?.timestamp ?? null;
+  const lastTs = [...rows].reverse().find((r) => r.timestamp)?.timestamp ?? null;
+  const now = new Date().toISOString();
+
+  const meta = JSON.stringify({
+    id: sessionId,
+    createdAt: firstTs ?? now,
+    updatedAt: lastTs ?? now,
+    recoveredFrom: "recall.db",
+    sourceDb: dbPath,
+    messageCount: rows.length,
+  });
+
+  const lines = [meta];
+  for (const r of rows) {
+    lines.push(JSON.stringify({ role: r.role, content: reviveContent(r.content) }));
+  }
+
+  const outPath = join(process.cwd(), `${sessionId}.jsonl`);
+  await writeFile(outPath, lines.join("\n") + "\n");
+
+  console.log("");
+  console.log(`✓ Recovered ${rows.length} messages → ${outPath}`);
+  console.log(`  Session: ${sessionId}`);
+  console.log(`  Range:   index ${target.minIndex}–${target.maxIndex}  (${firstTs ?? "?"} → ${lastTs ?? "?"})`);
+  if (gaps.length > 0) {
+    console.log("");
+    console.log(`  ⚠ ${gaps.length} gap(s) in msg_index — some messages were never indexed:`);
+    for (const [a, b] of gaps.slice(0, 10)) console.log(`      ${a} → ${b}`);
+    if (gaps.length > 10) console.log(`      … and ${gaps.length - 10} more`);
+  }
+  console.log("");
+  console.log("  Note: recall.db only holds messages indexed at turn-finish, so the");
+  console.log("  final turn(s) before a crash may be missing. Everything indexed is exact.");
+  console.log("");
+  console.log("  Move into the agent's sessions dir to use it:");
+  console.log(`    mv ${outPath} <agent>/.kern/sessions/`);
+  console.log("");
+}


### PR DESCRIPTION
Closes #301. Recovery escape hatch for the crash-loop case in #300: when a session `.jsonl` is lost or truncated to 0 bytes, rebuild it from `recall.db`.

## Why this works
recall.db stores every message losslessly — `messages(session_id, msg_index, role, content, timestamp)`, where `content` is the raw string or `JSON.stringify(structured)` (recall.ts:84). So the full conversation is reconstructable even when the session file is gone.

## Command
```
kern scripts recover-session <recall.db> [--list] [--session <id>]
```
- New `kern scripts <name>` group for recovery/utility tooling (keeps it off the top-level list).
- `--list` — show all sessions in the db (msg count, index range, time range).
- `--session <id>` — pick a session; default = the one with the most messages.
- Writes `<session_id>.jsonl` to cwd (reuses original ID = correct drop-in name), prints a `mv` hint. **Read-only on recall.db; never overwrites a live session file.**

## Reconstruction
- `SELECT msg_index, role, content, timestamp FROM messages WHERE session_id=? ORDER BY msg_index`
- Per row: `content` starting with `[`/`{` → `JSON.parse` (tool calls / multipart round-trip); else keep string. Inverse of recall.ts:84.
- Meta line `{ id, createdAt: MIN(ts), updatedAt: MAX(ts), recoveredFrom: "recall.db", sourceDb, messageCount }`, then one `{role, content}` line per message.
- Warns on `msg_index` gaps; prints a caveat that the final crashed turn(s) (post last-index) may be missing.

## Tested against vega's live recall.db (75k+ msgs)
- `--list` → both sessions listed correctly.
- Recovered the 85-msg session and diffed against its still-present original file: **85/85 messages byte-identical**, 0 bad lines, all roles preserved (user/assistant/tool), 71 structured-content messages parsed back to arrays (not double-stringified). Output 66646 B vs original 66560 B.

## Not in this PR (see #300)
The crash guard in `session.load()` (don't die on empty/truncated files) and atomic writes in `save()` (prevent truncation) — those are the real fixes; this is the recovery path.
