### PR TITLE
Fix kern-media:// URIs leaking to the model provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixes
-- **`kern-media://` URIs leaking to the provider** — when media resolution failed (media file deleted or unreadable, sidecar never initialized), the raw `kern-media://` URI was sent to the model provider, which rejects the scheme (`URL scheme must be http, https, or data`). Because the session history never changes, one leaked URI locked the agent into that fatal error on every turn. Resolution failures now degrade to text placeholders (`[attached image: <file>]`), the media sidecar is created lazily instead of skipping resolution when missing, and a final strip pass guarantees no raw media URI ever reaches the provider.
+- **`kern-media://` URIs leaking to the provider** ([#307](https://github.com/oguzbilgic/kern-ai/pull/307)) — when media resolution failed (media file deleted or unreadable, sidecar never initialized), the raw `kern-media://` URI was sent to the model provider, which rejects the scheme (`URL scheme must be http, https, or data`). Because the session history never changes, one leaked URI locked the agent into that fatal error on every turn. Resolution failures now degrade to text placeholders (`[attached image: <file>]`), the media sidecar is created lazily instead of skipping resolution when missing, and a final strip pass guarantees no raw media URI ever reaches the provider.
 
 ## 0.32.0 (2026-06-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **`kern-media://` URIs leaking to the provider** — when media resolution failed (media file deleted or unreadable, sidecar never initialized), the raw `kern-media://` URI was sent to the model provider, which rejects the scheme (`URL scheme must be http, https, or data`). Because the session history never changes, one leaked URI locked the agent into that fatal error on every turn. Resolution failures now degrade to text placeholders (`[attached image: <file>]`), the media sidecar is created lazily instead of skipping resolution when missing, and a final strip pass guarantees no raw media URI ever reaches the provider.
+
 ## 0.32.0 (2026-06-24)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build:web": "cd web && npm run build",
     "prepublishOnly": "npm run build",
     "dev": "tsx src/index.ts",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "tsx --test test/media.test.ts"
   },
   "keywords": [
     "ai",

--- a/src/plugins/media/media.ts
+++ b/src/plugins/media/media.ts
@@ -259,7 +259,15 @@ export async function digestMediaAtIngest(
   const fullPath = join(mediaDir, file);
   if (!existsSync(fullPath)) return null;
 
-  const buf = readFileSync(fullPath);
+  let buf: Buffer;
+  try {
+    buf = readFileSync(fullPath);
+  } catch (err) {
+    // existsSync passed but the read failed (deleted in between, permissions).
+    // A digest miss must never take the turn down.
+    log.warn("media", `cannot read ${file} for digest: ${err}`);
+    return null;
+  }
   const chain = getDigestModelChain(config);
 
   // Ollama thinking models blow the 300-token budget on reasoning before
@@ -412,7 +420,14 @@ export async function resolveMediaInMessages(
             let description = sidecar.getDescription(filename);
             if (!description) {
               const mimeType = part.mediaType || "image/unknown";
-              description = await digestMediaAtIngest(sidecar, agentDir, filename, mimeType, config);
+              try {
+                description = await digestMediaAtIngest(sidecar, agentDir, filename, mimeType, config);
+              } catch (err) {
+                // A raw kern-media:// URI reaching the provider is a fatal,
+                // self-repeating error — fall through to the placeholder.
+                log.warn("media", `digest failed for ${filename}: ${err}`);
+                description = null;
+              }
             }
             if (description) {
               digested++;
@@ -423,16 +438,22 @@ export async function resolveMediaInMessages(
           // 2. Within mediaContext limit — resolve to raw Buffer
           if (resolveSet.has(msgIdx)) {
             const fullPath = join(mediaDir, filename);
-            if (existsSync(fullPath)) {
-              resolved++;
-              const buf = new Uint8Array(readFileSync(fullPath));
-              if (part.type === "image") {
-                return { ...part, image: buf };
-              } else {
-                return { ...part, data: buf };
+            try {
+              if (existsSync(fullPath)) {
+                const buf = new Uint8Array(readFileSync(fullPath));
+                resolved++;
+                if (part.type === "image") {
+                  return { ...part, image: buf };
+                } else {
+                  return { ...part, data: buf };
+                }
               }
+              log.warn("media", `file not found: ${filename}`);
+            } catch (err) {
+              // Read can fail even after existsSync (deleted in between,
+              // permissions, path is a directory). Placeholder, not a throw.
+              log.warn("media", `failed to read ${filename}: ${err}`);
             }
-            log.warn("media", `file not found: ${filename}`);
           }
 
           // 3. Text placeholder
@@ -452,4 +473,33 @@ export async function resolveMediaInMessages(
   if (placeholders > 0) log.debug("media", `${placeholders} media placeholder(s)`);
 
   return result;
+}
+
+/**
+ * Last-resort guard: replace any kern-media:// part still present with a text
+ * placeholder. Providers reject the scheme outright ("URL scheme must be
+ * http, https, or data"), and because the session history never changes, one
+ * leaked URI locks the agent into a fatal error on every subsequent turn.
+ * Covers what resolveMediaInMessages doesn't: non-user roles, and anything
+ * left behind if resolution itself failed. Pure transformation, no I/O.
+ */
+export function stripUnresolvedMedia(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map((msg) => {
+    if (!Array.isArray(msg.content)) return msg;
+    let changed = false;
+    const parts = (msg.content as any[]).map((p) => {
+      const uri =
+        p.type === "image" && typeof p.image === "string" && p.image.startsWith(MEDIA_SCHEME)
+          ? p.image
+          : p.type === "file" && typeof p.data === "string" && p.data.startsWith(MEDIA_SCHEME)
+            ? p.data
+            : null;
+      if (!uri) return p;
+      changed = true;
+      const filename = uri.slice(MEDIA_SCHEME.length);
+      const isImage = p.type === "image" || p.mediaType?.startsWith("image/");
+      return { type: "text" as const, text: `[${isImage ? "attached image" : "attached file"}: ${filename} (unavailable)]` };
+    });
+    return changed ? ({ ...msg, content: parts } as ModelMessage) : msg;
+  });
 }

--- a/src/plugins/media/plugin.ts
+++ b/src/plugins/media/plugin.ts
@@ -3,7 +3,7 @@ import type { KernPlugin, PluginContext, RouteHandler } from "../types.js";
 import type { Attachment } from "../../interfaces/types.js";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { saveMedia, buildUserContent, MediaSidecar, resolveMediaInMessages, digestMediaAtIngest } from "./media.js";
+import { saveMedia, buildUserContent, MediaSidecar, resolveMediaInMessages, digestMediaAtIngest, stripUnresolvedMedia } from "./media.js";
 import { log } from "../../log.js";
 
 const MIME_MAP: Record<string, string> = {
@@ -14,6 +14,25 @@ const MIME_MAP: Record<string, string> = {
 };
 
 let mediaSidecar: MediaSidecar | null = null;
+
+/**
+ * Get the sidecar, creating it lazily if the session wasn't loaded yet when
+ * onStartup ran. Resolution must never be skipped for lack of a sidecar — it
+ * only needs it for labels and the digest cache.
+ */
+function ensureSidecar(ctx: PluginContext): MediaSidecar {
+  if (mediaSidecar) return mediaSidecar;
+  const sessionsDir = join(ctx.agentDir, ".kern", "sessions");
+  const sessionId = ctx.sessionId();
+  if (sessionId) {
+    mediaSidecar = new MediaSidecar(sessionsDir, sessionId, ctx.db);
+    mediaSidecar.load();
+    return mediaSidecar;
+  }
+  // No session yet — ephemeral, not cached, so the real one is picked up
+  // as soon as a session exists.
+  return new MediaSidecar(sessionsDir, "unknown-session", null);
+}
 
 export const mediaPlugin: KernPlugin = {
   name: "media",
@@ -79,20 +98,19 @@ export const mediaPlugin: KernPlugin = {
       if (attachments.length === 0) return null;
 
       const mediaRefs: Awaited<ReturnType<typeof saveMedia>>[] = [];
+      const sidecar = ensureSidecar(ctx);
       for (const att of attachments) {
         const ref = saveMedia(ctx.agentDir, att.data, att.mimeType, att.filename);
         log("runtime", `saved media: ${ref.uri} (${ref.size} bytes)`);
-        if (mediaSidecar) {
-          mediaSidecar.append({
-            file: ref.file,
-            originalName: att.filename,
-            mimeType: ref.mimeType,
-            size: ref.size,
-            timestamp: new Date().toISOString(),
-          });
-          if (ctx.config.mediaDigest) {
-            await digestMediaAtIngest(mediaSidecar, ctx.agentDir, ref.file, ref.mimeType, ctx.config);
-          }
+        sidecar.append({
+          file: ref.file,
+          originalName: att.filename,
+          mimeType: ref.mimeType,
+          size: ref.size,
+          timestamp: new Date().toISOString(),
+        });
+        if (ctx.config.mediaDigest) {
+          await digestMediaAtIngest(sidecar, ctx.agentDir, ref.file, ref.mimeType, ctx.config);
         }
         mediaRefs.push(ref);
       }
@@ -100,8 +118,16 @@ export const mediaPlugin: KernPlugin = {
     },
 
     async resolveMessages(messages: ModelMessage[], ctx: PluginContext): Promise<ModelMessage[]> {
-      if (!mediaSidecar) return messages;
-      return resolveMediaInMessages(messages, mediaSidecar, ctx.agentDir, ctx.config);
+      // Providers reject the kern-media: scheme as a fatal error, and the
+      // dispatcher fails open on plugin errors — so resolution must neither
+      // be skipped nor allowed to leak a raw URI, no matter what fails here.
+      let resolved = messages;
+      try {
+        resolved = await resolveMediaInMessages(messages, ensureSidecar(ctx), ctx.agentDir, ctx.config);
+      } catch (err) {
+        log.warn("media", `resolveMediaInMessages failed, stripping raw refs: ${err}`);
+      }
+      return stripUnresolvedMedia(resolved);
     },
   },
 

--- a/test/media.test.ts
+++ b/test/media.test.ts
@@ -1,0 +1,145 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { ModelMessage } from "ai";
+import {
+  MEDIA_SCHEME,
+  MediaSidecar,
+  buildUserContent,
+  resolveMediaInMessages,
+  stripUnresolvedMedia,
+} from "../src/plugins/media/media.js";
+import { mediaPlugin } from "../src/plugins/media/plugin.js";
+
+const CONFIG = { mediaDigest: false, mediaContext: 2 } as any;
+
+async function makeAgentDir(): Promise<string> {
+  const agentDir = await mkdtemp(join(tmpdir(), "kern-media-test-"));
+  await mkdir(join(agentDir, ".kern", "media"), { recursive: true });
+  await mkdir(join(agentDir, ".kern", "sessions"), { recursive: true });
+  return agentDir;
+}
+
+function sidecarFor(agentDir: string): MediaSidecar {
+  return new MediaSidecar(join(agentDir, ".kern", "sessions"), "test-session", null);
+}
+
+/** Assert no kern-media:// URI remains anywhere in the message array. */
+function assertNoRawRefs(messages: ModelMessage[]): void {
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) continue;
+    for (const p of msg.content as any[]) {
+      if (typeof p.image === "string") assert.ok(!p.image.startsWith(MEDIA_SCHEME), `raw image ref leaked: ${p.image}`);
+      if (typeof p.data === "string") assert.ok(!p.data.startsWith(MEDIA_SCHEME), `raw file ref leaked: ${p.data}`);
+    }
+  }
+}
+
+function mediaMessage(uri: string, image = true): ModelMessage {
+  return {
+    role: "user",
+    content: image
+      ? [{ type: "image", image: uri, mediaType: "image/png" }, { type: "text", text: "look at this" }]
+      : [{ type: "file", data: uri, mediaType: "application/pdf", filename: "doc.pdf" }],
+  } as ModelMessage;
+}
+
+test("existing file within mediaContext resolves to a buffer", async () => {
+  const agentDir = await makeAgentDir();
+  try {
+    await writeFile(join(agentDir, ".kern", "media", "abc123.png"), Buffer.from([1, 2, 3]));
+    const messages = [mediaMessage(`${MEDIA_SCHEME}abc123.png`)];
+    const out = await resolveMediaInMessages(messages, sidecarFor(agentDir), agentDir, CONFIG);
+    const part = (out[0].content as any[])[0];
+    assert.equal(part.type, "image");
+    assert.ok(part.image instanceof Uint8Array);
+    assertNoRawRefs(out);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("missing file becomes a text placeholder, never a raw URI", async () => {
+  const agentDir = await makeAgentDir();
+  try {
+    const messages = [
+      mediaMessage(`${MEDIA_SCHEME}gone.png`),
+      mediaMessage(`${MEDIA_SCHEME}gone.pdf`, false),
+    ];
+    const out = await resolveMediaInMessages(messages, sidecarFor(agentDir), agentDir, CONFIG);
+    assertNoRawRefs(out);
+    assert.match((out[0].content as any[])[0].text, /attached image: gone\.png/);
+    assert.match((out[1].content as any[])[0].text, /attached file: gone\.pdf/);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("unreadable path (EISDIR) falls back to placeholder instead of throwing", async () => {
+  const agentDir = await makeAgentDir();
+  try {
+    // existsSync passes but readFileSync throws — the crash path behind the
+    // "URL scheme must be http, https, or data" lockup.
+    await mkdir(join(agentDir, ".kern", "media", "trap.png"));
+    const messages = [mediaMessage(`${MEDIA_SCHEME}trap.png`)];
+    const out = await resolveMediaInMessages(messages, sidecarFor(agentDir), agentDir, CONFIG);
+    assertNoRawRefs(out);
+    assert.match((out[0].content as any[])[0].text, /attached image: trap\.png/);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("digest path with unreadable file does not throw", async () => {
+  const agentDir = await makeAgentDir();
+  try {
+    await mkdir(join(agentDir, ".kern", "media", "trap.png"));
+    const messages = [mediaMessage(`${MEDIA_SCHEME}trap.png`)];
+    const config = { mediaDigest: true, mediaContext: 2, provider: "openai", model: "gpt-x" } as any;
+    const out = await resolveMediaInMessages(messages, sidecarFor(agentDir), agentDir, config);
+    assertNoRawRefs(out);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});
+
+test("stripUnresolvedMedia replaces leftover refs in any role", () => {
+  const messages: ModelMessage[] = [
+    mediaMessage(`${MEDIA_SCHEME}a.png`),
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "here" },
+        { type: "image", image: `${MEDIA_SCHEME}b.jpg`, mediaType: "image/jpeg" },
+      ],
+    } as ModelMessage,
+    { role: "user", content: "plain text untouched" },
+  ];
+  const out = stripUnresolvedMedia(messages);
+  assertNoRawRefs(out);
+  assert.match((out[1].content as any[])[1].text, /attached image: b\.jpg \(unavailable\)/);
+  assert.equal(out[2].content, "plain text untouched");
+  // Non-media parts and resolved buffers pass through unchanged
+  assert.equal((out[1].content as any[])[0].text, "here");
+});
+
+test("plugin resolveMessages resolves even without an initialized sidecar", async () => {
+  const agentDir = await makeAgentDir();
+  try {
+    await writeFile(join(agentDir, ".kern", "media", "late.png"), Buffer.from([9]));
+    const ctx = {
+      agentDir,
+      config: CONFIG,
+      db: null,
+      sessionId: () => null, // no session — previously caused a wholesale bypass
+    } as any;
+    const messages = [mediaMessage(`${MEDIA_SCHEME}late.png`), mediaMessage(`${MEDIA_SCHEME}gone.pdf`, false)];
+    const out = await mediaPlugin.onMessage!.resolveMessages!(messages, ctx);
+    assertNoRawRefs(out);
+    assert.ok(((out[0].content as any[])[0].image) instanceof Uint8Array);
+  } finally {
+    await rm(agentDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

When a user uploads a file, kern stores it under `.kern/media/` and persists a `kern-media://<hash>.<ext>` reference in the session JSONL. `resolveMediaInMessages` is supposed to convert these before `streamText` — but when resolution fails, the raw URI reaches the provider, which rejects the scheme as a fatal error:

```
URL scheme must be http, https, or data, got kern-media:
```

Because the session history never changes, one leaked URI **permanently locks the agent** into this error on every subsequent turn. Observed in production on a v0.32.0 agent (OpenRouter provider); the only workaround was rotating the session and losing history.

## Root cause — two leak paths

**1. Resolution can throw, and the dispatcher fails open.** `resolveMediaInMessages` guards file reads with `existsSync` but not `try/catch`: `readFileSync` still throws if the file is deleted between check and read (e.g. manual `.kern/media/` cleanup), on permission errors, or if the path is a directory. `digestMediaAtIngest` has the same unguarded read. When it throws, `dispatchResolveMessages` catches the error, logs it — and passes the **unresolved** messages straight through to `streamText`.

**2. Wholesale bypass when the sidecar is missing.** `plugin.ts` had `if (!mediaSidecar) return messages;` — if the sidecar wasn't created at `onStartup` (no session yet) it stayed null forever, and every media ref in the session leaked, every turn. The resolver only needs the sidecar for display labels and the digest cache; skipping resolution for lack of it turns a cosmetic gap into a fatal error.

Both paths reproduce mechanically (pre-fix):

```
resolver: THREW (EISDIR) -> dispatcher fails open -> raw URI to provider
plugin (no sidecar): RAW URI LEAKED to provider
```

## Fix (three layers)

1. **Never throw:** read failures in `resolveMediaInMessages` and `digestMediaAtIngest` now log a warning and degrade to the *existing* text-placeholder path (`[attached image: <file>]`) — the same treatment already given to files that fail the `existsSync` check.
2. **Never skip:** the sidecar is created lazily on first use (`ensureSidecar`); if there's still no session, resolution runs with an ephemeral sidecar rather than being bypassed. `processAttachments` also uses it, so uploads made before a session existed no longer silently skip sidecar/digest bookkeeping.
3. **Never leak (invariant):** `resolveMessages` finishes with a new pure `stripUnresolvedMedia()` pass that replaces any remaining `kern-media://` image/file part — in **any** role, covering shapes the resolver doesn't handle (it only processes user messages) — with a `[attached image: <file> (unavailable)]` placeholder. Even if resolution itself fails wholesale, no raw URI can leave the plugin.

The dispatcher's fail-open behavior is intentionally left unchanged (a broken plugin shouldn't kill unrelated turns); with the layers above, the media plugin simply never hands it unresolved output.

Existing behavior is preserved: resolvable media still resolves to buffers/digests exactly as before; recovery is automatic on upgrade — an agent currently stuck in the error loop starts responding again on next restart, keeping its history (missing media renders as placeholders).

## Tests

Adds `test/media.test.ts` (`npm test`, node:test via the existing `tsx` devDependency — no new dependencies): buffer resolution happy path, missing-file placeholders, EISDIR no-throw (the repro above), digest-path no-throw, `stripUnresolvedMedia` across roles, and plugin-level resolution with a null sidecar.

`npm run build:server` (tsc) clean; all 6 tests pass.

Note: the `package.json` test script will conflict trivially with #305 if both land — same one-line script slot; happy to rebase whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)