### PR TITLE
Fix: YAML block scalars in skill frontmatter parsed as ">-"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **Multi-line skill descriptions no longer show up as `>-`** ([#318](https://github.com/oguzbilgic/kern-ai/issues/318)) — skill frontmatter written with a YAML block scalar (`>`, `>-`, `|`, `|-`) had the indicator itself parsed as the description and the actual text discarded. The skill still worked, but the always-on catalog carried no trigger information, so the model had no basis to pick it. Block scalars are now parsed properly: folded with spaces for `>`, newlines kept for `|`.
+
 ## 0.32.3 (2026-08-11)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixes
-- **Multi-line skill descriptions no longer show up as `>-`** ([#318](https://github.com/oguzbilgic/kern-ai/issues/318)) — skill frontmatter written with a YAML block scalar (`>`, `>-`, `|`, `|-`) had the indicator itself parsed as the description and the actual text discarded. The skill still worked, but the always-on catalog carried no trigger information, so the model had no basis to pick it. Block scalars are now parsed properly: folded with spaces for `>`, newlines kept for `|`.
+- **Multi-line skill descriptions showed up as `>-`** ([#318](https://github.com/oguzbilgic/kern-ai/issues/318)) — skill frontmatter written with a YAML block scalar (`>`, `>-`, `|`, `|-`) parsed the indicator as the description and dropped the text, leaving the catalog with no trigger info for the model. Block scalars are now parsed properly.
 
 ## 0.32.3 (2026-08-11)
 

--- a/src/plugins/skills/scanner.ts
+++ b/src/plugins/skills/scanner.ts
@@ -29,19 +29,63 @@ function getPackageRoot(): string {
 
 /**
  * Parse YAML frontmatter from SKILL.md content.
- * Returns { meta, body } where meta has name/description extracted from simple key: value lines.
+ * Returns { meta, body } where meta has name/description extracted from
+ * `key: value` lines and block scalars (`>`, `>-`, `|`, `|-`).
+ *
+ * Block scalars matter: writing a multi-line description is the natural way to
+ * document when a skill applies, and without this the catalog would show the
+ * literal indicator (`>-`) as the description, leaving the model no basis to
+ * pick the skill. Values are trimmed, so chomping indicators are accepted and
+ * ignored.
  */
-function parseFrontmatter(content: string): { meta: Record<string, string>; body: string } {
+export function parseFrontmatter(content: string): { meta: Record<string, string>; body: string } {
   const meta: Record<string, string> = {};
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
   if (!match) return { meta, body: content };
 
-  const yamlBlock = match[1];
+  const lines = match[1].split("\n");
   const body = match[2];
 
-  for (const line of yamlBlock.split("\n")) {
-    const kv = line.match(/^(\w[\w_-]*):\s*(.+)$/);
-    if (kv) meta[kv[1].trim()] = kv[2].trim().replace(/^["']|["']$/g, "");
+  for (let i = 0; i < lines.length; i++) {
+    const kv = lines[i].match(/^(\w[\w_-]*):\s*(.*)$/);
+    if (!kv) continue;
+    const key = kv[1].trim();
+    const raw = kv[2].trim();
+    if (!raw) continue;
+
+    // Block scalar header: `|`, `>`, optional indentation digit and chomping indicator.
+    const block = raw.match(/^([|>])(?:\d*[-+]?|[-+]?\d*)$/);
+    if (!block) {
+      meta[key] = raw.replace(/^["']|["']$/g, "");
+      continue;
+    }
+
+    // Consume the following more-indented (or blank) lines as the value.
+    const collected: string[] = [];
+    let j = i + 1;
+    for (; j < lines.length; j++) {
+      const line = lines[j];
+      if (line.trim() === "") { collected.push(""); continue; }
+      if (!/^\s/.test(line)) break;
+      collected.push(line);
+    }
+    i = j - 1;
+    while (collected.length && collected[collected.length - 1] === "") collected.pop();
+
+    const indent = Math.min(
+      ...collected.filter(l => l !== "").map(l => l.match(/^\s*/)![0].length),
+      Infinity,
+    );
+    const text = collected.map(l => (l === "" ? "" : l.slice(indent === Infinity ? 0 : indent)));
+
+    // `|` keeps newlines; `>` folds lines with spaces, blank line = paragraph break.
+    meta[key] = block[1] === "|"
+      ? text.join("\n").trim()
+      : text.reduce((acc, line, idx) => {
+          if (idx === 0) return line;
+          if (line === "") return `${acc}\n`;
+          return acc.endsWith("\n") ? acc + line : `${acc} ${line}`;
+        }, "").trim();
   }
 
   return { meta, body };

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { parseFrontmatter } from "../src/plugins/skills/scanner.js";
+
+test("parses plain key: value frontmatter", () => {
+  const { meta, body } = parseFrontmatter(
+    `---\nname: deploy-lxc\ndescription: Create a Debian LXC on kamrui\n---\nbody text\n`,
+  );
+  assert.equal(meta.name, "deploy-lxc");
+  assert.equal(meta.description, "Create a Debian LXC on kamrui");
+  assert.equal(body, "body text\n");
+});
+
+test("strips surrounding quotes from plain values", () => {
+  const { meta } = parseFrontmatter(`---\nname: "quoted"\ndescription: 'also quoted'\n---\n`);
+  assert.equal(meta.name, "quoted");
+  assert.equal(meta.description, "also quoted");
+});
+
+test("folds a >- block scalar into a single line", () => {
+  const { meta, body } = parseFrontmatter(
+    `---\nname: product-knowledge\ndescription: >-\n  Product knowledge for three product lines.\n  This is the WHAT/WHY/GOTCHA layer.\n---\nbody\n`,
+  );
+  assert.equal(meta.name, "product-knowledge");
+  assert.equal(
+    meta.description,
+    "Product knowledge for three product lines. This is the WHAT/WHY/GOTCHA layer.",
+  );
+  assert.equal(body, "body\n");
+});
+
+test("folded block scalars treat a blank line as a paragraph break", () => {
+  const { meta } = parseFrontmatter(
+    `---\ndescription: >\n  first para line one\n  line two\n\n  second para\n---\n`,
+  );
+  assert.equal(meta.description, "first para line one line two\nsecond para");
+});
+
+test("literal block scalars keep newlines", () => {
+  const { meta } = parseFrontmatter(`---\ndescription: |\n  line one\n  line two\n---\n`);
+  assert.equal(meta.description, "line one\nline two");
+
+  const chomped = parseFrontmatter(`---\ndescription: |-\n  line one\n  line two\n---\n`);
+  assert.equal(chomped.meta.description, "line one\nline two");
+});
+
+test("block scalar accepts indentation and chomping indicators", () => {
+  for (const header of [">", ">-", ">+", "|", "|-", "|+", "|2", ">2-"]) {
+    const { meta } = parseFrontmatter(`---\ndescription: ${header}\n  hello\n---\n`);
+    assert.equal(meta.description, "hello", `header ${header}`);
+  }
+});
+
+test("keys after a block scalar are still parsed", () => {
+  const { meta } = parseFrontmatter(
+    `---\ndescription: >-\n  folded value\n  continued\nname: after-block\n---\n`,
+  );
+  assert.equal(meta.description, "folded value continued");
+  assert.equal(meta.name, "after-block");
+});
+
+test("indented continuation lines are never mistaken for keys", () => {
+  const { meta } = parseFrontmatter(
+    `---\ndescription: >-\n  usage: run this when deploying\n  more text\n---\n`,
+  );
+  assert.equal(meta.description, "usage: run this when deploying more text");
+  assert.equal(meta.usage, undefined);
+});
+
+test("empty values and missing frontmatter are handled", () => {
+  const { meta } = parseFrontmatter(`---\nname:\ndescription: real\n---\n`);
+  assert.equal(meta.name, undefined);
+  assert.equal(meta.description, "real");
+
+  const none = parseFrontmatter("no frontmatter here\n");
+  assert.deepEqual(none.meta, {});
+  assert.equal(none.body, "no frontmatter here\n");
+});


### PR DESCRIPTION
Fixes #318.

## Problem

`parseFrontmatter` in `src/plugins/skills/scanner.ts` walked frontmatter lines applying a single-line regex. For a block scalar:

```markdown
---
name: product-knowledge
description: >-
  Product knowledge for three product lines — CMS, App and Pay.
  This is the WHAT/WHY/GOTCHA layer.
---
```

it captured `>-` as the description and dropped the indented continuation lines. The skill still activated and its body loaded fine, so nothing errored — but the always-on catalog advertised `>-` as the description, which is the only thing the model sees when deciding whether a skill is relevant. Silently undiscoverable skills. A user reported 8 of 22 skills in their repo hit this.

Block scalars are the natural way to write a description longer than one line, and the AgentSkills spec doesn't forbid them.

## Fix

When the captured value is a block indicator, consume the following more-indented (or blank) lines, dedent by the block's minimum indentation, then:
- `>` / `>-` → fold lines with spaces, blank line becomes a paragraph break
- `|` / `|-` → keep newlines

Indentation digits and chomping indicators (`+`, `-`) are accepted and ignored, since values are trimmed anyway. Parsing resumes at the first dedented line, so keys after a block scalar still parse and indented `foo: bar` text inside a block is no longer mistaken for a key.

No new dependency — block scalars are the only common YAML feature that broke here.

## Verification

- New `test/skills.test.ts`: 9 tests covering plain values, quote stripping, folded/literal blocks, paragraph breaks, all indicator variants, keys after a block, indented text that looks like a key, empty values, missing frontmatter. Full suite 25/25 green.
- End-to-end `scanSkills` run on the exact repro from the report now yields the full folded description instead of `>-`.