### PR TITLE
Fix: an embedding dimension rebuild loses every existing vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## next
+- **Embedding rebuilds no longer lose existing memory** ([#335](https://github.com/oguzbilgic/kern-ai/pull/335)) — a dimension change drops the vector tables, and the backfill that followed re-embedded every chunk but skipped the vector insert for rows that already existed, so recall over that history stopped matching for good. Existing rows are now re-vectorized in place. A failed dimension probe also no longer counts as a dimension change: an unreachable provider or a bad key kept the healthy index it used to destroy.
+
 ## 0.34.1 (2026-09-09)
 
 ### Improvements

--- a/src/app.ts
+++ b/src/app.ts
@@ -117,7 +117,7 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   // Initialize semantic segments (uses embeddings for context summarization)
   let segmentIndex: SegmentIndex | null = null;
   let segmentRunning = false;
-  if (embeddingDims > 0) {
+  if (memoryDB.dimensions > 0) {
     try {
       segmentIndex = new SegmentIndex(memoryDB, config);
       runtime.setSegmentIndex(segmentIndex);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -15,13 +15,16 @@ const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
  */
 export class MemoryDB {
   public db: Database.Database;
-  private embeddingDimensions: number;
+  /** Width the vector tables were opened at. Never null after initSchema. */
+  public dimensions = DEFAULT_EMBEDDING_DIMENSIONS;
+  private probedDimensions: number | null;
 
-  constructor(agentDir: string, dimensions?: number) {
+  /** `dimensions` null means the probe failed; the width on disk is kept. */
+  constructor(agentDir: string, dimensions?: number | null) {
     const dbPath = join(agentDir, ".kern", "recall.db");
     this.db = new Database(dbPath);
     sqliteVec.load(this.db);
-    this.embeddingDimensions = dimensions ?? DEFAULT_EMBEDDING_DIMENSIONS;
+    this.probedDimensions = dimensions ?? null;
     this.initSchema();
   }
 
@@ -121,10 +124,19 @@ export class MemoryDB {
    * Create or migrate vector tables. Detects dimension mismatch
    * and rebuilds vector indexes + resets indexing state when
    * the embedding model changes (e.g. OpenAI 1536 → Ollama 768).
+   *
+   * A failed probe is not a dimension. Rebuilding on one would drop a healthy
+   * index because the provider was briefly unreachable, so the width already
+   * on disk wins.
    */
   private initVecTables(): void {
-    const dims = this.embeddingDimensions;
     const existingDims = this.getVecTableDimensions();
+    const dims = this.probedDimensions ?? existingDims ?? DEFAULT_EMBEDDING_DIMENSIONS;
+    this.dimensions = dims;
+
+    if (this.probedDimensions === null && existingDims !== null) {
+      log.warn("memory", `Embedding dimensions unknown, keeping the existing ${existingDims}`);
+    }
 
     if (existingDims !== null && existingDims !== dims) {
       log.warn("memory", `Embedding dimension changed (${existingDims} → ${dims}), rebuilding vector indexes...`);
@@ -164,19 +176,20 @@ export class MemoryDB {
 
   /**
    * Probe the actual embedding model to detect its output dimensions.
-   * Returns the dimension count, or the default if probing fails.
+   * Returns null when the width could not be established, which the caller
+   * must not confuse with a real change of model.
    */
-  static async detectEmbeddingDimensions(config: KernConfig): Promise<number> {
+  static async detectEmbeddingDimensions(config: KernConfig): Promise<number | null> {
     try {
       const model = createEmbeddingModel(config);
-      if (!model) return DEFAULT_EMBEDDING_DIMENSIONS;
+      if (!model) return null;
       const result = await embed({ model, value: "dimension probe" });
       const dims = result.embedding.length;
       log.debug("memory", `Detected embedding dimensions: ${dims}`);
       return dims;
     } catch (err: any) {
       log.warn("memory", `Failed to probe embedding dimensions: ${err.message}`);
-      return DEFAULT_EMBEDDING_DIMENSIONS;
+      return null;
     }
   }
 

--- a/src/plugins/recall/recall.ts
+++ b/src/plugins/recall/recall.ts
@@ -141,6 +141,11 @@ export class RecallIndex {
     const insertChunk = this.db.prepare(
       "INSERT OR IGNORE INTO chunks (session_id, msg_start, msg_end, text, timestamp, token_count) VALUES (?, ?, ?, ?, ?, ?)"
     );
+    const selectChunkId = this.db.prepare(
+      "SELECT id FROM chunks WHERE session_id = ? AND msg_start = ? AND msg_end = ?"
+    );
+    // vec0 rejects INSERT OR REPLACE, so a stale vector is deleted first.
+    const deleteVec = this.db.prepare("DELETE FROM vec_chunks WHERE rowid = ?");
     const insertVec = this.db.prepare(
       "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)"
     );
@@ -160,8 +165,17 @@ export class RecallIndex {
           chunk.timestamp,
           chunk.token_count
         );
-        if (info.changes === 0) continue; // duplicate chunk, skip vec insert
-        const chunkId = typeof info.lastInsertRowid === "bigint" ? info.lastInsertRowid : BigInt(info.lastInsertRowid);
+        // A chunk row can already exist while its vector does not: the vector
+        // tables are dropped and re-created on a dimension change, and the
+        // rows they described stay behind. Re-vectorize instead of skipping,
+        // or that history is never searchable again.
+        const existing = info.changes === 0
+          ? (selectChunkId.get(chunk.session_id, chunk.msg_start, chunk.msg_end) as { id: number } | undefined)
+          : undefined;
+        const rowid = info.changes === 0 ? existing?.id : info.lastInsertRowid;
+        if (rowid === undefined) continue;
+        const chunkId = typeof rowid === "bigint" ? rowid : BigInt(rowid);
+        deleteVec.run(chunkId);
         insertVec.run(chunkId, new Float32Array(embeddings[i]));
         indexed++;
       }

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -253,6 +253,11 @@ export class SegmentIndex {
       const insertSeg = this.db.prepare(
         "INSERT OR IGNORE INTO semantic_segments (session_id, msg_start, msg_end, start_time, end_time, level, summary, token_count) VALUES (?, ?, ?, ?, ?, 0, ?, ?)"
       );
+      const selectSegId = this.db.prepare(
+        "SELECT id FROM semantic_segments WHERE session_id = ? AND level = 0 AND msg_start = ? AND msg_end = ?"
+      );
+      // vec0 rejects INSERT OR REPLACE, so a stale vector is deleted first.
+      const deleteVec = this.db.prepare("DELETE FROM vec_segments WHERE rowid = ?");
       const insertVec = this.db.prepare(
         "INSERT INTO vec_segments (rowid, embedding) VALUES (?, ?)"
       );
@@ -266,8 +271,15 @@ export class SegmentIndex {
       const tx = this.db.transaction(() => {
         for (const seg of merged) {
           const info = insertSeg.run(seg.session_id, seg.msg_start, seg.msg_end, seg.start_time, seg.end_time, seg.text, seg.token_count);
-          if (info.changes === 0) continue;
-          const segId = typeof info.lastInsertRowid === "bigint" ? info.lastInsertRowid : BigInt(info.lastInsertRowid);
+          // Same as recall: an existing row whose vector was dropped by a
+          // dimension rebuild has to be re-vectorized, not skipped.
+          const existing = info.changes === 0
+            ? (selectSegId.get(seg.session_id, seg.msg_start, seg.msg_end) as { id: number } | undefined)
+            : undefined;
+          const rowid = info.changes === 0 ? existing?.id : info.lastInsertRowid;
+          if (rowid === undefined) continue;
+          const segId = typeof rowid === "bigint" ? rowid : BigInt(rowid);
+          deleteVec.run(segId);
           insertVec.run(segId, new Float32Array(seg.embedding));
           created++;
         }

--- a/test/recall-rebuild.test.ts
+++ b/test/recall-rebuild.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { MemoryDB } from "../src/memory.js";
+import { RecallIndex } from "../src/plugins/recall/recall.js";
+import { configDefaults, type KernConfig } from "../src/config.js";
+
+const DIMS = 8;
+const config: KernConfig = { ...configDefaults, provider: "ollama", model: "gemma3:4b" };
+
+// Stand-in for a provider embedding model: deterministic, offline.
+function fakeModel(dims = DIMS) {
+  return {
+    specificationVersion: "v3" as const,
+    provider: "test",
+    modelId: "test-embed",
+    maxEmbeddingsPerCall: 100,
+    supportsParallelCalls: false,
+    async doEmbed({ values }: { values: string[] }) {
+      return {
+        embeddings: values.map((v) => Array.from({ length: dims }, (_, i) => (v.length + i) / 100)),
+        warnings: [],
+      };
+    },
+  };
+}
+
+async function agentWithSession(): Promise<{ dir: string; sessionId: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "kern-recall-"));
+  await mkdir(join(dir, ".kern", "sessions"), { recursive: true });
+  const sessionId = "11111111-2222-3333-4444-555555555555";
+  const lines = [
+    JSON.stringify({ createdAt: new Date().toISOString() }),
+    JSON.stringify({ role: "user", content: "where are my mounts" }),
+    JSON.stringify({ role: "assistant", content: "under /mnt" }),
+    JSON.stringify({ role: "user", content: "and the backups" }),
+    JSON.stringify({ role: "assistant", content: "read only" }),
+  ];
+  await writeFile(join(dir, ".kern", "sessions", `${sessionId}.jsonl`), lines.join("\n") + "\n", "utf-8");
+  return { dir, sessionId };
+}
+
+function index(db: MemoryDB, dir: string) {
+  const idx = new RecallIndex(db, dir, config);
+  (idx as any).embeddingModel = fakeModel();
+  return idx;
+}
+
+const count = (db: MemoryDB, table: string) =>
+  (db.db.prepare(`SELECT count(*) c FROM ${table}`).get() as { c: number }).c;
+
+test("recall: a dimension rebuild re-vectorizes chunks that already exist", async () => {
+  const { dir, sessionId } = await agentWithSession();
+
+  const first = new MemoryDB(dir, DIMS);
+  assert.equal(await index(first, dir).indexSession(sessionId), 2);
+  assert.equal(count(first, "chunks"), 2);
+  assert.equal(count(first, "vec_chunks"), 2);
+  first.db.close();
+
+  // Reopen at a different width: vec tables are dropped, chunk rows survive.
+  const second = new MemoryDB(dir, DIMS * 2);
+  assert.equal(count(second, "chunks"), 2);
+  assert.equal(count(second, "vec_chunks"), 0);
+
+  const idx = new RecallIndex(second, dir, config);
+  (idx as any).embeddingModel = fakeModel(DIMS * 2);
+  await idx.indexSession(sessionId);
+  assert.equal(count(second, "vec_chunks"), 2, "existing chunks must be re-vectorized, not skipped");
+  assert.equal(count(second, "chunks"), 2, "and not duplicated");
+  second.db.close();
+});
+
+test("recall: re-indexing an unchanged session does not duplicate vectors", async () => {
+  const { dir, sessionId } = await agentWithSession();
+  const db = new MemoryDB(dir, DIMS);
+  await index(db, dir).indexSession(sessionId);
+  db.db.prepare("DELETE FROM index_state").run();
+  await index(db, dir).indexSession(sessionId);
+  assert.equal(count(db, "vec_chunks"), 2);
+  assert.equal(count(db, "chunks"), 2);
+  db.db.close();
+});
+
+test("memory: a failed probe keeps the width already on disk", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "kern-probe-"));
+  await mkdir(join(dir, ".kern"), { recursive: true });
+
+  const first = new MemoryDB(dir, 3072);
+  first.db.prepare("INSERT INTO chunks (session_id, msg_start, msg_end, text, timestamp, token_count) VALUES ('s', 0, 1, 't', '2026-01-01', 5)").run();
+  first.db.prepare("INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)").run(1n, new Float32Array(3072));
+  first.db.close();
+
+  const second = new MemoryDB(dir, null);
+  assert.equal(second.dimensions, 3072);
+  assert.equal(count(second, "vec_chunks"), 1, "a failed probe must not drop a healthy index");
+  second.db.close();
+});


### PR DESCRIPTION
Fixes the first two parts of #333. `provider` swaps and failed probes both destroy recall today, and neither is recoverable without hand-editing `recall.db`.

## Problem

A dimension change drops `vec_chunks` and `vec_segments`, clears the indexing state, and logs "backfill will run automatically". The backfill then re-reads the session JSONL, re-chunks it and re-embeds everything, but the re-chunk produces the same `UNIQUE(session_id, msg_start, msg_end)` tuples, so `INSERT OR IGNORE` returns `changes === 0` and the vector insert is skipped:

```js
if (info.changes === 0) continue; // duplicate chunk, skip vec insert
```

The rows keep their text and lose their vectors permanently, while `index_state` advances in the same transaction as if the rebuild had worked. `search` joins `vec_chunks`, so that history stops matching and nothing says so.

Worse, a failed probe counts as a dimension. `detectEmbeddingDimensions` catches every error and returns the 1536 default, so a bad key, a typo in a model ID, or a gateway that is not up yet reads as a change of model and drops a healthy index.

## Fix

**Re-vectorize existing rows instead of skipping them.** Look up the existing rowid when the chunk is already there and write the fresh embedding to it. vec0 rejects `INSERT OR REPLACE` (`UNIQUE constraint failed on vec_chunks primary key`), so a stale vector is deleted first. Same edit in `segments.ts` against `idx_segments_unique`.

**A failed probe is not a dimension.** `detectEmbeddingDimensions` returns `null` rather than 1536, and `initVecTables` then keeps the width already recorded in `recall.db` and leaves the tables alone:

```
WRN [memory] Failed to probe embedding dimensions: /embeddings: Invalid model name passed in model=gemini-embedding-76.
WRN [memory] Embedding dimensions unknown, keeping the existing 768
```

`MemoryDB` now exposes the width it settled on, which is what `app.ts` gates segment init on, so a probe failure no longer silently disables segments either.

## Evidence

A throwaway agent on Gemini, 3 real chunks, then the same volume driven through both paths on a build with and without this patch:

| scenario | before | with this PR |
|---|---|---|
| real width change, 3 chunks present | `indexed 0 chunks`, 0 of 3 vectors | `indexed 3 chunks`, 3 of 3 |
| failed probe (typo in the model ID) | `Embedding dimension changed (3072 → 1536)`, tables dropped, 0 of 3 | `keeping the existing 768`, 3 of 3 untouched |

This started as a real incident rather than a code read: two of my agents lost their vectors this morning, 39 chunks holding 1 vector and 27 holding 0, and recovering them meant deleting `chunks`, `index_state`, `semantic_segments` and `segment_state` by hand. Numbers and logs are in #333. Both agents have been running this patch since, 41 and 28 chunks with every one vectorized.

## Tests

`test/recall-rebuild.test.ts`, three tests, offline against a stub embedding model: a rebuild re-vectorizes existing chunks, re-indexing an unchanged session does not duplicate them, and a failed probe leaves a healthy index alone. The first and third fail on master and pass here. `npm test` 109, `npm run build:server` clean.

## Notes

- **It prevents the loss, it does not repair one.** An agent already stranded by an earlier version has `index_state` advanced past those messages, so nothing re-indexes them and the manual delete in #333 is still the way out. A one-time migration could clear the state for sessions whose chunks have no vectors, and I left it out because it is a different change.
- **Model identity is still not tracked**, which is the third defect in #333. kern compares vector width, so swapping one 3072-dimension model for another keeps the old index and searches it with vectors from a different embedding space. Worth doing, bigger, and it wants a decision about where that metadata lives.
- The `segments.ts` half is the same edit as recall and is exercised in production, but it is not unit tested here: constructing a `SegmentIndex` pulls in a summary model too.
- The `CHANGELOG.md` entry will conflict trivially with #334 if both land, same `## next` slot. Happy to rebase whichever merges second.

Do you want the model identity work as a follow-up, and is a migration for already-stranded agents worth having?
