### PR TITLE
feat(irc): replace rigid commands with versatile raw send action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 - **Your agent is on IRC** — chat with your agent from any IRC client or self-hosted server. Point `IRC_URL` at your network (`ircs://myagent:pass@irc.example.com:6697/#homelab`) and the agent joins, registers with NickServ, and listens. Private messages use pairing like Telegram; shared channels stay open with leading mentions stripped automatically so multiple agents can collaborate.
 - **Your agent is on Nostr** — direct-message your agent from any Nostr client using encrypted DMs. Give it `NOSTR_NSEC` and it listens across public relays with automatic deduplication, gift-wrap encryption (NIP-17 / NIP-44), and no servers to maintain.
-- **Autonomous IRC management** — a built-in `irc` tool and bundled `irc-setup` skill let the agent probe IRC servers, register accounts with NickServ, configure its own URL, and manage channels on the fly without operator scripting.
+- **Autonomous IRC management** — a built-in `irc` tool and bundled `irc-setup` skill let the agent probe IRC servers, register accounts with NickServ, configure its own URL, and send IRC protocol commands (`send`) on the fly (joining/parting channels, NickServ authentication, WHOIS, NAMES, TOPIC, MODE) with responses captured and returned directly to the model.
 - **Self-provisioning Nostr identity** — with the bundled `nostr-setup` skill, the agent generates its own keypair, secures its `nsec`, and shares its `npub` for instant pairing.
 
 ### Behaviour Changes

--- a/skills/irc-setup/SKILL.md
+++ b/skills/irc-setup/SKILL.md
@@ -65,10 +65,16 @@ Prompt your operator:
 
 Once restarted:
 1. Run `/status` — IRC should report `connected`.
-2. Inspect channel members using the tool:
-   `irc({ action: "names", channel: "#homelab" })`
-3. Check WHOIS on users to verify authenticated accounts:
-   `irc({ action: "whois", target: "<nick>" })`
-4. Join or leave channels on the fly if needed:
-   `irc({ action: "join", channel: "#dev" })`
-   `irc({ action: "part", channel: "#dev" })`
+2. Send commands directly to the server using `action: "send"`:
+   - Identify or authenticate:
+     `irc({ action: "send", command: "PRIVMSG NickServ :IDENTIFY <password>" })`
+   - Inspect channel members:
+     `irc({ action: "send", command: "NAMES #homelab" })`
+   - Inspect user accounts and hostmasks:
+     `irc({ action: "send", command: "WHOIS <nick>" })`
+   - Join or leave channels on the fly:
+     `irc({ action: "send", command: "JOIN #dev" })`
+     `irc({ action: "send", command: "PART #dev :Leaving" })`
+   - Inspect or set channel topic/modes:
+     `irc({ action: "send", command: "TOPIC #homelab" })`
+     `irc({ action: "send", command: "MODE #homelab" })`

--- a/src/interfaces/irc.ts
+++ b/src/interfaces/irc.ts
@@ -402,9 +402,73 @@ class IrcConnection {
     return true;
   }
 
-  // Active query callbacks for WHOIS, NAMES, etc.
+  // Active query callbacks for WHOIS, NAMES, raw lines, etc.
   private pendingWhois = new Map<string, { resolve: (val: any) => void; info: any; timer: NodeJS.Timeout }>();
   private pendingNames = new Map<string, { resolve: (val: any) => void; nicks: string[]; timer: NodeJS.Timeout }>();
