### PR TITLE
feat: embeddingModel config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## next
+- **`embeddingModel` config field** ([#334](https://github.com/oguzbilgic/kern-ai/pull/334)) — recall and segments picked their embedding model from `provider` alone, so an `openai` agent pointed at an OpenAI-compatible endpoint that does not serve `text-embedding-3-small` got a 404 on every embedding request while chat kept working. Set `embeddingModel` to the ID that endpoint does serve (`gemini-embedding-001` on Google's OpenAI-compatible endpoint, for example). Empty (default) keeps the existing per-provider defaults.
+
 ## 0.34.1 (2026-09-09)
 
 ### Improvements

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 | `summaryModel` | `""` | Model for segment summarization. Empty = provider default (OpenAI: `gpt-4.1-mini`, Anthropic: `anthropic/claude-haiku-4.5` via OpenRouter, OpenRouter: `google/gemini-2.5-flash-lite`, Ollama: reuses `model`). Summary calls always use an OpenAI-compatible client: `openai` and `ollama` route directly, **all other providers (including `anthropic`) route via OpenRouter** — so on an Anthropic agent `summaryModel` needs an OpenRouter-style ID like `"anthropic/claude-haiku-4.5"`, not a bare Anthropic model ID. Exception: on `ollama` and `openai` agents, a namespaced `summaryModel` (contains `/`, e.g. `"openai/gpt-4.1-mini"`) routes via OpenRouter when `OPENROUTER_API_KEY` is set — lets local-model agents offload summaries to a cheap cloud model. Ollama `hf.co/...` IDs stay local. Useful when the main `model` is a thinking model — thinking burns the summary token budget on reasoning and returns empty text. Set this to a non-thinking model (e.g. `"google/gemini-2.5-flash-lite"` on OpenRouter/Anthropic, `"qwen3:4b-instruct"` on Ollama). |
 | `subAgentModel` | `""` | Model for spawned sub-agents, on the parent's provider. The model ID must be valid for that provider — same format as `model` (e.g. `claude-haiku-4-5` on `anthropic`, `anthropic/claude-haiku-4.5` on `openrouter`). Empty = inherit the parent's `model`. Sub-agents are read-only and bounded, so a cheaper model usually suffices — in heavy research fan-out they can account for most of the token volume. Individual `spawn` calls can override per-child. |
 | `autoRecall` | `false` | Automatically inject relevant old context before each turn. Requires recall enabled. |
+| `embeddingModel` | `""` | Embedding model for recall and segments. Empty = provider default (OpenAI: `text-embedding-3-small`, Anthropic and OpenRouter: `openai/text-embedding-3-small` via OpenRouter, Ollama: `nomic-embed-text`). The ID is used on the agent's own provider client, so it has to be valid there: a bare ID on `openai` and `ollama`, an OpenRouter-style ID like `"openai/text-embedding-3-large"` on `anthropic` and `openrouter`. Needed when `provider: "openai"` points at a gateway that doesn't serve OpenAI's embedding IDs. |
 | `mediaDigest` | `true` | Enable media pre-digest: describes images (vision model) and transcribes audio (audio model) on arrival, caches results, and replaces raw media with text in context. Set to `false` to disable the entire digest pipeline. |
 | `mediaModel` | `""` | Vision model for media descriptions. Fallback chain: `mediaModel` → agent model → hardcoded provider default. Example: `"openai/gpt-4.1-mini"`. |
 | `audioModel` | `""` | Audio-capable model for the `audio` tool and voice-message transcription at ingest. Fallback chain: `audioModel` → agent model → provider default (`google/gemini-3.7-flash` on OpenRouter, `gpt-audio-mini` on OpenAI) → `google/gemini-3.7-flash` via OpenRouter for anthropic/ollama/openai agents with `OPENROUTER_API_KEY` set. Setting this field skips the (usually failing) attempt on the text-only chat model. |
@@ -74,6 +75,18 @@ Recall and segment boundary detection use an embedding model chosen automaticall
 | `anthropic` | `openai/text-embedding-3-small` (via OpenRouter — Anthropic has no embeddings API) |
 | `openrouter` | `openai/text-embedding-3-small` |
 | `ollama` | `nomic-embed-text` |
+
+Set `embeddingModel` to override the default. This is what you want with `provider: "openai"` pointed at an OpenAI-compatible gateway that doesn't serve OpenAI's own embedding IDs, such as Google's `https://generativelanguage.googleapis.com/v1beta/openai/`, where `text-embedding-3-small` returns a 404 and recall fails on every turn:
+
+```json
+{
+  "provider": "openai",
+  "model": "gemini-3.8-flash",
+  "embeddingModel": "gemini-embedding-001"
+}
+```
+
+Changing this on an agent that already has memory is not safe yet. kern tracks the vector width, not which model produced the vectors, so a same-width change (`gemini-embedding-001` to another 3072-dimension model) leaves the old vectors in place and searches them with vectors from a different embedding space. A different-width change does recreate the vector tables, but the rows already in `chunks` are not re-vectorized. Pick the embedding model when you create an agent.
 
 ## Environment variable overrides
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ export interface KernConfig {
   // Memory
   recall: boolean;
   autoRecall: boolean;
+  embeddingModel: string;
 
   // Media
   mediaDigest: boolean;
@@ -92,6 +93,7 @@ export const configDefaults: KernConfig = {
   subAgentModel: "",
   recall: true,
   autoRecall: false,
+  embeddingModel: "",
   mediaDigest: true,
   mediaModel: "",
   audioModel: "",
@@ -117,6 +119,7 @@ const FIELD_TYPES: Record<string, string> = {
   subAgentModel: "string",
   recall: "boolean",
   autoRecall: "boolean",
+  embeddingModel: "string",
   mediaDigest: "boolean",
   mediaModel: "string",
   audioModel: "string",

--- a/src/model.ts
+++ b/src/model.ts
@@ -50,6 +50,10 @@ function createOpenAIClient(provider: string) {
  * Create an embedding model for recall and segments.
  * Returns null if no suitable provider/key is available.
  *
+ * `config.embeddingModel` overrides the default. It is used as-is on the same
+ * client, so the ID must be valid there: bare on openai/ollama, namespaced on
+ * the OpenRouter-routed providers.
+ *
  * Defaults by provider:
  * - openai: text-embedding-3-small
  * - anthropic: openai/text-embedding-3-small (Anthropic has no embeddings API; routed via OpenRouter)
@@ -59,6 +63,8 @@ function createOpenAIClient(provider: string) {
 export function createEmbeddingModel(config: KernConfig): Parameters<typeof embed>[0]["model"] | null {
   const client = createOpenAIClient(config.provider);
   if (!client) return null;
+
+  if (config.embeddingModel) return client.embeddingModel(config.embeddingModel);
 
   switch (config.provider) {
     case "openai":

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { mkdtemp, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadConfig } from "../src/config.js";
+
+async function agentDir(config: Record<string, unknown>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "kern-config-"));
+  await mkdir(join(dir, ".kern"));
+  await writeFile(join(dir, ".kern", "config.json"), JSON.stringify(config), "utf-8");
+  return dir;
+}
+
+test("loadConfig: embeddingModel survives validation", async () => {
+  const config = await loadConfig(await agentDir({ provider: "openai", embeddingModel: "gemini-embedding-001" }));
+  assert.equal(config.embeddingModel, "gemini-embedding-001");
+});
+
+test("loadConfig: wrong-typed embeddingModel falls back to the default", async () => {
+  const config = await loadConfig(await agentDir({ provider: "openai", embeddingModel: 3072 }));
+  assert.equal(config.embeddingModel, "");
+});

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -1,6 +1,6 @@
 import { test, beforeEach, afterEach } from "node:test";
 import assert from "node:assert";
-import { summaryViaOpenRouter } from "../src/model.js";
+import { createEmbeddingModel, summaryViaOpenRouter } from "../src/model.js";
 import { configDefaults, type KernConfig } from "../src/config.js";
 
 function cfg(overrides: Partial<KernConfig>): KernConfig {
@@ -8,14 +8,18 @@ function cfg(overrides: Partial<KernConfig>): KernConfig {
 }
 
 let savedKey: string | undefined;
+let savedOpenAIKey: string | undefined;
 
 beforeEach(() => {
   savedKey = process.env.OPENROUTER_API_KEY;
+  savedOpenAIKey = process.env.OPENAI_API_KEY;
 });
 
 afterEach(() => {
   if (savedKey === undefined) delete process.env.OPENROUTER_API_KEY;
   else process.env.OPENROUTER_API_KEY = savedKey;
+  if (savedOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = savedOpenAIKey;
 });
 
 test("summaryViaOpenRouter: ollama + namespaced ID + key → true", () => {
@@ -62,4 +66,30 @@ test("summaryViaOpenRouter: openrouter/anthropic providers unaffected", () => {
     summaryViaOpenRouter(cfg({ provider: "anthropic", summaryModel: "anthropic/claude-haiku-4.5" })),
     false,
   );
+});
+
+test("createEmbeddingModel: embeddingModel overrides the provider default", () => {
+  const model = createEmbeddingModel(cfg({ provider: "openai", embeddingModel: "gemini-embedding-001" })) as any;
+  assert.equal(model.modelId, "gemini-embedding-001");
+});
+
+test("createEmbeddingModel: unset embeddingModel keeps the provider default", () => {
+  const openai = createEmbeddingModel(cfg({ provider: "openai" })) as any;
+  assert.equal(openai.modelId, "text-embedding-3-small");
+  const ollama = createEmbeddingModel(cfg({})) as any;
+  assert.equal(ollama.modelId, "nomic-embed-text");
+});
+
+test("createEmbeddingModel: override reaches the OpenRouter-backed providers too", () => {
+  process.env.OPENROUTER_API_KEY = "test-key";
+  const model = createEmbeddingModel(
+    cfg({ provider: "anthropic", embeddingModel: "openai/text-embedding-3-large" }),
+  ) as any;
+  assert.equal(model.modelId, "openai/text-embedding-3-large");
+});
+
+test("createEmbeddingModel: still null when the provider has no key", () => {
+  delete process.env.OPENROUTER_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  assert.equal(createEmbeddingModel(cfg({ provider: "openrouter", embeddingModel: "openai/text-embedding-3-large" })), null);
 });


### PR DESCRIPTION
Option A from #86: `embeddingModel` as a validated config field that overrides the per-provider default when set.

## Problem

`createEmbeddingModel` picks the embedding model from `provider` alone. With `provider: "openai"` pointed at an OpenAI-compatible endpoint that does not serve OpenAI's model IDs, every recall and segment embedding request 404s while chat keeps working — memory fails quietly in the background. Against Google's `https://generativelanguage.googleapis.com/v1beta/openai/`:

```
WRN [memory] Failed to probe embedding dimensions: models/text-embedding-3-small is not found for API version v1main, or is not supported for embedContent.
ERR [recall] embedding failed: models/text-embedding-3-small is not found for API version v1main, or is not supported for embedContent.
```

`summaryModel` already solves this for summaries. There was no equivalent for embeddings, and setting `embeddingModel` on v0.34.x logs it as an unknown field and ignores it.

## Fix

**New bare-string config field.** Three lines in `config.ts` (interface, default, `FIELD_TYPES`) and one in `model.ts`:

```ts
if (config.embeddingModel) return client.embeddingModel(config.embeddingModel);
```

The ID is passed unchanged to the embedding client already selected for `provider`, so it has to be one that endpoint accepts: a plain ID on `openai` and `ollama`, an OpenRouter-style ID on `anthropic` and `openrouter`. No routing changes, and empty (default) preserves the existing per-provider defaults.

```json
{
  "provider": "openai",
  "model": "gemini-3.8-flash",
  "embeddingModel": "gemini-embedding-001"
}
```

## Running it

Two agents of mine, `provider: "openai"` on `gemini-3.8-flash`. Until this morning they sat behind a LiteLLM gateway whose only real job was aliasing `text-embedding-3-small` onto `gemini-embedding-001`. On this build that alias is deleted and each agent names the Gemini model in its own config.json.

In order, because the warm upgrade did not go cleanly:

- I first dropped the gateway entirely and pointed one agent straight at Google. The probe reported 3072 dimensions and it backfilled 38 chunks — the field works against the endpoint the issue is about. The next chat turn died on something unrelated (below), so the gateway went back in with no model aliases in it.
- The restart after that hit a pre-existing rebuild bug rather than anything in this PR: 39 chunks re-embedded and 1 stored, 0 of 27 on the second agent. Filed as #333.
- After clearing the derived tables by hand and restarting, both rebuilt: 39/39 and 27/27 chunk vectors at 3072 dimensions. They have kept indexing since, 41 and 28 chunks now with every one vectorized, 11 segments built and summarized on the busier agent, and no embedding errors on either.

Treat that as a smoke test rather than broad validation. Every batch was well under recall's 100-value batch size, and I have not pushed a chunk anywhere near `gemini-embedding-001`'s 2,048 token input limit.

## Notes

- **The gateway is still in the path, for chat and for embeddings** — one `OPENAI_BASE_URL` client serves both. Direct to Google, the AI SDK rejects Gemini's streamed tool-call delta: it carries `extra_content.google.thought_signature` and no `index`, and fails the chunk schema with `Type validation failed`. Nothing to do with this field, and I can file it separately. It does correct something I wrote in #86 — my "chat works, including tool calls" was true through the gateway, not direct.
- **Changing `embeddingModel` on an agent that already has memory is not safe yet.** That is pre-existing and reachable today by switching provider, so it stays out of this PR; `docs/config.md` warns against it here. Two reasons: the rebuild bug above, and the fact that the dimension check compares vector width rather than model identity, so a same-width swap is not detected at all.

## Tests

Four in `test/model.test.ts` cover the override, the untouched provider defaults, an OpenRouter-routed provider, and the no-key null. Two in a new `test/config.test.ts` go through `loadConfig`, so the field cannot regress to being filtered out while the factory tests keep passing. `npm test` passes 112, `npm run build:server` is clean. Docs get a `docs/config.md` table row and a short example under the existing embedding model section, plus a changelog entry.

The rebuild issue has a few possible shapes and I did not want to pick one for you. Say which you want and I will send it as its own PR.
