### PR TITLE
Graceful step-cap handling + trim coverage guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **Turns that hit the step limit now end with a message instead of silence** ([#310](https://github.com/oguzbilgic/kern-ai/issues/310)) — when a turn reaches `maxSteps`, the final step is forced to be text-only (`prepareStep` disables tools and nudges the model to wrap up), so the user always gets a closing message instead of the turn dying on a tool result with nothing sent.
+- **Context trimming can no longer drop messages before they're summarized** ([#311](https://github.com/oguzbilgic/kern-ai/issues/311)) — the trim boundary is clamped to summarizer coverage (last L0 segment end). Previously a heavy turn could be trimmed out of the raw window before its summary existed, making the agent forget work it finished seconds earlier; now unsummarized messages stay in the raw window even if the token budget is temporarily overshot.
+
 ## 0.32.2 (2026-08-11)
 
 ### Fixes

--- a/src/context.ts
+++ b/src/context.ts
@@ -297,6 +297,28 @@ function trimToTokenBudget({ messages, maxTokens, segmentIndex, sessionId }: Tri
     }
   }
 
+
+  // Coverage guard: never trim messages the summarizer hasn't reached yet.
+  // Summaries are built asynchronously after turns finish, so the freshest
+  // messages may exist in neither the raw window nor any summary — trimming
+  // past them makes the agent forget work it just completed (#311). Clamp the
+  // boundary to the end of the last L0 segment; anything beyond stays raw
+  // even if the window overshoots the budget for a turn.
+  if (segmentIndex && sessionId) {
+    const l0Ends = segmentIndex.getL0Boundaries(sessionId);
+    const covered = l0Ends.length > 0 ? l0Ends[l0Ends.length - 1] : 0;
+    if (cutIndex > covered) {
+      // Walk backward to the nearest user message so the clamped boundary
+      // stays turn-safe (never cuts inside a tool-call/tool-result pair).
+      let clamped = covered;
+      while (clamped > 0 && messages[clamped]?.role !== "user") {
+        clamped--;
+      }
+      log("context", `trim clamped to summary coverage: ${cutIndex} → ${clamped} (last L0 end ${covered}); window may exceed budget until summaries catch up`);
+      cutIndex = clamped;
+    }
+  }
+
   if (sessionId && cutIndex > 0) {
     const prev = heldTrimBoundaries.get(sessionId);
     if (prev !== cutIndex) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -305,7 +305,9 @@ function trimToTokenBudget({ messages, maxTokens, segmentIndex, sessionId }: Tri
   // boundary to the end of the last L0 segment; anything beyond stays raw
   // even if the window overshoots the budget for a turn.
   if (segmentIndex && sessionId) {
-    const l0Ends = segmentIndex.getL0Boundaries(sessionId);
+    // summarizedOnly: composeHistory() only injects summarized segments, so a
+    // segment that exists but hasn't been summarized yet is NOT coverage.
+    const l0Ends = segmentIndex.getL0Boundaries(sessionId, true);
     const covered = l0Ends.length > 0 ? l0Ends[l0Ends.length - 1] : 0;
     if (cutIndex > covered) {
       // Walk backward to the nearest user message so the clamped boundary

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -309,12 +309,18 @@ export class Runtime {
           // no final text — the user gets silence and the session ends without
           // a conclusion. Forcing the last step to be text-only guarantees
           // every capped turn closes with an assistant message.
+          const wrapUpNudge =
+            "\n\n[System: step limit reached — this is the final step of this turn. " +
+            "Tools are disabled. Summarize what you accomplished, what remains, and reply to the user now.]";
+          // systemWithInjections may be a SystemModelMessage object (Anthropic
+          // prompt caching) — append to its content and preserve providerOptions
+          // rather than string-concatenating, which would yield "[object Object]".
           const finalStep = stepNumber >= this.config.maxSteps - 1
             ? {
                 toolChoice: "none" as const,
-                system: systemWithInjections +
-                  "\n\n[System: step limit reached — this is the final step of this turn. " +
-                  "Tools are disabled. Summarize what you accomplished, what remains, and reply to the user now.]",
+                system: typeof systemWithInjections === "string"
+                  ? systemWithInjections + wrapUpNudge
+                  : { ...systemWithInjections, content: systemWithInjections.content + wrapUpNudge },
               }
             : {};
           if (stepNumber >= this.config.maxSteps - 1) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -303,7 +303,25 @@ export class Runtime {
           }
         },
         prepareStep: ({ messages, stepNumber }) => {
-          if (stepNumber === 0 || !pendingInjections) return {};
+          // Final-step tool lockout (#310): when the next step is the last one
+          // allowed by maxSteps, disable tools and tell the model to wrap up.
+          // Without this, a turn that hits the cap ends on a tool result with
+          // no final text — the user gets silence and the session ends without
+          // a conclusion. Forcing the last step to be text-only guarantees
+          // every capped turn closes with an assistant message.
+          const finalStep = stepNumber >= this.config.maxSteps - 1
+            ? {
+                toolChoice: "none" as const,
+                system: systemWithInjections +
+                  "\n\n[System: step limit reached — this is the final step of this turn. " +
+                  "Tools are disabled. Summarize what you accomplished, what remains, and reply to the user now.]",
+              }
+            : {};
+          if (stepNumber >= this.config.maxSteps - 1) {
+            log("runtime", `prepareStep: step limit reached at step ${stepNumber} — forcing text-only final step`);
+          }
+
+          if (stepNumber === 0 || !pendingInjections) return finalStep;
 
           // Collect any new injections; record the chronological position
           // (current messages length) at which each arrived.
@@ -322,7 +340,7 @@ export class Runtime {
             });
           }
 
-          if (midTurnMessages.length === 0) return {};
+          if (midTurnMessages.length === 0) return finalStep;
 
           log("runtime", `prepareStep: splicing ${midTurnMessages.length} mid-turn message(s) at step ${stepNumber}`);
 
@@ -342,7 +360,7 @@ export class Runtime {
             out.splice(insertAt, 0, msg);
           }
 
-          return { messages: out };
+          return { ...finalStep, messages: out };
         },
       });
 

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -718,13 +718,17 @@ export class SegmentIndex {
   }
 
   /**
-   * Return sorted L0 segment msg_start values for a session.
+   * Return sorted L0 segment msg_end values (exclusive) for a session.
    * Used to snap trim boundaries to stable segment edges for cache stability.
+   *
+   * With summarizedOnly, only segments whose summary has been generated are
+   * returned — composeHistory() can only inject summarized=1 segments, so
+   * coverage checks must not count segments that are merely segmented (#311).
    */
-  getL0Boundaries(sessionId: string): number[] {
+  getL0Boundaries(sessionId: string, summarizedOnly = false): number[] {
     const rows = this.db.prepare(
       `SELECT msg_end FROM semantic_segments
-       WHERE session_id = ? AND level = 0
+       WHERE session_id = ? AND level = 0${summarizedOnly ? " AND summarized = 1" : ""}
        ORDER BY msg_end ASC`
     ).all(sessionId) as Array<{ msg_end: number }>;
     return rows.map(r => r.msg_end);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -23,9 +23,12 @@ function makeMessages(count: number): ModelMessage[] {
 }
 
 // Fake SegmentIndex: only the two methods prepareContext/trim use.
-function fakeSegmentIndex(l0Ends: number[]) {
+// summarizedEnds defaults to l0Ends (all segments summarized); pass a shorter
+// list to simulate segments that exist but haven't been summarized yet.
+function fakeSegmentIndex(l0Ends: number[], summarizedEnds: number[] = l0Ends) {
   return {
-    getL0Boundaries: () => l0Ends,
+    getL0Boundaries: (_sessionId: string, summarizedOnly = false) =>
+      summarizedOnly ? summarizedEnds : l0Ends,
     composeHistory: () => null,
   } as any;
 }
@@ -83,4 +86,18 @@ test("clamped boundary is turn-safe (walks back to a user message)", () => {
     segmentIndex: fakeSegmentIndex([41]),
   });
   assert.strictEqual(result.messages[0].role, "user");
+});
+
+test("segmented-but-unsummarized regions do not count as coverage", () => {
+  const messages = makeMessages(100);
+  // Segments exist up to msg 80, but the summarizer has only reached msg 40.
+  // composeHistory() can only inject summarized segments, so the boundary
+  // must clamp to 40 — not 80.
+  const result = prepareContext({
+    messages,
+    config: makeConfig(2000),
+    sessionId: "s5",
+    segmentIndex: fakeSegmentIndex([20, 40, 60, 80], [20, 40]),
+  });
+  assert.ok(result.messages.length >= 60, `expected >= 60 raw messages, got ${result.messages.length}`);
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,0 +1,86 @@
+import { test, beforeEach } from "node:test";
+import assert from "node:assert";
+import { prepareContext, clearTrimBoundaries } from "../src/context.js";
+import type { KernConfig } from "../src/config.js";
+import type { ModelMessage } from "ai";
+
+// Minimal config for trim tests. summaryBudget 0.5 → raw budget = maxContextTokens / 2.
+function makeConfig(maxContextTokens: number): KernConfig {
+  return {
+    maxContextTokens,
+    summaryBudget: 0.5,
+    maxToolResultChars: 100000,
+  } as KernConfig;
+}
+
+// ~100 tokens per message (4 chars ≈ 1 token)
+function makeMessages(count: number): ModelMessage[] {
+  const msgs: ModelMessage[] = [];
+  for (let i = 0; i < count; i++) {
+    msgs.push({ role: i % 2 === 0 ? "user" : "assistant", content: `msg ${i} ${"x".repeat(400)}` });
+  }
+  return msgs;
+}
+
+// Fake SegmentIndex: only the two methods prepareContext/trim use.
+function fakeSegmentIndex(l0Ends: number[]) {
+  return {
+    getL0Boundaries: () => l0Ends,
+    composeHistory: () => null,
+  } as any;
+}
+
+beforeEach(() => clearTrimBoundaries());
+
+test("trim clamps to summary coverage — no coverage means no trim", () => {
+  // 100 messages × ~100 tokens, raw budget 1000 tokens → would normally trim ~90.
+  const messages = makeMessages(100);
+  const result = prepareContext({
+    messages,
+    config: makeConfig(2000),
+    sessionId: "s1",
+    segmentIndex: fakeSegmentIndex([]),
+  });
+  // No L0 segments exist → nothing is summarized → nothing may be trimmed.
+  assert.strictEqual(result.messages.length, 100);
+});
+
+test("trim clamps to summary coverage — boundary never passes last L0 end", () => {
+  const messages = makeMessages(100);
+  // Summaries cover messages 0..40 only.
+  const result = prepareContext({
+    messages,
+    config: makeConfig(2000),
+    sessionId: "s2",
+    segmentIndex: fakeSegmentIndex([20, 40]),
+  });
+  // Boundary must be ≤ 40 → at least 60 messages stay raw, budget overshot.
+  assert.ok(result.messages.length >= 60, `expected >= 60 raw messages, got ${result.messages.length}`);
+});
+
+test("trim proceeds normally when coverage is ahead of the cut point", () => {
+  const messages = makeMessages(100);
+  // Summaries cover everything.
+  const result = prepareContext({
+    messages,
+    config: makeConfig(2000),
+    sessionId: "s3",
+    segmentIndex: fakeSegmentIndex([20, 40, 60, 80, 99]),
+  });
+  // Raw budget is 1000 tokens ≈ 10 messages → most messages should be trimmed.
+  assert.ok(result.messages.length < 60, `expected < 60 raw messages, got ${result.messages.length}`);
+  // Boundary is turn-safe: window starts on a user message.
+  assert.strictEqual(result.messages[0].role, "user");
+});
+
+test("clamped boundary is turn-safe (walks back to a user message)", () => {
+  const messages = makeMessages(100);
+  // Coverage ends at 41 (an assistant message index) → clamp must walk back to 40 (user).
+  const result = prepareContext({
+    messages,
+    config: makeConfig(2000),
+    sessionId: "s4",
+    segmentIndex: fakeSegmentIndex([41]),
+  });
+  assert.strictEqual(result.messages[0].role, "user");
+});


### PR DESCRIPTION
Fixes #310, fixes #311.

Two halves of one live incident (rho, 2026-08-11): a 30-step turn hit `maxSteps` and ended with **zero final text** — the user saw a typing indicator, then silence. Twelve seconds later a follow-up question arrived, the trim boundary jumped past the entire (not-yet-summarized) turn, and the agent had **no memory of the work it had just finished**.

## 1. Step cap → forced text-only final step (#310)

`stopWhen: stepCountIs(maxSteps)` kills the loop right after the last tool result, so a capped turn never gets a closing message. Now `prepareStep` detects the last allowed step and reshapes it:

- `toolChoice: "none"` — the model physically cannot call tools, it can only write text
- system prompt gets a wrap-up nudge: step limit reached, summarize what you did and reply

Capped turns close with an assistant message **by construction**. No extra API call — we reshape the step we were going to run anyway. Interfaces always have text to deliver, and the session ends with a conclusion instead of a dangling tool result.

Merges cleanly with the existing mid-turn-injection logic in `prepareStep` (final-step overrides are spread into all three return paths).

## 2. Trim boundary clamped to summary coverage (#311)

Summaries are built asynchronously *after* turns finish, so the freshest messages can exist in neither the raw window nor any summary. Trimming trusted summaries that didn't exist yet.

New invariant: **every message is either in the raw window or covered by a summary — never neither.** The trim cut point (after snap) is clamped to the end of the last L0 segment, walking back to the nearest user message for turn safety. Unsummarized messages stay raw even if the raw budget is overshot; hysteresis trims normally once the summarizer catches up.

Tradeoff: if the summarizer stalls entirely (#282-class failures), the boundary freezes and the window grows — logged as `trim clamped to summary coverage`. Degraded cost beats silent memory loss.

## Tests

- 4 new tests in `test/context.test.ts` covering: no coverage → no trim; boundary never passes last L0 end; normal trim when coverage is ahead; clamped boundary is turn-safe.
- Full suite 15/15.