### PR TITLE
Fix: oversized recall chunks permanently fail embedding batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **Oversized recall chunks no longer break embedding batches** — a chunk over the embedding model's token limit (8192 for `text-embedding-3-small`/`nomic-embed-text`) got HTTP 400, failing the whole `embedMany` batch — permanently, since the indexer retries the same chunks forever, leaving every chunk in the batch unindexed. Chunk text sent to the embedder is now capped (full text is still stored and returned by search).
+
 ## 0.32.3 (2026-08-11)
 
 ### Fixes

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -11,6 +11,28 @@ import type { KernConfig } from "../../config.js";
 
 const MAX_CHUNK_TOKENS = 1000; // rough token limit per chunk
 
+// Max characters sent to the embedding model per chunk. Embedding APIs reject
+// inputs over their token limit (8192 for text-embedding-3-small and
+// nomic-embed-text) with HTTP 400 — and one oversized chunk fails the whole
+// embedMany batch, permanently: the indexer retries the same chunks forever,
+// so every chunk batched with it stays unindexed too. chunkMessages() caps
+// chunk *growth*, but a single oversized message bypasses the cap, and the
+// chars/4 token estimate undercounts dense text. 16k chars stays safely under
+// 8192 tokens even at ~2 chars/token. Only the embedded representation is
+// truncated — the full chunk text is still stored and returned by search.
+const EMBED_MAX_CHARS = 16000;
+
+/** Truncate text for embedding without splitting a surrogate pair at the cut. */
+export function capForEmbedding(text: string, max: number = EMBED_MAX_CHARS): string {
+  if (text.length <= max) return text;
+  let cut = text.slice(0, max);
+  // A cut mid-emoji leaves a lone high surrogate — ill-formed UTF-16
+  // serializes to invalid JSON, which providers reject.
+  const last = cut.charCodeAt(cut.length - 1);
+  if (last >= 0xd800 && last <= 0xdbff) cut = cut.slice(0, -1);
+  return cut;
+}
+
 // Normalize an ISO8601 string (UTC `Z` or `±HH:MM` offset) to canonical UTC
 // `Z` form for storage. Ensures `recall.db` timestamp column is UTC-normalized
 // regardless of the envelope format the model saw.
@@ -119,7 +141,7 @@ export class RecallIndex {
 
     // Embed chunks in batches (API limits)
     const BATCH_SIZE = 100;
-    const texts = chunks.map((c) => c.text);
+    const texts = chunks.map((c) => capForEmbedding(c.text));
     log.debug("recall", `embedding ${texts.length} chunks (${texts.reduce((a, t) => a + t.length, 0)} chars)`);
 
     const embeddings: number[][] = [];

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -17,9 +17,11 @@ const MAX_CHUNK_TOKENS = 1000; // rough token limit per chunk
 // embedMany batch, permanently: the indexer retries the same chunks forever,
 // so every chunk batched with it stays unindexed too. chunkMessages() caps
 // chunk *growth*, but a single oversized message bypasses the cap, and the
-// chars/4 token estimate undercounts dense text. 16k chars stays safely under
-// 8192 tokens even at ~2 chars/token. Only the embedded representation is
-// truncated — the full chunk text is still stored and returned by search.
+// chars/4 token estimate undercounts dense text. 16k chars is a heuristic
+// that stays under 8192 tokens for typical text (~2-4 chars/token); extreme
+// cases (e.g. CJK-heavy text at ~1 char/token) could still exceed it. Only
+// the embedded representation is truncated — the full chunk text is still
+// stored and returned by search.
 const EMBED_MAX_CHARS = 16000;
 
 /** Truncate text for embedding without splitting a surrogate pair at the cut. */

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -19,9 +19,10 @@ test("capForEmbedding: respects a custom max", () => {
 
 test("capForEmbedding: never splits a surrogate pair at the cut", () => {
   // Cut lands exactly mid-emoji: "ab" + 💰 = 4 code units, cut at 3 would
-  // leave a lone high surrogate.
+  // leave a lone high surrogate. (Don't use isWellFormed() here — it's
+  // Node 20+ and engines allows >=18.)
   const text = "ab💰cd";
   const cut = capForEmbedding(text, 3);
   assert.equal(cut, "ab");
-  assert.equal(cut.isWellFormed(), true);
+  assert.equal(/[\uD800-\uDBFF]$/.test(cut), false);
 });

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { capForEmbedding } from "../src/plugins/recall/recall.js";
+
+test("capForEmbedding: passes short text through unchanged", () => {
+  assert.equal(capForEmbedding("hello"), "hello");
+  const text = "x".repeat(16000);
+  assert.equal(capForEmbedding(text), text);
+});
+
+test("capForEmbedding: truncates oversized text to the cap", () => {
+  const text = "x".repeat(50000);
+  assert.equal(capForEmbedding(text).length, 16000);
+});
+
+test("capForEmbedding: respects a custom max", () => {
+  assert.equal(capForEmbedding("abcdef", 3), "abc");
+});
+
+test("capForEmbedding: never splits a surrogate pair at the cut", () => {
+  // Cut lands exactly mid-emoji: "ab" + 💰 = 4 code units, cut at 3 would
+  // leave a lone high surrogate.
+  const text = "ab💰cd";
+  const cut = capForEmbedding(text, 3);
+  assert.equal(cut, "ab");
+  assert.equal(cut.isWellFormed(), true);
+});


### PR DESCRIPTION
## Problem

Live failure on lyra, rho, and arlo (adjacent to #303): a recall chunk over the embedding model's input limit (8192 tokens for `text-embedding-3-small` / `nomic-embed-text`) gets HTTP 400:

```
maximum input length is 8192 tokens
```

One oversized chunk fails the **whole `embedMany` batch** (up to 100 chunks), and `indexSession()` bails without updating `index_state` — so the next pass retries the exact same oversized chunk. Deterministic retry loop; every chunk batched with it stays unindexed forever. Recall coverage silently gaps.

## Why chunks get that big

`chunkMessages()` caps chunk *growth* at `MAX_CHUNK_TOKENS * 2`, but:
- the cap only applies between messages (`parts.length > 1`) — a single huge user/assistant message bypasses it entirely
- the `chars/4` token estimate undercounts dense text (code, JSON, non-English)

## Fix

- `capForEmbedding()`: cap text sent to the embedder at 16k chars (safely under 8192 tokens even at ~2 chars/token). The full chunk text is still stored in the DB and returned by search — only the embedded representation is truncated.
- The cut avoids leaving a lone high surrogate at the boundary (same failure class as #313).

## Testing

20/20 tests pass, incl. new `test/recall.test.ts` covering pass-through, cap, custom max, and surrogate-safe cut.

Related: #303 (embedMany "Invalid JSON response" — different symptom, same batch-failure blast radius), #313 (surrogate splits).