### PR TITLE
fix: keep cache breakpoints within Anthropic's 4-block limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **Agent bricked by a cache breakpoint on a parallel tool call** ([#316](https://github.com/oguzbilgic/kern-ai/issues/316)) — on Anthropic models a `tool` message is expanded into one API message per tool result, each carrying a copy of the message's `cache_control`. A stable breakpoint landing on a parallel tool call therefore blew Anthropic's 4-block limit and every turn failed instantly with an opaque `Provider returned error` — permanently, since the breakpoint index is deliberately sticky. Breakpoints are now only placed on messages that map to a single block.
+
 ## 0.32.3 (2026-08-11)
 
 ### Fixes

--- a/src/context.ts
+++ b/src/context.ts
@@ -435,6 +435,23 @@ const CACHE_CONTROL = {
 const BP_SNAP_INTERVAL = 20;
 
 /**
+ * How many `cache_control` blocks a provider emits for one message.
+ *
+ * Anthropic allows at most 4 blocks per request and kern's budget is exactly
+ * 4 (system + stable + turn, leaving one spare). A message-level cache marker
+ * normally produces a single block — except on `tool` messages, where the
+ * OpenRouter/Anthropic mapping copies it onto *every* tool result. A turn with
+ * parallel tool calls therefore blows the budget and Anthropic rejects the
+ * whole request with "A maximum of 4 blocks with cache_control may be
+ * provided", surfaced by OpenRouter as an opaque "Provider returned error".
+ */
+function cacheBlockCount(msg: ModelMessage | undefined): number {
+  if (!msg) return 0;
+  if (msg.role === "tool" && Array.isArray(msg.content)) return msg.content.length;
+  return 1;
+}
+
+/**
  * Check if a model config supports Anthropic-style explicit prompt caching.
  */
 export function supportsPromptCaching(config: KernConfig): boolean {
@@ -478,12 +495,17 @@ export function addCacheBreakpoints(messages: ModelMessage[], config: KernConfig
   }
   if (turnBpIdx < 0) return messages;
 
-  // BP2: snap to stable interval before the turn breakpoint
-  const stableBpIdx = Math.floor(turnBpIdx / BP_SNAP_INTERVAL) * BP_SNAP_INTERVAL;
-  const useStableBp = stableBpIdx >= 0 && stableBpIdx < turnBpIdx - 4;
+  // BP2: snap to stable interval before the turn breakpoint, then shift down to
+  // the nearest single-block message (see cacheBlockCount).
+  const snappedIdx = Math.floor(turnBpIdx / BP_SNAP_INTERVAL) * BP_SNAP_INTERVAL;
+  let stableBpIdx = snappedIdx;
+  while (stableBpIdx > 0 && cacheBlockCount(messages[stableBpIdx]) !== 1) stableBpIdx--;
+  const useStableBp =
+    cacheBlockCount(messages[stableBpIdx]) === 1 && stableBpIdx < turnBpIdx - 4;
 
   if (useStableBp) {
-    log("context", `cache breakpoints: stable=${stableBpIdx} turn=${turnBpIdx} (${messages.length} msgs)`);
+    const shifted = stableBpIdx === snappedIdx ? "" : ` (snapped ${snappedIdx}, shifted off multi-block msg)`;
+    log("context", `cache breakpoints: stable=${stableBpIdx} turn=${turnBpIdx} (${messages.length} msgs)${shifted}`);
   } else {
     log("context", `cache breakpoint: turn=${turnBpIdx} (${messages.length} msgs)`);
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -437,8 +437,8 @@ const BP_SNAP_INTERVAL = 20;
 /**
  * How many `cache_control` blocks a provider emits for one message.
  *
- * Anthropic allows at most 4 blocks per request and kern's budget is exactly
- * 4 (system + stable + turn, leaving one spare). A message-level cache marker
+ * Anthropic allows at most 4 blocks per request; kern places 3 markers
+ * (system + stable + turn), leaving one spare. A message-level cache marker
  * normally produces a single block — except on `tool` messages, where the
  * OpenRouter/Anthropic mapping copies it onto *every* tool result. A turn with
  * parallel tool calls therefore blows the budget and Anthropic rejects the

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,6 +1,6 @@
 import { test, beforeEach } from "node:test";
 import assert from "node:assert";
-import { prepareContext, clearTrimBoundaries } from "../src/context.js";
+import { prepareContext, clearTrimBoundaries, addCacheBreakpoints } from "../src/context.js";
 import type { KernConfig } from "../src/config.js";
 import type { ModelMessage } from "ai";
 
@@ -100,4 +100,78 @@ test("segmented-but-unsummarized regions do not count as coverage", () => {
     segmentIndex: fakeSegmentIndex([20, 40, 60, 80], [20, 40]),
   });
   assert.ok(result.messages.length >= 60, `expected >= 60 raw messages, got ${result.messages.length}`);
+});
+
+// --- cache breakpoints -----------------------------------------------------
+
+function cacheConfig(): KernConfig {
+  return { provider: "openrouter", model: "anthropic/claude-opus-5" } as KernConfig;
+}
+
+// Counts cache_control blocks a provider would emit: one per message, except
+// tool messages where the marker is copied onto every tool result.
+function countBlocks(messages: ModelMessage[]): number {
+  return messages.reduce((n, m) => {
+    const opts = (m as any).providerOptions;
+    if (!opts?.anthropic?.cacheControl && !opts?.openrouter?.cacheControl) return n;
+    return n + (m.role === "tool" && Array.isArray(m.content) ? m.content.length : 1);
+  }, 0);
+}
+
+function toolMsg(id: string, results: number): ModelMessage {
+  return {
+    role: "tool",
+    content: Array.from({ length: results }, (_, i) => ({
+      type: "tool-result" as const,
+      toolCallId: `${id}-${i}`,
+      toolName: "bash",
+      output: { type: "text" as const, value: "ok" },
+    })),
+  };
+}
+
+test("cache breakpoints stay within Anthropic's 4-block budget", () => {
+  // 30 messages; index 20 (the snapped stable breakpoint) is a tool message
+  // with 3 parallel results — marking it would emit 3 blocks and, with the
+  // system + turn breakpoints, exceed Anthropic's limit of 4.
+  const messages = makeMessages(30);
+  messages[20] = toolMsg("t20", 3);
+  const marked = addCacheBreakpoints(messages, cacheConfig());
+
+  // +1 for the system message breakpoint, which is added separately.
+  assert.ok(countBlocks(marked) + 1 <= 4, `emitted ${countBlocks(marked) + 1} blocks`);
+  assert.strictEqual(countBlocks([marked[20]]), 0, "multi-result tool message must not be marked");
+});
+
+test("stable breakpoint shifts off a multi-result tool message", () => {
+  const messages = makeMessages(30);
+  messages[20] = toolMsg("t20", 3);
+  const marked = addCacheBreakpoints(messages, cacheConfig());
+  const markedIdx = marked
+    .map((m, i) => (countBlocks([m]) > 0 ? i : -1))
+    .filter(i => i >= 0);
+  // Turn breakpoint on the last user message (28), stable shifted 20 → 19.
+  assert.deepStrictEqual(markedIdx, [19, 28]);
+});
+
+test("single-result tool messages are still valid breakpoints", () => {
+  const messages = makeMessages(30);
+  messages[20] = toolMsg("t20", 1);
+  const marked = addCacheBreakpoints(messages, cacheConfig());
+  assert.strictEqual(countBlocks(marked), 2);
+  assert.ok(countBlocks([marked[20]]) === 1, "index 20 should keep the breakpoint");
+});
+
+test("no stable breakpoint when every candidate is multi-block", () => {
+  const messages = makeMessages(30);
+  for (let i = 0; i <= 20; i++) messages[i] = toolMsg(`t${i}`, 2);
+  const marked = addCacheBreakpoints(messages, cacheConfig());
+  // Only the turn breakpoint survives.
+  assert.strictEqual(countBlocks(marked), 1);
+});
+
+test("no breakpoints for providers without prompt caching", () => {
+  const messages = makeMessages(30);
+  const marked = addCacheBreakpoints(messages, { provider: "openai", model: "gpt-5.6-sol" } as KernConfig);
+  assert.strictEqual(countBlocks(marked), 0);
 });


### PR DESCRIPTION
Fixes #316.

## What broke

`rho` went permanently dead after its model was switched to an `anthropic/*` model on OpenRouter. Every turn, every retry:

```
[runtime] stream finished, text length: 0
ERR [runtime] [provider] Provider returned error
```

~2s to fail, identical each time. Recovering the masked upstream error by replaying the request by hand:

```
A maximum of 4 blocks with cache_control may be provided. Found 5.
```

kern budgets 3 breakpoints (system + stable + turn), so 5 shouldn't be possible. But a message-level cache marker only maps to one block for *some* roles. For `tool` messages, `@openrouter/ai-sdk-provider` emits one API message per tool result and copies `cache_control` onto each one:

```js
case "tool": {
  for (const toolResponse of content) {
    messages.push({ role: "tool", ..., cache_control: getCacheControl(providerOptions) ?? ... });
  }
}
```

`rho`'s stable breakpoint had snapped onto a tool message with 3 parallel results → `1 + 3 + 1 = 5` blocks → hard 400. And because the stable index is intentionally sticky (`floor(turnBpIdx / 20) * 20`), it stayed there and bricked the agent.

## Fix

`addCacheBreakpoints` now shifts the snapped stable index down to the nearest message that maps to a single block, and drops the stable breakpoint if no such candidate exists. Shifting is deterministic given the same history, so the breakpoint is just as stable as before and cache hit rates are unaffected.

New `cacheBlockCount()` helper encodes the "tool messages cost N blocks" rule in one place. The turn breakpoint is always a user message, so it is unaffected.

## Tests

5 new tests in `test/context.test.ts`, counting emitted blocks the way the provider does:

- budget stays ≤ 4 when the snapped index is a 3-result tool message
- stable breakpoint shifts 20 → 19 off a multi-result tool message
- single-result tool messages are still valid breakpoints
- stable breakpoint is dropped when every candidate is multi-block
- no breakpoints at all for non-caching providers

21/21 pass.

## Notes

Not fixed here, but worth a follow-up: `parseProviderError` reads OpenRouter's masked `error.message` and never looks at `error.metadata.raw`, which is where the real upstream message lives. Surfacing it would have turned this from an hour of bisecting into a one-line log read.
