### PR TITLE
Fix: truncation splitting surrogate pairs breaks summary/embedding calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **Truncation no longer breaks summary/embedding API calls** ([#313](https://github.com/oguzbilgic/kern-ai/issues/313)) — truncating tool output with `.slice()` could split a surrogate pair (e.g. an emoji), leaving ill-formed UTF-16 that providers reject as invalid JSON. The affected segment could then never be summarized, retrying (and failing) every hour. Inputs to summary and embedding calls are now normalized with `toWellFormed()`.
+
 ## 0.32.3 (2026-08-11)
 
 ### Fixes

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -3,7 +3,7 @@ import { embed, embedMany } from "ai";
 import { readFile, stat } from "fs/promises";
 import { existsSync } from "fs";
 import { log } from "../../log.js";
-import { extractText } from "../../util.js";
+import { extractText, wellFormed } from "../../util.js";
 import { createEmbeddingModel } from "../../model.js";
 import type { ModelMessage } from "ai";
 import type { MemoryDB } from "../../memory.js";
@@ -309,7 +309,9 @@ export class RecallIndex {
       }
 
       const turnEnd = i;
-      const chunkText = parts.join("\n");
+      // wellFormed(): tool-output truncation can split surrogate pairs (e.g.
+      // emoji), producing ill-formed UTF-16 that embedding APIs reject.
+      const chunkText = wellFormed(parts.join("\n"));
 
       // Absolute indices
       const absTurnStart = absoluteOffset + turnStart;

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -1,6 +1,6 @@
 import { embed, embedMany, generateText } from "ai";
 import { log } from "./log.js";
-import { extractText } from "./util.js";
+import { extractText, wellFormed } from "./util.js";
 import { createEmbeddingModel, createSummaryModel } from "./model.js";
 import type { KernConfig } from "./config.js";
 import type { MemoryDB } from "./memory.js";
@@ -291,7 +291,9 @@ export class SegmentIndex {
     return messages.map((_, i) => {
       const start = Math.max(0, i - half);
       const end = Math.min(messages.length, i + half + 1);
-      return messages.slice(start, end).map(m => `${m.role}: ${this.messageText(m)}`).join("\n");
+      // wellFormed(): messageText truncation can split surrogate pairs (e.g.
+      // emoji), producing ill-formed UTF-16 that embedding APIs reject.
+      return wellFormed(messages.slice(start, end).map(m => `${m.role}: ${this.messageText(m)}`).join("\n"));
     });
   }
 
@@ -324,7 +326,9 @@ export class SegmentIndex {
       ).all(seg.session_id, seg.msg_start, seg.msg_end) as Array<{ role: string; content: string }>;
 
       inputText = rows.map((m) => `${m.role}: ${extractText(m.content)}`).join("\n");
-      inputText = inputText.replace(/^tool: .{500,}$/gm, (m) => m.slice(0, 300) + '... [truncated]').slice(0, 60000);
+      // wellFormed(): slicing can split surrogate pairs (e.g. emoji), producing
+      // ill-formed UTF-16 that upstream providers reject as invalid JSON.
+      inputText = wellFormed(inputText.replace(/^tool: .{500,}$/gm, (m) => m.slice(0, 300) + '... [truncated]').slice(0, 60000));
       targetTokens = Math.max(200, Math.min(1500, Math.round(seg.token_count / 10)));
       prompt = segmentSummaryPrompt(inputText, targetTokens);
     } else {
@@ -384,7 +388,9 @@ export class SegmentIndex {
       if (this.abortController?.signal.aborted) return;
       try {
         const summaryInput = row.summary.replace(/^tool: .{500,}$/gm, (m) => m.slice(0, 300) + '... [truncated]');
-        const inputText = summaryInput.slice(0, 60000);
+        // wellFormed(): slicing can split surrogate pairs (e.g. emoji), producing
+        // ill-formed UTF-16 that upstream providers reject as invalid JSON.
+        const inputText = wellFormed(summaryInput.slice(0, 60000));
         const targetTokens = Math.max(200, Math.min(1500, Math.round(row.token_count / 10)));
 
         const result = await generateText({

--- a/src/util.ts
+++ b/src/util.ts
@@ -164,7 +164,13 @@ export function substituteEnvDeep<T>(
  * with "Invalid body: failed to parse JSON". Lone surrogates are replaced
  * with U+FFFD.
  */
+const LONE_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
 export function wellFormed(s: string): string {
-  // String.prototype.toWellFormed requires Node 20+; kern requires Node 22.
-  return (s as any).toWellFormed?.() ?? s;
+  // String.prototype.toWellFormed requires Node 20+; fall back to a regex
+  // replacement on older runtimes (engines allows >=18).
+  return typeof (s as any).toWellFormed === "function"
+    ? (s as any).toWellFormed()
+    : s.replace(LONE_SURROGATE, "\uFFFD");
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -155,3 +155,16 @@ export function substituteEnvDeep<T>(
   }
   return value;
 }
+
+/**
+ * Ensure a string is well-formed UTF-16 (no lone surrogates).
+ * Truncating strings with .slice() can split surrogate pairs (e.g. emoji),
+ * producing ill-formed UTF-16 that serializes to invalid JSON bytes —
+ * upstream APIs (OpenAI, Azure, embedding endpoints) reject such requests
+ * with "Invalid body: failed to parse JSON". Lone surrogates are replaced
+ * with U+FFFD.
+ */
+export function wellFormed(s: string): string {
+  // String.prototype.toWellFormed requires Node 20+; kern requires Node 22.
+  return (s as any).toWellFormed?.() ?? s;
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -2,6 +2,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { wellFormed } from "../src/util.js";
 
+// Local lone-surrogate detector — String.prototype.isWellFormed() is Node 20+
+// and engines allows >=18, so don't rely on it in tests.
+function hasLoneSurrogate(s: string): boolean {
+  return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(s);
+}
+
 test("wellFormed: passes through well-formed strings unchanged", () => {
   assert.equal(wellFormed("hello"), "hello");
   assert.equal(wellFormed("emoji 💰 intact"), "emoji 💰 intact");
@@ -13,16 +19,16 @@ test("wellFormed: replaces lone surrogates from a split surrogate pair", () => {
   // tool-line truncation at char 300 split 💰 → provider rejected the
   // request body as invalid JSON).
   const truncated = "cost: 💰".slice(0, 7); // ends with lone high surrogate
-  assert.equal(truncated.isWellFormed(), false);
+  assert.equal(hasLoneSurrogate(truncated), true);
   const fixed = wellFormed(truncated);
-  assert.equal(fixed.isWellFormed(), true);
+  assert.equal(hasLoneSurrogate(fixed), false);
   assert.ok(fixed.endsWith("\uFFFD"));
 });
 
 test("wellFormed: fixes lone surrogates mid-string", () => {
   const bad = "a\uD83Db... [truncated]\nmore text";
-  assert.equal(bad.isWellFormed(), false);
+  assert.equal(hasLoneSurrogate(bad), true);
   const fixed = wellFormed(bad);
-  assert.equal(fixed.isWellFormed(), true);
+  assert.equal(hasLoneSurrogate(fixed), false);
   assert.equal(fixed, "a\uFFFDb... [truncated]\nmore text");
 });

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,28 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { wellFormed } from "../src/util.js";
+
+test("wellFormed: passes through well-formed strings unchanged", () => {
+  assert.equal(wellFormed("hello"), "hello");
+  assert.equal(wellFormed("emoji 💰 intact"), "emoji 💰 intact");
+  assert.equal(wellFormed(""), "");
+});
+
+test("wellFormed: replaces lone surrogates from a split surrogate pair", () => {
+  // Slicing mid-emoji leaves a lone high surrogate (real-world failure:
+  // tool-line truncation at char 300 split 💰 → provider rejected the
+  // request body as invalid JSON).
+  const truncated = "cost: 💰".slice(0, 7); // ends with lone high surrogate
+  assert.equal(truncated.isWellFormed(), false);
+  const fixed = wellFormed(truncated);
+  assert.equal(fixed.isWellFormed(), true);
+  assert.ok(fixed.endsWith("\uFFFD"));
+});
+
+test("wellFormed: fixes lone surrogates mid-string", () => {
+  const bad = "a\uD83Db... [truncated]\nmore text";
+  assert.equal(bad.isWellFormed(), false);
+  const fixed = wellFormed(bad);
+  assert.equal(fixed.isWellFormed(), true);
+  assert.equal(fixed, "a\uFFFDb... [truncated]\nmore text");
+});


### PR DESCRIPTION
Fixes #313

## Problem

Live failure on arlo: one L0 segment failed summarization **every hour, forever** with a bare `Provider returned error`. Root cause: kern's tool-line truncation (`m.slice(0, 300)`) split a 💰 emoji at exactly char 300, leaving a lone high surrogate. Ill-formed UTF-16 serializes to invalid JSON bytes, and the upstream provider (OpenAI/Azure via OpenRouter) rejects the body with `invalid_json`. Deterministic → permanent retry loop, segment never summarized.

## Fix

- New `wellFormed()` util (wraps `String.prototype.toWellFormed()`, Node 20+; kern requires 22). Lone surrogates → U+FFFD.
- Applied after truncation at every site that feeds an API call:
  - `segments.ts summarizeUnsummarized()` — the observed failure
  - `segments.ts resummarizeSegment()` — same truncation, same risk
  - `segments.ts buildWindowTexts()` — feeds **embedding** calls
  - `plugins/recall/recall.ts` chunk build — feeds `embedMany`

The embedding sites matter too: a split pair there silently gaps recall/segmentation coverage.

## Testing

- 19/19 tests pass, incl. new `test/util.test.ts` reproducing the real failure shape (slice mid-emoji → `isWellFormed() === false` → normalized).
- Root cause verified on arlo's live DB: raw segment text is well-formed, post-truncation input has two lone surrogates at truncation boundaries; direct API replication returns the exact `invalid_json` provider error.