+  private rawCaptures = new Set<{ onLine: (raw: string, line: IrcLine) => void }>();
+
+  /**
+   * Send a raw IRC line and capture server response lines for a short duration.
+   */
+  async sendCommand(
+    command: string,
+    timeoutMs = 2500,
+  ): Promise<{ success: boolean; lines: string[]; error?: string }> {
+    if (!this.socket || !this.registered) return { success: false, lines: [], error: "Not connected to IRC server" };
+
+    const captured: string[] = [];
+    return new Promise((resolve) => {
+      let settled = false;
+      let idleTimer: NodeJS.Timeout | null = null;
+
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        if (idleTimer) clearTimeout(idleTimer);
+        clearTimeout(maxTimer);
+        this.rawCaptures.delete(capture);
+        resolve({ success: true, lines: captured });
+      };
+
+      const maxTimer = setTimeout(finish, timeoutMs);
+
+      const resetIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        // After receiving some lines, settle if quiet for 500ms
+        idleTimer = setTimeout(finish, 600);
+      };
+
+      const capture = {
+        onLine: (raw: string, line: IrcLine) => {
+          captured.push(raw);
+          resetIdle();
+
+          // Settle early on known terminal responses
+          const cmd = line.command;
+          if (
+            cmd === "318" || // RPL_ENDOFWHOIS
+            cmd === "366" || // RPL_ENDOFNAMES
+            cmd === "323" || // RPL_LISTEND
+            cmd === "368" || // RPL_ENDOFBANLIST
+            cmd === "401" || // ERR_NOSUCHNICK
+            cmd === "402" || // ERR_NOSUCHSERVER
+            cmd === "403" || // ERR_NOSUCHCHANNEL
+            cmd === "404" || // ERR_CANNOTSENDTOCHAN
+            cmd === "421" || // ERR_UNKNOWNCOMMAND
+            cmd === "433" || // ERR_NICKNAMEINUSE
+            cmd === "442" || // ERR_NOTONCHANNEL
+            cmd === "461" || // ERR_NEEDMOREPARAMS
+            cmd === "482"    // ERR_CHANOPRIVSNEEDED
+          ) {
+            setTimeout(finish, 50);
+          }
+        },
+      };
+
+      this.rawCaptures.add(capture);
+      this.enqueue(command);
+    });
+  }
 
   async queryWhois(target: string, timeoutMs = 8000): Promise<{ success: boolean; info?: any; error?: string }> {
     if (!this.socket || !this.registered) return { success: false, error: "Not connected to IRC server" };
@@ -543,7 +607,12 @@ class IrcConnection {
     for (const raw of lines) {
       if (!raw) continue;
       const line = parseIrcLine(raw);
-      if (line) this.handleLine(line);
+      if (line) {
+        for (const capture of this.rawCaptures) {
+          capture.onLine(raw, line);
+        }
+        this.handleLine(line);
+      }
     }
   }
 
@@ -913,6 +982,17 @@ export class IrcInterface implements Interface {
     const conn = host ? this.connections.find((c) => c.host === host) : this.connections[0];
     if (!conn) return false;
     return conn.sendRaw(line);
+  }
+
+  /** Run a raw command and capture the response lines. */
+  async sendCommand(
+    command: string,
+    host?: string,
+    timeoutMs = 2500,
+  ): Promise<{ success: boolean; lines: string[]; error?: string }> {
+    const conn = host ? this.connections.find((c) => c.host === host) : this.connections[0];
+    if (!conn) return { success: false, lines: [], error: "No active IRC connection" };
+    return conn.sendCommand(command, timeoutMs);
   }
 
   /** Run a WHOIS query against a user. */

--- a/src/tools/irc.ts
+++ b/src/tools/irc.ts
@@ -90,25 +90,26 @@ function runProbeSocket(opts: {
 
 export const ircTool = tool({
   description:
-    "Manage IRC connection, configuration, registration, and runtime operations (join, part, whois, names).",
+    "Manage IRC connection, configuration, and send IRC protocol commands (e.g. WHOIS, NAMES, JOIN, PART, PRIVMSG NickServ, MODE).",
   inputSchema: z.object({
     action: z
-      .enum(["probe", "register", "configure", "join", "part", "names", "whois"])
+      .enum(["probe", "register", "configure", "send"])
       .describe(
-        "probe: test IRC server connectivity and features. register: register nick with NickServ. configure: format and write connection URL to config. join: join a channel. part: leave a channel. names: list users in a channel. whois: inspect user/account info.",
+        "probe: test IRC server connectivity and features. register: register nick with NickServ during setup. configure: format and write connection URL to config. send: send a raw IRC command to the running interface and capture response lines.",
       ),
-    host: z.string().optional().describe("IRC server hostname (required for probe, register, configure, or targeting specific connection)"),
+    command: z
+      .string()
+      .optional()
+      .describe("Raw IRC command to send (for send action, e.g. 'WHOIS Atlas', 'NAMES #homelab', 'JOIN #dev', 'PRIVMSG NickServ :IDENTIFY pass')"),
+    host: z.string().optional().describe("IRC server hostname (for probe, register, configure, or targeting specific connection in send)"),
     port: z.number().optional().describe("IRC server port (default: 6667 plain, 6697 TLS)"),
     tls: z.boolean().optional().describe("Use TLS/SSL (default: true if port is 6697, false otherwise)"),
     nick: z.string().optional().describe("Nickname (for register or configure)"),
     password: z.string().optional().describe("Account password (for register or configure)"),
     email: z.string().optional().describe("Optional email address for NickServ registration"),
     channels: z.string().optional().describe("Comma-separated list of channels to join, e.g. '#homelab,#general'"),
-    channel: z.string().optional().describe("Channel name (for join, part, names)"),
-    target: z.string().optional().describe("Nick to inspect (for whois)"),
-    reason: z.string().optional().describe("Part reason (for part)"),
   }),
-  execute: async ({ action, host, port, tls, nick, password, email, channels, channel, target, reason }) => {
+  execute: async ({ action, command, host, port, tls, nick, password, email, channels }) => {
     switch (action) {
       case "probe": {
         if (!host) return "Error: host is required for probe";
@@ -266,54 +267,31 @@ export const ircTool = tool({
         }
       }
 
-      case "join": {
-        if (!channel) return "Error: channel is required for join";
-        const chan = /^[#&]/.test(channel) ? channel : `#${channel}`;
+      case "send": {
+        if (!command) return "Error: command is required for send (e.g. 'WHOIS nick' or 'NAMES #chan')";
         if (!_ircBot) return "Error: IRC interface is not running on this agent";
 
-        const sent = _ircBot.raw(`JOIN ${chan}`, host);
-        if (!sent) return `Failed to send JOIN: no connection for host ${host || "(default)"}`;
-        return `Joined ${chan}`;
-      }
+        const clean = command.trim();
+        // Prevent CRLF injection
+        if (/[\r\n]/.test(clean)) {
+          return "Error: command must not contain carriage return or newline characters";
+        }
 
-      case "part": {
-        if (!channel) return "Error: channel is required for part";
-        const chan = /^[#&]/.test(channel) ? channel : `#${channel}`;
-        if (!_ircBot) return "Error: IRC interface is not running on this agent";
+        // Prevent destructive QUIT via send
+        if (/^QUIT(\s|$)/i.test(clean)) {
+          return "Error: QUIT command cannot be sent via irc tool as it terminates the connection";
+        }
 
-        const msg = reason ? ` :${reason}` : "";
-        const sent = _ircBot.raw(`PART ${chan}${msg}`, host);
-        if (!sent) return `Failed to send PART: no connection for host ${host || "(default)"}`;
-        return `Parted ${chan}`;
-      }
+        const res = await _ircBot.sendCommand(clean, host);
+        if (!res.success) {
+          return `Command failed: ${res.error || "failed to send command"}`;
+        }
 
-      case "names": {
-        if (!channel) return "Error: channel is required for names";
-        const chan = /^[#&]/.test(channel) ? channel : `#${channel}`;
-        if (!_ircBot) return "Error: IRC interface is not running on this agent";
+        if (!res.lines || res.lines.length === 0) {
+          return `Command sent: ${clean} (no server reply received)`;
+        }
 
-        const result = await _ircBot.queryNames(chan, host);
-        if (!result.success || !result.nicks) return `NAMES query failed: ${result.error || "no names returned"}`;
-        return `Users in ${chan} (${result.nicks.length}):\n  ${result.nicks.join(", ")}`;
-      }
-
-      case "whois": {
-        if (!target) return "Error: target (nick) is required for whois";
-        if (!_ircBot) return "Error: IRC interface is not running on this agent";
-
-        const result = await _ircBot.queryWhois(target, host);
-        if (!result.success) return `WHOIS query failed: ${result.error}`;
-        const info = result.info;
-        return [
-          `WHOIS ${info.nick}:`,
-          info.user && info.host ? `  Mask: ${info.nick}!${info.user}@${info.host}` : null,
-          info.realname ? `  Realname: ${info.realname}` : null,
-          info.account ? `  Account: ${info.account} (Identified)` : `  Account: none (Unidentified)`,
-          info.channels?.length ? `  Channels: ${info.channels.join(" ")}` : null,
-          info.server ? `  Server: ${info.server} (${info.serverInfo || ""})` : null,
-        ]
-          .filter(Boolean)
-          .join("\n");
+        return res.lines.join("\n");
       }
     }
   },

--- a/test/irc-tool.test.ts
+++ b/test/irc-tool.test.ts
@@ -27,39 +27,49 @@ test("ircTool: configure action formats URL and writes to config.json", async ()
   }
 });
 
-test("ircTool: join, part, names, whois delegate cleanly to ircBot", async () => {
-  let lastRaw = "";
+test("ircTool: send action executes raw command and returns server response lines", async () => {
+  let lastSentCommand = "";
   const fakeBot: any = {
-    raw(line: string) {
-      lastRaw = line;
-      return true;
-    },
-    async queryNames(channel: string) {
-      return { success: true, nicks: ["alice", "bob"] };
-    },
-    async queryWhois(target: string) {
-      return {
-        success: true,
-        info: { nick: target, user: "u", host: "h.net", account: target, realname: "Real Name" },
-      };
+    async sendCommand(cmd: string) {
+      lastSentCommand = cmd;
+      if (cmd.startsWith("WHOIS")) {
+        return {
+          success: true,
+          lines: [
+            ":irc 311 bot alice ~u host * :Real Name",
+            ":irc 330 bot alice alice :is logged in as",
+            ":irc 318 bot alice :End of /WHOIS list.",
+          ],
+        };
+      }
+      if (cmd.startsWith("PRIVMSG NickServ")) {
+        return {
+          success: true,
+          lines: [":NickServ NOTICE bot :You are now identified for alice."],
+        };
+      }
+      return { success: true, lines: [] };
     },
   };
 
   setIrcInterface(fakeBot);
 
-  const joinRes = await (ircTool as any).execute({ action: "join", channel: "#test" });
-  assert.equal(joinRes, "Joined #test");
-  assert.equal(lastRaw, "JOIN #test");
+  // Rejects CRLF injection
+  const crlfRes = await (ircTool as any).execute({ action: "send", command: "WHOIS alice\r\nQUIT" });
+  assert.match(crlfRes, /carriage return or newline/);
 
-  const partRes = await (ircTool as any).execute({ action: "part", channel: "#test", reason: "bye" });
-  assert.equal(partRes, "Parted #test");
-  assert.equal(lastRaw, "PART #test :bye");
+  // Rejects QUIT
+  const quitRes = await (ircTool as any).execute({ action: "send", command: "QUIT :bye" });
+  assert.match(quitRes, /QUIT command cannot be sent/);
 
-  const namesRes = await (ircTool as any).execute({ action: "names", channel: "#test" });
-  assert.match(namesRes, /Users in #test \(2\):/);
-  assert.match(namesRes, /alice, bob/);
+  // Executes WHOIS
+  const whoisRes = await (ircTool as any).execute({ action: "send", command: "WHOIS alice" });
+  assert.equal(lastSentCommand, "WHOIS alice");
+  assert.match(whoisRes, /311 bot alice/);
+  assert.match(whoisRes, /is logged in as/);
 
-  const whoisRes = await (ircTool as any).execute({ action: "whois", target: "alice" });
-  assert.match(whoisRes, /WHOIS alice:/);
-  assert.match(whoisRes, /Account: alice \(Identified\)/);
+  // Executes NickServ IDENTIFY
+  const idRes = await (ircTool as any).execute({ action: "send", command: "PRIVMSG NickServ :IDENTIFY secretpass" });
+  assert.equal(lastSentCommand, "PRIVMSG NickServ :IDENTIFY secretpass");
+  assert.match(idRes, /You are now identified/);
 });


### PR DESCRIPTION
Streamlines the `irc` tool from 7 rigid actions (`probe`, `register`, `configure`, `join`, `part`, `names`, `whois`) down to 4 focused actions:

- `probe`: pre-connection handshake / TLS / cap testing.
- `register`: setup-time NickServ registration.
- `configure`: formatting and saving the connection URL to `.kern/config.json`.
- `send`: raw IRC command sender with real-time response capture. Replaces `whois`, `names`, `join`, `part` and unblocks commands like:
  - `PRIVMSG NickServ :IDENTIFY <password>` (fixes authentication issues on servers expecting NickServ identify or non-standard PASS flows)
  - `NAMES <channel>`
  - `WHOIS <nick>`
  - `JOIN <channel>`
  - `PART <channel>`
  - `TOPIC <channel>`
  - `MODE <channel> ...`

Includes:
- Protection against CRLF line injection and accidental `QUIT` disconnects.
- Automatic capture and early return on terminal IRC numerics (`RPL_ENDOFWHOIS`, `RPL_ENDOFNAMES`, errors, etc.) or quiet timeout.
- Full update to `skills/irc-setup/SKILL.md` demonstrating how agents can use `send` for auth, whois, names, and channel management.
- Complete test suite passing (106/106 tests).