### PR TITLE
Idle-based turn timeout with real stream abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **Turn timeout is now idle-based and actually aborts the stream** — the 5-minute turn timeout was wall-clock: long productive turns (many tool calls) died mid-work while the abandoned LLM stream kept running as a zombie, burning tokens on work that was thrown away. The timer now resets on every stream event, so only turns with no activity for 5 minutes are killed — and the kill aborts the underlying stream via `AbortSignal` instead of leaving it running.
+
 ## 0.32.1 (2026-07-28)
 
 ### Fixes

--- a/src/app.ts
+++ b/src/app.ts
@@ -217,7 +217,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     }).catch((e) => log.error("subagent", `announce enqueue failed for ${id}: ${e.message}`));
   });
 
-  queue.setHandler(async (msg, getPendingMessages) => {
+  queue.setHandler(async (msg, getPendingMessages, signal) => {
 
     const time = formatLocalISO(new Date(), envelopeTimezone);
     const context = `[via ${msg.interface}${msg.channel ? `, ${msg.channel}` : ""}, user: ${msg.userId}, time: ${time}]\n${msg.text}`;
@@ -247,9 +247,10 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
     });
 
     const result = await runtime.handleMessage(context, (event: StreamEvent) => {
+      queue.touch(); // stream activity — reset the idle timeout
       server.broadcast(event);
       msg.onEvent?.(event);
-    }, msg.attachments);
+    }, msg.attachments, signal);
 
     // Post-turn: let plugins index new messages (async, non-blocking)
     const sessionId = runtime.getSessionId();

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -30,11 +30,22 @@ export class MessageQueue {
   // so we can resolve their Promises with NO_REPLY when the turn finishes —
   // otherwise the interface handlers that awaited onMessage() would hang.
   private drainedSameChannel: QueuedMessage[] = [];
-  private handler: ((msg: QueuedMessage, pendingMessages: () => QueuedMessage[]) => Promise<string>) | null = null;
-  private timeoutMs = 5 * 60 * 1000; // 5 minute timeout per message
+  private handler: ((msg: QueuedMessage, pendingMessages: () => QueuedMessage[], signal: AbortSignal) => Promise<string>) | null = null;
+  // Idle timeout: a turn is killed only after this long with NO activity
+  // (no stream events). Every token/tool event resets the timer via touch(),
+  // so long productive turns never time out — only genuinely hung ones.
+  private idleTimeoutMs = 5 * 60 * 1000;
+  // Resets the current turn's idle timer. Null when no turn is active.
+  private touchFn: (() => void) | null = null;
 
-  setHandler(fn: (msg: QueuedMessage, pendingMessages: () => QueuedMessage[]) => Promise<string>) {
+  setHandler(fn: (msg: QueuedMessage, pendingMessages: () => QueuedMessage[], signal: AbortSignal) => Promise<string>) {
     this.handler = fn;
+  }
+
+  // Called on every stream event to signal the active turn is making progress.
+  // No-op when no turn is active.
+  touch() {
+    this.touchFn?.();
   }
 
   getActiveChannel(): string | null {
@@ -106,18 +117,33 @@ export class MessageQueue {
 
     log("queue", `processing (${msg.interface}:${msg.channel || "?"}) remaining=${this.queue.length}`);
 
+    // Abort controller for this turn. On idle timeout we abort so the
+    // handler's LLM stream actually stops instead of running on as a zombie.
+    const controller = new AbortController();
+    let idleTimer: NodeJS.Timeout | null = null;
+
     try {
-      // Race handler against timeout. Promise.race doesn't cancel the loser,
-      // so a timed-out handler keeps running; the turnId guard below makes
-      // any late drain calls a no-op instead of corrupting the next turn.
+      // Race handler against an idle timeout. The timer resets on every
+      // stream event (via touch()), so only turns with no activity die.
+      const idleTimeout = new Promise<string>((_, reject) => {
+        const fire = () => {
+          controller.abort();
+          reject(new Error(`Message processing timed out (no activity for ${this.idleTimeoutMs / 1000}s)`));
+        };
+        idleTimer = setTimeout(fire, this.idleTimeoutMs);
+        this.touchFn = () => {
+          if (turnId !== this.turnId) return;
+          if (idleTimer) clearTimeout(idleTimer);
+          idleTimer = setTimeout(fire, this.idleTimeoutMs);
+        };
+      });
+
       const response = await Promise.race([
         this.handler!(msg, () => {
           if (turnId !== this.turnId) return [];
           return this.drainPendingSameChannel();
-        }),
-        new Promise<string>((_, reject) =>
-          setTimeout(() => reject(new Error("Message processing timed out")), this.timeoutMs)
-        ),
+        }, controller.signal),
+        idleTimeout,
       ]);
 
       msg.resolve(response);
@@ -130,6 +156,8 @@ export class MessageQueue {
       // messages were never touched — requeue them for their own turn.
       this.finalizePendingSameChannel();
     } finally {
+      if (idleTimer) clearTimeout(idleTimer);
+      this.touchFn = null;
       this.processing = false;
       this.activeChannel = null;
       log("queue", `done, remaining=${this.queue.length}`);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -194,6 +194,7 @@ export class Runtime {
     userMessage: string,
     onEvent: StreamHandler,
     attachments?: Attachment[],
+    abortSignal?: AbortSignal,
   ): Promise<string> {
     // Signal that we're processing
     onEvent({ type: "thinking" });
@@ -275,6 +276,7 @@ export class Runtime {
         system: systemWithInjections,
         messages: resolvedMessages,
         tools,
+        abortSignal,
         ...ollamaOptions,
         stopWhen: stepCountIs(this.config.maxSteps),
         onError: ({ error }) => {
@@ -401,6 +403,13 @@ export class Runtime {
 
       return fullText || "(no text response)";
     } catch (error: any) {
+      // Aborted by the queue's idle timeout — the queue already rejected the
+      // turn and reported the timeout. Steps completed before the abort were
+      // persisted by onStepFinish; exit quietly instead of double-reporting.
+      if (abortSignal?.aborted) {
+        log("runtime", "turn aborted (idle timeout) — stream stopped");
+        throw error;
+      }
       const { message: msg, category } = parseProviderError(streamError, error);
       log.error("runtime", `[${category}] ${msg}`);
       onEvent({ type: "error", error: msg });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -407,7 +407,8 @@ export class Runtime {
       // turn and reported the timeout. Steps completed before the abort were
       // persisted by onStepFinish; exit quietly instead of double-reporting.
       if (abortSignal?.aborted) {
-        log("runtime", "turn aborted (idle timeout) — stream stopped");
+        const { message: msg, category } = parseProviderError(streamError, error);
+        log("runtime", `turn aborted (idle timeout) — stream stopped [${category}: ${msg}]`);
         throw error;
       }
       const { message: msg, category } = parseProviderError(streamError, error);


### PR DESCRIPTION
## Problem

`Message processing timed out` was a fixed 5-minute wall clock raced against the whole turn (`src/queue.ts`). Two consequences:

1. **Productive turns died mid-work.** A long multi-tool turn (or a slow prefill) hit 5 minutes even while making steady progress. And since `Promise.race` doesn't cancel the loser, the abandoned LLM stream kept running as a **zombie** — burning tokens on a result nobody would receive.
2. **The agent "forgot" what it was doing.** The turn's final synthesis was never produced/saved, so the next turn saw dangling tool calls with no conclusion.

## Fix

- **Idle-based timeout** — the timer resets on every stream event (text delta, tool call, tool result) via a new `queue.touch()` hook wired into the event callback in `app.ts`. A turn is killed only after 5 minutes with **zero activity**, i.e. a genuine hang. Productive turns can run as long as they keep producing events.
- **Real abort** — the queue owns a per-turn `AbortController`; on timeout it aborts, and the signal is threaded through `app.ts` → `runtime.handleMessage` → `streamText`, so the underlying stream actually stops. No more zombie turns.
- **Quiet abort path** — the runtime detects the abort and exits without emitting a second error event (the queue already rejected the turn with the timeout message). Steps completed before the abort were already persisted by `onStepFinish`, and the existing interrupted-turn marker in `session.ts` covers the dangling-tool-call case on next load.

No new config: with an idle-based timer a configurable duration is unnecessary — hung turns still die in 5 minutes, productive turns never do.

## Testing

- `npm test` — 11/11 pass
- Build clean