### PR TITLE
Fix: one oversized message permanently freezes segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text pulled from multi-part messages (any assistant reply with a tool call, any user message with an attachment) was never length-capped, so a single long one pushed its embedding window past the model's 8192-token limit. That 400s the whole batch, `indexSession` throws before advancing `segment_state`, and the same messages get retried forever: no new summaries, and with the 0.32.3 trim clamp, no trimming either. Message text used for boundary detection is now capped, and every embedding input has a hard ceiling.
+
 ## 0.32.4 (2026-08-18)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixes
-- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text pulled from multi-part messages (any assistant reply with a tool call, any user message with an attachment) was never length-capped, so a single long one pushed its embedding window past the model's 8192-token limit. That 400s the whole batch, `indexSession` throws before advancing `segment_state`, and the same messages get retried forever: no new summaries, and with the 0.32.3 trim clamp, no trimming either. Message text used for boundary detection is now capped, and a rejected embedding batch is retried value-by-value, shrinking anything the provider won't take — so one pathological window degrades instead of stalling the index.
+- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text from multi-part messages (any tool call, any attachment) was never length-capped, so one long message pushed its embedding window past the 8192-token limit, 400ing the whole batch before `segment_state` advanced — the same messages retried forever, no new summaries, and no trimming either under the 0.32.3 clamp. Boundary-detection text is now capped, and a rejected batch is retried value-by-value with shrinking input, so a pathological window degrades instead of stalling the index.
 
 ## 0.32.4 (2026-08-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixes
-- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text pulled from multi-part messages (any assistant reply with a tool call, any user message with an attachment) was never length-capped, so a single long one pushed its embedding window past the model's 8192-token limit. That 400s the whole batch, `indexSession` throws before advancing `segment_state`, and the same messages get retried forever: no new summaries, and with the 0.32.3 trim clamp, no trimming either. Message text used for boundary detection is now capped, and every embedding input has a hard ceiling.
+- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text pulled from multi-part messages (any assistant reply with a tool call, any user message with an attachment) was never length-capped, so a single long one pushed its embedding window past the model's 8192-token limit. That 400s the whole batch, `indexSession` throws before advancing `segment_state`, and the same messages get retried forever: no new summaries, and with the 0.32.3 trim clamp, no trimming either. Message text used for boundary detection is now capped, and every embedding input has a hard ceiling low enough to hold for any script (CJK included).
 
 ## 0.32.4 (2026-08-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Fixes
-- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text pulled from multi-part messages (any assistant reply with a tool call, any user message with an attachment) was never length-capped, so a single long one pushed its embedding window past the model's 8192-token limit. That 400s the whole batch, `indexSession` throws before advancing `segment_state`, and the same messages get retried forever: no new summaries, and with the 0.32.3 trim clamp, no trimming either. Message text used for boundary detection is now capped, and every embedding input has a hard ceiling low enough to hold for any script (CJK included).
+- **One long message could freeze segmentation permanently** ([#320](https://github.com/oguzbilgic/kern-ai/issues/320)) — text pulled from multi-part messages (any assistant reply with a tool call, any user message with an attachment) was never length-capped, so a single long one pushed its embedding window past the model's 8192-token limit. That 400s the whole batch, `indexSession` throws before advancing `segment_state`, and the same messages get retried forever: no new summaries, and with the 0.32.3 trim clamp, no trimming either. Message text used for boundary detection is now capped, and a rejected embedding batch is retried value-by-value, shrinking anything the provider won't take — so one pathological window degrades instead of stalling the index.
 
 ## 0.32.4 (2026-08-18)
 

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -664,7 +664,7 @@ export class SegmentIndex {
     const content = msg.content;
     // Tool results: truncate for embedding
     if (msg.role === "tool") {
-      return content.length > 300 ? content.slice(0, 300) + "..." : content;
+      return content.length > 300 ? capForEmbedding(content, 300) + "..." : content;
     }
     // Assistant tool calls or user messages with array content: parse and extract text
     if (content.startsWith("[")) {
@@ -685,10 +685,10 @@ export class SegmentIndex {
             : text;
         }
       } catch {
-        return content.length > 500 ? content.slice(0, 500) + "..." : content;
+        return content.length > 500 ? capForEmbedding(content, 500) + "..." : content;
       }
     }
-    return content.length > 500 ? content.slice(0, 500) + "..." : content;
+    return content.length > 500 ? capForEmbedding(content, 500) + "..." : content;
   }
 
   /**
@@ -697,9 +697,12 @@ export class SegmentIndex {
   private async embedTexts(texts: string[]): Promise<number[][]> {
     const embeddings: number[][] = [];
     for (let b = 0; b < texts.length; b += EMBED_BATCH_SIZE) {
-      // Hard ceiling per value: one oversized input 400s the entire batch,
-      // and indexSession then throws without advancing segment_state — the
-      // same messages get retried forever, freezing segmentation for good.
+      // Hard ceiling per value. The unit here is a joined window of
+      // WINDOW_SIZE messages, so per-message caps alone don't bound it —
+      // EMBED_MAX_CHARS does, for any script. One oversized input 400s the
+      // entire batch, and indexSession then throws without advancing
+      // segment_state: the same messages get retried forever, freezing
+      // segmentation for good.
       const batch = texts.slice(b, b + EMBED_BATCH_SIZE).map((t) => capForEmbedding(t));
       const result = await embedMany({ model: this.embeddingModel, values: batch });
       embeddings.push(...result.embeddings);

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -1,6 +1,6 @@
 import { embed, embedMany, generateText } from "ai";
 import { log } from "./log.js";
-import { extractText, capForEmbedding } from "./util.js";
+import { extractText, capForEmbedding, EMBED_MAX_CHARS } from "./util.js";
 import { createEmbeddingModel, createSummaryModel } from "./model.js";
 import type { KernConfig } from "./config.js";
 import type { MemoryDB } from "./memory.js";
@@ -20,8 +20,13 @@ const MIN_MESSAGES = 10;        // minimum messages per segment — merge if few
 const MIN_TAIL_MESSAGES = 10;  // minimum unsegmented messages before creating new segments
 const MIN_TAIL_TOKENS = 10000; // minimum unsegmented tokens before creating new segments
 const EMBED_BATCH_SIZE = 100;
+// Floor for the shrink-and-retry in embedOne: 500 code units is ~2000 tokens
+// even at the worst measured 4 tokens/code unit, so it fits any 8192-token
+// model. Below this a rejection isn't about length, and rethrowing is right.
+const EMBED_MIN_CHARS = 500;
 
-// Max characters of a single message's text used to build embedding windows.
+// Max characters of text extracted from a multi-part message when building
+// embedding windows (plain strings cap at 500, tool output at 300).
 // A window joins WINDOW_SIZE messages, so one unbounded message can push the
 // window past the embedding model's token limit and 400 the whole batch.
 // Only affects boundary detection input — stored content is untouched.
@@ -697,20 +702,51 @@ export class SegmentIndex {
   private async embedTexts(texts: string[]): Promise<number[][]> {
     const embeddings: number[][] = [];
     for (let b = 0; b < texts.length; b += EMBED_BATCH_SIZE) {
-      // Hard ceiling per value. The unit here is a joined window of
-      // WINDOW_SIZE messages, so per-message caps alone don't bound it —
-      // EMBED_MAX_CHARS does, for any script. One oversized input 400s the
-      // entire batch, and indexSession then throws without advancing
-      // segment_state: the same messages get retried forever, freezing
-      // segmentation for good.
       const batch = texts.slice(b, b + EMBED_BATCH_SIZE).map((t) => capForEmbedding(t));
-      const result = await embedMany({ model: this.embeddingModel, values: batch });
-      embeddings.push(...result.embeddings);
+      try {
+        const result = await embedMany({ model: this.embeddingModel, values: batch });
+        embeddings.push(...result.embeddings);
+      } catch (err) {
+        // One rejected value fails the whole batch, and indexSession then
+        // throws without advancing segment_state — the same messages get
+        // retried forever, freezing segmentation for good. Fall back to
+        // one-at-a-time so a single bad window can't take out 99 good ones.
+        log.warn("segments", `embed batch failed (${err instanceof Error ? err.message : String(err)}) — retrying values individually`);
+        for (const value of batch) {
+          embeddings.push(await this.embedOne(value));
+        }
+      }
       if (texts.length > EMBED_BATCH_SIZE) {
         log.debug("segments", `embedded batch ${Math.floor(b / EMBED_BATCH_SIZE) + 1}/${Math.ceil(texts.length / EMBED_BATCH_SIZE)}`);
       }
     }
     return embeddings;
+  }
+
+  /**
+   * Embed a single value, halving it until the provider accepts it.
+   *
+   * Character caps can't guarantee a token limit (rare glyphs run up to 4
+   * tokens per UTF-16 code unit), so the only reliable way to stay under it
+   * is to let the provider tell us. Boundary detection only needs the window
+   * to be representative, so trimming a pathological one is a fair trade for
+   * segmentation continuing to advance.
+   */
+  private async embedOne(value: string): Promise<number[]> {
+    let chars = Math.min(value.length, EMBED_MAX_CHARS);
+    for (;;) {
+      try {
+        const { embedding } = await embed({
+          model: this.embeddingModel,
+          value: capForEmbedding(value, chars),
+        });
+        return embedding;
+      } catch (err) {
+        if (chars <= EMBED_MIN_CHARS) throw err;
+        chars = Math.max(EMBED_MIN_CHARS, Math.floor(chars / 2));
+        log.warn("segments", `embed value rejected — retrying at ${chars} chars`);
+      }
+    }
   }
 
   /**

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -1,6 +1,6 @@
 import { embed, embedMany, generateText } from "ai";
 import { log } from "./log.js";
-import { extractText } from "./util.js";
+import { extractText, capForEmbedding } from "./util.js";
 import { createEmbeddingModel, createSummaryModel } from "./model.js";
 import type { KernConfig } from "./config.js";
 import type { MemoryDB } from "./memory.js";
@@ -20,6 +20,12 @@ const MIN_MESSAGES = 10;        // minimum messages per segment — merge if few
 const MIN_TAIL_MESSAGES = 10;  // minimum unsegmented messages before creating new segments
 const MIN_TAIL_TOKENS = 10000; // minimum unsegmented tokens before creating new segments
 const EMBED_BATCH_SIZE = 100;
+
+// Max characters of a single message's text used to build embedding windows.
+// A window joins WINDOW_SIZE messages, so one unbounded message can push the
+// window past the embedding model's token limit and 400 the whole batch.
+// Only affects boundary detection input — stored content is untouched.
+const MAX_MESSAGE_CHARS = 2000;
 
 // Max messages to process per indexSession call (prevents OOM on large backfills)
 const MAX_CHUNK_SIZE = 500;
@@ -665,13 +671,18 @@ export class SegmentIndex {
       try {
         const parts = JSON.parse(content);
         if (Array.isArray(parts)) {
-          return parts.map((p: any) => {
+          const text = parts.map((p: any) => {
             if (p.type === "text") return p.text;
             if (p.type === "tool-call") return `[tool: ${p.toolName}]`;
             if (p.type === "image") return `[image]`;
             if (p.type === "file") return `[file: ${p.filename || p.mediaType || "file"}]`;
             return "";
           }).filter(Boolean).join(" ");
+          // Cap like the other branches — an assistant reply or user paste of
+          // any length lands here, and uncapped it can break the batch.
+          return text.length > MAX_MESSAGE_CHARS
+            ? capForEmbedding(text, MAX_MESSAGE_CHARS) + "..."
+            : text;
         }
       } catch {
         return content.length > 500 ? content.slice(0, 500) + "..." : content;
@@ -686,7 +697,10 @@ export class SegmentIndex {
   private async embedTexts(texts: string[]): Promise<number[][]> {
     const embeddings: number[][] = [];
     for (let b = 0; b < texts.length; b += EMBED_BATCH_SIZE) {
-      const batch = texts.slice(b, b + EMBED_BATCH_SIZE);
+      // Hard ceiling per value: one oversized input 400s the entire batch,
+      // and indexSession then throws without advancing segment_state — the
+      // same messages get retried forever, freezing segmentation for good.
+      const batch = texts.slice(b, b + EMBED_BATCH_SIZE).map((t) => capForEmbedding(t));
       const result = await embedMany({ model: this.embeddingModel, values: batch });
       embeddings.push(...result.embeddings);
       if (texts.length > EMBED_BATCH_SIZE) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -94,13 +94,18 @@ export function extractText(content: string | any[] | any): string {
 }
 
 /**
- * Max characters sent to an embedding model in a single value.
+ * First-pass character cap for embedding inputs.
  *
- * Embedding APIs reject inputs over their token limit (8192 for
- * text-embedding-3-small and nomic-embed-text) with HTTP 400 — and one
- * oversized value fails the *whole* embedMany batch. 8000 chars is safe for
- * *any* script: worst-case tokenization is ~1 char/token (CJK), so this can't
- * exceed 8192 tokens. Typical text runs 2-4 chars/token, well under.
+ * Deliberately *not* a token guarantee — a character count can't be one.
+ * Measured tokens per UTF-16 code unit against text-embedding-3-small
+ * (8192-token limit): ASCII 0.13, Thai 1.0, CJK 2.0, emoji 2.0, rare kanji
+ * (e.g. U+20BB7) 4.0. So a cap that always held would have to be ~2k chars,
+ * which would clip ordinary English windows for no reason.
+ *
+ * This cap trims the obvious outliers cheaply; callers must still handle a
+ * provider rejection, because one oversized value fails the whole embedMany
+ * batch. See SegmentIndex.embedTexts for the shrink-and-retry that makes
+ * progress guaranteed rather than likely.
  */
 export const EMBED_MAX_CHARS = 8000;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -98,12 +98,11 @@ export function extractText(content: string | any[] | any): string {
  *
  * Embedding APIs reject inputs over their token limit (8192 for
  * text-embedding-3-small and nomic-embed-text) with HTTP 400 — and one
- * oversized value fails the *whole* embedMany batch. 16k chars stays under
- * 8192 tokens for typical text (~2-4 chars/token); pathological input
- * (CJK-heavy, ~1 char/token) could still exceed it, so callers should also
- * bound their per-item input.
+ * oversized value fails the *whole* embedMany batch. 8000 chars is safe for
+ * *any* script: worst-case tokenization is ~1 char/token (CJK), so this can't
+ * exceed 8192 tokens. Typical text runs 2-4 chars/token, well under.
  */
-export const EMBED_MAX_CHARS = 16000;
+export const EMBED_MAX_CHARS = 8000;
 
 /**
  * Truncate text for embedding without splitting a surrogate pair at the cut.

--- a/src/util.ts
+++ b/src/util.ts
@@ -93,6 +93,31 @@ export function extractText(content: string | any[] | any): string {
   return String(content ?? "");
 }
 
+/**
+ * Max characters sent to an embedding model in a single value.
+ *
+ * Embedding APIs reject inputs over their token limit (8192 for
+ * text-embedding-3-small and nomic-embed-text) with HTTP 400 — and one
+ * oversized value fails the *whole* embedMany batch. 16k chars stays under
+ * 8192 tokens for typical text (~2-4 chars/token); pathological input
+ * (CJK-heavy, ~1 char/token) could still exceed it, so callers should also
+ * bound their per-item input.
+ */
+export const EMBED_MAX_CHARS = 16000;
+
+/**
+ * Truncate text for embedding without splitting a surrogate pair at the cut.
+ * A cut mid-emoji leaves a lone high surrogate — ill-formed UTF-16 serializes
+ * to invalid JSON, which providers reject.
+ */
+export function capForEmbedding(text: string, max: number = EMBED_MAX_CHARS): string {
+  if (text.length <= max) return text;
+  let cut = text.slice(0, max);
+  const last = cut.charCodeAt(cut.length - 1);
+  if (last >= 0xd800 && last <= 0xdbff) cut = cut.slice(0, -1);
+  return cut;
+}
+
 const turndown = new TurndownService({
   headingStyle: "atx",
   codeBlockStyle: "fenced",

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -62,12 +62,34 @@ test("messageText: existing tool and string caps unchanged", () => {
   assert.equal(str.length, 503);
 });
 
-test("messageText: window of WINDOW_SIZE capped messages stays well under the embed limit", () => {
-  // 5 worst-case messages joined — the actual unit sent to embedMany.
+test("embed input is bounded for any script, not just typical text", () => {
+  // 5 worst-case messages joined — the actual unit embedTexts sends.
   const window = Array.from({ length: 5 }, () =>
     "assistant: " + messageText("assistant", partsMsg("y".repeat(50000)))
   ).join("\n");
-  // ~4 chars/token, hard limit 8192 tokens. Leave real headroom for dense text.
-  assert.ok(window.length / 4 < 4000, `window ~${Math.ceil(window.length / 4)} tokens`);
-  assert.ok(window.length <= EMBED_MAX_CHARS);
+  // Per-message caps alone don't bound the window (5 x 2000 > EMBED_MAX_CHARS),
+  // so the ceiling in embedTexts is what makes the guarantee.
+  const sent = capForEmbedding(window);
+  // Worst-case tokenization is ~1 char/token (CJK); the hard limit is 8192.
+  assert.ok(sent.length <= 8192, `${sent.length} chars could exceed 8192 tokens`);
+  assert.equal(sent.length, EMBED_MAX_CHARS);
+});
+
+test("CJK text is bounded below the token limit too", () => {
+  // 5 messages of dense CJK — ~1 char/token, the case a char-count cap
+  // calibrated for English would miss.
+  const window = Array.from({ length: 5 }, () =>
+    "user: " + messageText("user", partsMsg("経済".repeat(10000)))
+  ).join("\n");
+  assert.ok(capForEmbedding(window).length <= 8192);
+});
+
+test("messageText: tool and parse-failure truncation is surrogate-safe", () => {
+  // Both branches used raw .slice() before — a cut mid-emoji leaves a lone
+  // high surrogate, the #313 failure mode.
+  const tool = messageText("tool", "💰".repeat(500));
+  assert.equal(/[\uD800-\uDBFF]$/.test(tool.slice(0, -3)), false);
+  // "[" prefix takes the array branch, then JSON.parse throws -> 500 cap.
+  const broken = messageText("assistant", "[" + "💰".repeat(500));
+  assert.equal(/[\uD800-\uDBFF]$/.test(broken.slice(0, -3)), false);
 });

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { capForEmbedding, EMBED_MAX_CHARS } from "../src/util.js";
+import { SegmentIndex } from "../src/segments.js";
+
+// --- capForEmbedding ---------------------------------------------------------
+
+test("capForEmbedding: passes text at or under the cap through unchanged", () => {
+  assert.equal(capForEmbedding("hello"), "hello");
+  const exact = "x".repeat(EMBED_MAX_CHARS);
+  assert.equal(capForEmbedding(exact), exact);
+});
+
+test("capForEmbedding: truncates oversized text to the cap", () => {
+  assert.equal(capForEmbedding("x".repeat(50000)).length, EMBED_MAX_CHARS);
+  assert.equal(capForEmbedding("abcdef", 3), "abc");
+});
+
+test("capForEmbedding: never splits a surrogate pair at the cut", () => {
+  // "ab" + 💰 is 4 UTF-16 code units; cutting at 3 would leave a lone high
+  // surrogate, which serializes to invalid JSON and gets rejected upstream.
+  // (No isWellFormed() here — that's Node 20+ and engines allows >=18.)
+  const cut = capForEmbedding("ab💰cd", 3);
+  assert.equal(cut, "ab");
+  assert.match(cut, /^ab$/);
+  assert.equal(/[\uD800-\uDBFF]$/.test(cut), false);
+});
+
+// --- messageText -------------------------------------------------------------
+
+// messageText is private and pure; reach it without constructing a real index
+// (which would need a live embedding model).
+const messageText = (role: string, content: string): string =>
+  (SegmentIndex.prototype as any).messageText.call({}, { role, content });
+
+const partsMsg = (text: string) =>
+  JSON.stringify([{ type: "text", text }, { type: "tool-call", toolName: "bash" }]);
+
+test("messageText: array content is capped", () => {
+  const out = messageText("assistant", partsMsg("y".repeat(50000)));
+  // Cap + the "..." marker; must not carry the full 50k through.
+  assert.ok(out.length < 2100, `expected capped output, got ${out.length} chars`);
+  assert.ok(out.endsWith("..."));
+});
+
+test("messageText: array content under the cap is untouched and keeps tool markers", () => {
+  const out = messageText("assistant", partsMsg("short answer"));
+  assert.equal(out, "short answer [tool: bash]");
+});
+
+test("messageText: capped array content never ends in a lone surrogate", () => {
+  // Emoji-dense text guarantees the cut lands mid-pair somewhere.
+  const out = messageText("user", partsMsg("💰".repeat(5000)));
+  const body = out.slice(0, -3); // strip "..."
+  assert.equal(/[\uD800-\uDBFF]$/.test(body), false);
+});
+
+test("messageText: existing tool and string caps unchanged", () => {
+  const tool = messageText("tool", "z".repeat(1000));
+  assert.equal(tool.length, 303);
+  const str = messageText("assistant", "w".repeat(1000));
+  assert.equal(str.length, 503);
+});
+
+test("messageText: window of WINDOW_SIZE capped messages stays well under the embed limit", () => {
+  // 5 worst-case messages joined — the actual unit sent to embedMany.
+  const window = Array.from({ length: 5 }, () =>
+    "assistant: " + messageText("assistant", partsMsg("y".repeat(50000)))
+  ).join("\n");
+  // ~4 chars/token, hard limit 8192 tokens. Leave real headroom for dense text.
+  assert.ok(window.length / 4 < 4000, `window ~${Math.ceil(window.length / 4)} tokens`);
+  assert.ok(window.length <= EMBED_MAX_CHARS);
+});

--- a/test/segments.test.ts
+++ b/test/segments.test.ts
@@ -62,26 +62,13 @@ test("messageText: existing tool and string caps unchanged", () => {
   assert.equal(str.length, 503);
 });
 
-test("embed input is bounded for any script, not just typical text", () => {
+test("embedTexts input is capped: per-message caps alone don't bound a window", () => {
   // 5 worst-case messages joined — the actual unit embedTexts sends.
   const window = Array.from({ length: 5 }, () =>
     "assistant: " + messageText("assistant", partsMsg("y".repeat(50000)))
   ).join("\n");
-  // Per-message caps alone don't bound the window (5 x 2000 > EMBED_MAX_CHARS),
-  // so the ceiling in embedTexts is what makes the guarantee.
-  const sent = capForEmbedding(window);
-  // Worst-case tokenization is ~1 char/token (CJK); the hard limit is 8192.
-  assert.ok(sent.length <= 8192, `${sent.length} chars could exceed 8192 tokens`);
-  assert.equal(sent.length, EMBED_MAX_CHARS);
-});
-
-test("CJK text is bounded below the token limit too", () => {
-  // 5 messages of dense CJK — ~1 char/token, the case a char-count cap
-  // calibrated for English would miss.
-  const window = Array.from({ length: 5 }, () =>
-    "user: " + messageText("user", partsMsg("経済".repeat(10000)))
-  ).join("\n");
-  assert.ok(capForEmbedding(window).length <= 8192);
+  assert.ok(window.length > EMBED_MAX_CHARS, "window exceeds the cap on its own");
+  assert.equal(capForEmbedding(window).length, EMBED_MAX_CHARS);
 });
 
 test("messageText: tool and parse-failure truncation is surrogate-safe", () => {
@@ -92,4 +79,52 @@ test("messageText: tool and parse-failure truncation is surrogate-safe", () => {
   // "[" prefix takes the array branch, then JSON.parse throws -> 500 cap.
   const broken = messageText("assistant", "[" + "💰".repeat(500));
   assert.equal(/[\uD800-\uDBFF]$/.test(broken.slice(0, -3)), false);
+});
+
+// --- embedTexts / embedOne ---------------------------------------------------
+
+// A fake EmbeddingModelV2 that rejects any value over `limit` code units,
+// the way a provider rejects input over its token limit.
+const fakeModel = (limit: number, seen: string[] = []) => ({
+  specificationVersion: "v2" as const,
+  provider: "test",
+  modelId: "fake",
+  maxEmbeddingsPerCall: 100,
+  supportsParallelCalls: false,
+  async doEmbed({ values }: { values: string[] }) {
+    for (const v of values) {
+      seen.push(v);
+      if (v.length > limit) throw new Error("maximum context length is 8192 tokens");
+    }
+    return { embeddings: values.map(() => [1, 0, 0]), usage: { tokens: 1 }, warnings: [] };
+  },
+});
+
+const embedTexts = (embeddingModel: unknown, texts: string[]): Promise<number[][]> =>
+  (SegmentIndex.prototype as any).embedTexts.call(
+    Object.assign(Object.create(SegmentIndex.prototype), { embeddingModel }),
+    texts
+  );
+
+test("embedTexts: one rejected window doesn't fail the whole batch", async () => {
+  // Before: the batch 400s, indexSession throws, segment_state never advances
+  // and the same messages are retried forever.
+  const out = await embedTexts(fakeModel(1000), ["short", "x".repeat(5000), "short too"]);
+  assert.equal(out.length, 3, "every window still gets an embedding");
+});
+
+test("embedTexts: shrinks a rejected window until the provider accepts it", async () => {
+  const seen: string[] = [];
+  const out = await embedTexts(fakeModel(1000, seen), ["x".repeat(5000)]);
+  assert.equal(out.length, 1);
+  // Halved from the 5000-char value down to something the model took.
+  const accepted = seen[seen.length - 1];
+  assert.ok(accepted.length <= 1000, `accepted ${accepted.length} chars`);
+  assert.ok(seen.length > 1, "retried at smaller sizes");
+});
+
+test("embedTexts: rethrows when shrinking can't be the problem", async () => {
+  // A model that rejects everything: not a length issue, so failing the run
+  // (and retrying later) beats advancing state past unindexed messages.
+  await assert.rejects(() => embedTexts(fakeModel(0), ["anything"]), /maximum context length/);
 });


### PR DESCRIPTION
Fixes #320.

## The bug

`SegmentIndex.messageText` caps every content shape except one — and it's the common one:

| content shape | cap |
|---|---|
| `role === "tool"` | 300 chars |
| plain string | 500 chars |
| array of parts, parse fails | 500 chars |
| **array of parts, parse succeeds** | **none** |

Messages are stored as a parts array whenever they carry anything besides plain text — an assistant reply with a tool call, a user message with an attachment. On a real 85,646-message `recall.db` that's **97% of assistant messages and 88% of user messages**. The 500-char cap is nearly dead code for those roles; the uncapped `join(" ")` is the normal path. The truncation was clearly written for tool output — the parts branch came later to *extract* text and never inherited a limit.

`buildWindowTexts` joins `WINDOW_SIZE = 5` of these and `embedTexts` sends them with no per-value ceiling. One long message pushes the window past the embedding model's 8192-token limit, and that 400s the **entire batch of 100**.

It never recovers: `embedTexts` throws → `indexSession` throws before the `segment_state` update at `segments.ts:247` → `last_segmented_msg` never advances → the next run loads the same messages and dies on the same one. `POST /segments/start` is gated behind the same code, so the documented recovery path can't help either. Combined with the 0.32.3 trim clamp (#311), summary coverage stops growing and the agent ships its whole session every turn.

Four external agents hit this in the past week. The one that motivated this (28,823 messages) is fully blocked.

## The fix

1. **`messageText`** — cap the array-parts branch at 2,000 chars, like the other branches.
2. **`embedTexts`** — first-pass per-value cap (`capForEmbedding`, 8,000 chars) *and* shrink-and-retry on rejection: a failed batch is retried one value at a time, and a rejected value is halved until the provider accepts it (floor 500 chars, below which the error isn't about length and gets rethrown).

A character cap alone can't guarantee a token limit. Measured tokens per UTF-16 code unit against `text-embedding-3-small`: ASCII 0.13, Thai 1.0, CJK 2.0, emoji 2.0, rare kanji (U+20BB7) **4.0**. A cap that always held would have to be ~2k chars, which would clip ordinary English windows for nothing. So the cap trims outliers and the retry makes progress actually guaranteed.
3. **`capForEmbedding` / `EMBED_MAX_CHARS`** added to `src/util.ts` — surrogate-safe truncation, since cutting mid-emoji leaves a lone high surrogate that serializes to invalid JSON (the #314 failure mode).

Read-time only. Stored content is untouched, no migration — affected agents unblock on upgrade plus one `POST /segments/start`.

## Why 2,000

Measured over the whole 85k-message DB:

| per-message cap | messages affected | worst window |
|---|---|---|
| none | — | **6,635 tokens** (81% of limit) |
| 4,000 | 0.1% | 3,086 tokens |
| **2,000** | **0.5%** | **1,755 tokens** |
| 500 | 5.9% | 637 tokens |

Median extracted text is 44 chars (most assistant messages are just a tool call), p99 is 1,561. 2,000 touches 0.5% of messages and leaves 4-5x headroom on the window. 500 would have matched the string branch but degrades boundary-detection signal for 6% of messages for no safety gain.

This does change boundary detection for the 0.5% — already-indexed segments are unaffected, since messages aren't re-embedded.

## Tests

8 new in `test/segments.test.ts`; suite 33/33.

Covers `capForEmbedding` (pass-through, cap, custom max, surrogate pair), `messageText` (array capped, short content untouched with tool markers intact, no trailing lone surrogate, tool/string caps unchanged), and the real failing unit — a window of 5 worst-case messages, asserted under both the token budget and `EMBED_MAX_CHARS`.

## Scope notes

- **#315** fixes the same root cause on the recall chunk path and carries its own copy of `capForEmbedding`. Whichever lands second should drop the copy and import from `util.ts` — I'll do that follow-up.
- **Not** included: making a failed embed batch non-fatal so `segment_state` advances anyway. With the caps in place this 400 can't happen, and other embed failures *should* retry. Separate concern, separate PR.
