### PR TITLE
Fix: tool calls fail against Google's OpenAI-compatible endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## next
+- **Tool calls work against Google's OpenAI-compatible endpoint** ([#336](https://github.com/oguzbilgic/kern-ai/pull/336)) — with `provider: "openai"` and `OPENAI_BASE_URL` pointed at `generativelanguage.googleapis.com`, the first tool call ended the turn with `Type validation failed`, because Google omits `index` on streamed tool-call deltas. That endpoint now uses `@ai-sdk/openai-compatible` under the `google` provider name, which also echoes the `thought_signature` Google requires on the request after a tool result. An agent on Gemini no longer needs a translating gateway in front of it. Every other endpoint, custom or not, is unchanged.
+
 ## 0.34.1 (2026-09-09)
 
 ### Improvements

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,7 +50,7 @@ The main config file. Committed to git. Unknown fields and wrong types are warne
 
 - **openrouter** — routes to cheapest provider. Model IDs like `anthropic/claude-opus-4.8`. Uses OpenAI-compatible chat completions API.
 - **anthropic** — direct Anthropic API. Model IDs like `claude-opus-4-8`.
-- **openai** — OpenAI or any OpenAI-compatible endpoint. Model IDs like `gpt-5.5`. Set `OPENAI_BASE_URL` in `.env` to route to Azure OpenAI, LiteLLM, or other compatible gateways (default: `https://api.openai.com/v1`). With a custom base URL, requests use the Chat Completions API.
+- **openai** — OpenAI or any OpenAI-compatible endpoint. Model IDs like `gpt-5.5`. Set `OPENAI_BASE_URL` in `.env` to route to Azure OpenAI, Google's OpenAI-compatible endpoint, LiteLLM, or other compatible gateways (default: `https://api.openai.com/v1`). With a custom base URL, requests use the Chat Completions API. Google's own endpoint (`https://generativelanguage.googleapis.com/v1beta/openai/`) is recognised and served by `@ai-sdk/openai-compatible` instead, because it omits `index` on streamed tool-call deltas and needs its `thought_signature` echoed back; without both, a tool call ends the turn.
 - **ollama** — local Ollama server. Model IDs match Ollama model names like `gemma4:31b`. Set `OLLAMA_BASE_URL` in `.env` for remote servers (default: `http://localhost:11434`).
 
 ### Summary model

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "kern-ai",
-  "version": "0.33.1",
+  "version": "0.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kern-ai",
-      "version": "0.33.1",
+      "version": "0.34.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.0",
         "@ai-sdk/mcp": "^1.0.36",
         "@ai-sdk/openai": "^3.0.48",
+        "@ai-sdk/openai-compatible": "^2.0.75",
         "@breezystack/lamejs": "^1.2.7",
         "@inquirer/prompts": "^8.3.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -168,6 +169,52 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible": {
+      "version": "2.0.75",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.75.tgz",
+      "integrity": "sha512-W9w3tCoYrevct2Ips2X4EFOow8Kzrg0nqVJi9jm0lHiMlTmTON4nzaCv3Zkzg6eFCJJVH60kd4+t7tHgtOxx9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.16",
+        "@ai-sdk/provider-utils": "4.0.51"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider": {
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.16.tgz",
+      "integrity": "sha512-9Av6kg0t/IN/dcYAAmEJ4B9OPhcEJqwSR+GfHEA8olRkindXpUHadc3p3cyvgFUQFTVm1G5thtsmgZ9yVb2w3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai-compatible/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.51",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.51.tgz",
+      "integrity": "sha512-ukLTs9x1Xm6lxSIwbJIxYQxbZHmVeIczNntARZrBcOa6pjdBhqeZnATNnJMHa7M9dZ8Ji5NJbpKpvz7o5XyBtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.16",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^6.28.0"
+      },
+      "engines": {
+        "node": ">=18.17"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1318,7 +1365,6 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -1329,7 +1375,6 @@
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1351,7 +1396,6 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1363,8 +1407,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -1387,6 +1430,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1395,15 +1439,13 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -1411,6 +1453,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1426,7 +1469,6 @@
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1436,7 +1478,6 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
@@ -1497,6 +1538,7 @@
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.137.tgz",
       "integrity": "sha512-9e/mNMTmXmMkmldEJPIumy9FFBuUWHUyj2yF8EglC3VVOhVVBwlnpeHYSFKdNc13Jj6Hso3EJcZioMaofgCs4A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@ai-sdk/gateway": "3.0.79",
         "@ai-sdk/provider": "3.0.8",
@@ -2300,9 +2342,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2322,6 +2364,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2735,6 +2778,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3606,6 +3650,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3616,7 +3661,6 @@
       "integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -3628,7 +3672,6 @@
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -3862,7 +3905,6 @@
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4319,12 +4361,22 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -4489,6 +4541,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@ai-sdk/anthropic": "^2.0.0",
     "@ai-sdk/mcp": "^1.0.36",
     "@ai-sdk/openai": "^3.0.48",
+    "@ai-sdk/openai-compatible": "^2.0.75",
     "@breezystack/lamejs": "^1.2.7",
     "@inquirer/prompts": "^8.3.2",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,6 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { embed } from "ai";
 import type { KernConfig } from "./config.js";
@@ -9,6 +10,15 @@ import { log } from "./log.js";
 function openaiBaseURL(): string | undefined {
   const raw = process.env.OPENAI_BASE_URL?.trim().replace(/\/+$/, "");
   return raw || undefined;
+}
+
+/** Google's own OpenAI-compatible endpoint, which needs its own provider. */
+function isGoogleEndpoint(baseURL: string): boolean {
+  try {
+    return new URL(baseURL).hostname === "generativelanguage.googleapis.com";
+  } catch {
+    return false;
+  }
 }
 
 const OPENROUTER_HEADERS = {
@@ -224,6 +234,20 @@ export function createModel(config: KernConfig): any {
     }
     case "openai": {
       const baseURL = openaiBaseURL();
+      // Google omits `index` on streamed tool-call deltas, which this provider's
+      // schema requires, so the first tool call fails validation. It also wants
+      // `thought_signature` echoed on the next request, and the compatible
+      // provider only re-serializes that under the `google` providerOptions
+      // namespace, which the provider name selects (vercel/ai#18962).
+      // includeUsage requests stream usage, which this provider omits by default.
+      if (baseURL && isGoogleEndpoint(baseURL)) {
+        return createOpenAICompatible({
+          name: "google",
+          baseURL,
+          apiKey: process.env.OPENAI_API_KEY,
+          includeUsage: true,
+        }).chatModel(config.model);
+      }
       const openai = createOpenAI({ baseURL });
       // Custom OpenAI-compatible endpoints (Azure, LiteLLM, local proxies)
       // typically only support the Chat Completions API, not the Responses API

--- a/test/model-endpoint.test.ts
+++ b/test/model-endpoint.test.ts
@@ -1,0 +1,149 @@
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { generateText, streamText, stepCountIs, tool } from "ai";
+import { z } from "zod";
+import { createModel } from "../src/model.js";
+import { configDefaults, type KernConfig } from "../src/config.js";
+
+const GOOGLE = "https://generativelanguage.googleapis.com/v1beta/openai/";
+const SIGNATURE = "test-thought-signature";
+
+const cfg = (overrides: Partial<KernConfig> = {}): KernConfig => ({
+  ...configDefaults,
+  provider: "openai",
+  model: "gemini-3.8-flash",
+  ...overrides,
+});
+
+const sse = (chunks: unknown[]) =>
+  new Response(
+    chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join("") + "data: [DONE]\n\n",
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+
+/** A tool-call delta shaped like Google's: no `index`, signature in extra_content. */
+const googleToolCallChunk = {
+  id: "1",
+  object: "chat.completion.chunk",
+  created: 1,
+  model: "gemini-3.8-flash",
+  choices: [
+    {
+      index: 0,
+      delta: {
+        role: "assistant",
+        tool_calls: [
+          {
+            extra_content: { google: { thought_signature: SIGNATURE } },
+            function: { name: "weather", arguments: '{"city":"Paris"}' },
+            id: "call_1",
+            type: "function",
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const finish = (reason: string) => ({
+  id: "1",
+  object: "chat.completion.chunk",
+  created: 1,
+  model: "gemini-3.8-flash",
+  choices: [{ index: 0, delta: {}, finish_reason: reason }],
+  usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+});
+
+let savedBase: string | undefined;
+let savedKey: string | undefined;
+let savedFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  savedBase = process.env.OPENAI_BASE_URL;
+  savedKey = process.env.OPENAI_API_KEY;
+  savedFetch = globalThis.fetch;
+  process.env.OPENAI_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  globalThis.fetch = savedFetch;
+  if (savedBase === undefined) delete process.env.OPENAI_BASE_URL;
+  else process.env.OPENAI_BASE_URL = savedBase;
+  if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = savedKey;
+});
+
+test("google endpoint: an index-less tool call runs and its signature goes back", async () => {
+  process.env.OPENAI_BASE_URL = GOOGLE;
+  const requests: any[] = [];
+  const responses = [
+    sse([googleToolCallChunk, finish("tool_calls")]),
+    sse([
+      { id: "1", object: "chat.completion.chunk", created: 1, model: "gemini-3.8-flash", choices: [{ index: 0, delta: { content: "20C in Paris." } }] },
+      finish("stop"),
+    ]),
+  ];
+  globalThis.fetch = (async (_url: any, init: any) => {
+    requests.push(JSON.parse(init.body));
+    return responses.shift()!;
+  }) as typeof globalThis.fetch;
+
+  const called: string[] = [];
+  const result = streamText({
+    model: createModel(cfg()),
+    tools: {
+      weather: tool({
+        description: "Weather for a city.",
+        inputSchema: z.object({ city: z.string() }),
+        execute: async ({ city }) => {
+          called.push(city);
+          return `${city}: 20C`;
+        },
+      }),
+    },
+    stopWhen: stepCountIs(3),
+    prompt: "weather in Paris?",
+  });
+  for await (const part of result.fullStream) {
+    if (part.type === "error") throw part.error;
+  }
+
+  assert.deepEqual(called, ["Paris"], "the tool must run despite the missing index");
+  assert.equal(requests.length, 2, "the tool result must produce a second request");
+  const assistant = requests[1].messages.find((m: any) => m.role === "assistant" && m.tool_calls);
+  assert.equal(
+    assistant?.tool_calls[0].extra_content?.google?.thought_signature,
+    SIGNATURE,
+    "Google rejects the follow-up unless the signature comes back",
+  );
+  assert.equal(requests[0].stream_options?.include_usage, true, "usage must still be requested");
+  assert.equal((await result.usage).totalTokens, 7);
+});
+
+test("other custom endpoints keep the OpenAI request shape for reasoning models", async () => {
+  process.env.OPENAI_BASE_URL = "https://my-gateway.example.com/v1";
+  let body: any;
+  globalThis.fetch = (async (_url: any, init: any) => {
+    body = JSON.parse(init.body);
+    return new Response(
+      JSON.stringify({
+        id: "1", object: "chat.completion", created: 1, model: "gpt-5.4",
+        choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof globalThis.fetch;
+
+  await generateText({ model: createModel(cfg({ model: "gpt-5.4" })), system: "Be brief.", prompt: "hi", maxOutputTokens: 321 });
+
+  assert.equal(body.messages[0].role, "developer", "reasoning models take a developer message");
+  assert.equal(body.max_completion_tokens, 321, "reasoning models need max_completion_tokens, not max_tokens");
+});
+
+test("no base URL leaves the OpenAI provider alone", () => {
+  delete process.env.OPENAI_BASE_URL;
+  const model = createModel(cfg({ model: "gpt-5.5" }));
+  assert.match(model.provider, /^openai\./);
+  assert.equal(model.modelId, "gpt-5.5");
+});


### PR DESCRIPTION
Tool calls do not work with `provider: "openai"` pointed at Google's OpenAI-compatible endpoint. There are two causes, and the second one only shows up once the first is fixed.

## Problem

`createModel` builds custom endpoints with `@ai-sdk/openai`, whose streaming schema requires `index` on every tool-call delta. Google does not send one, so the stream dies before the tool runs:

```
ERR [runtime] [provider] Type validation failed: Value: {"choices":[{"delta":{"role":"assistant","tool_calls":[{"extra_content":{"google":{"thought_signature":"EmcKZQERTTIPB2..."}},"function":{"arguments":"{\"query\":\"host access mounts\"}","name":"recall"},"id":"call_1700666","type":"function"}]},"index":0}], ...}
  "path": ["choices", 0, "delta", "tool_calls", 0, "index"],
  "message": "Invalid input: expected number, received undefined"
```

`@ai-sdk/openai-compatible` marks that field `index: z.number().nullish(), //google does not send index`. Switching to it clears the crash and reaches the next one, `400 Function call is missing a thought_signature in functionCall parts`, on the request after a tool result. The compatible provider does capture and re-serialize that signature, but only under the `google` providerOptions namespace, which the provider `name` selects. Under any other name it is captured and never sent back (vercel/ai#18962).

## Fix

Google's host is served by `@ai-sdk/openai-compatible` named `google`. `includeUsage` requests stream usage, which that provider omits by default.

Every other base URL keeps `@ai-sdk/openai` exactly as before, because the two providers do not serialize requests the same way. Captured against a local server, for `gpt-5.4` on a custom URL:

| | `@ai-sdk/openai` | compatible provider |
|---|---|---|
| system instruction | `role: "developer"` | `role: "system"` |
| `maxOutputTokens: 321` | `max_completion_tokens` | `max_tokens` |
| unsupported `temperature` | dropped, with a warning | sent |

Azure documents `max_completion_tokens` as required for reasoning models, so a blanket swap would have broken exactly the Azure and gateway setups the base URL exists for. My first cut did that, and the reasoning-model test below is what caught it.

## Evidence

Three tests in `test/model-endpoint.test.ts` drive `createModel` through a stub `fetch` and check what actually goes over the wire:

- an index-less Google tool-call delta executes the tool, and the **second** request body carries `extra_content.google.thought_signature` unchanged. Fails on master.
- a non-Google custom URL still sends `developer` and `max_completion_tokens` for `gpt-5.4`. Fails against my first cut.
- no base URL leaves the OpenAI provider untouched.

I also checked a few things against the real endpoint: parallel tool calls, three in one delta, assemble correctly, and `generateText` behaves the same as `streamText`. Putting a LiteLLM gateway back in front changes nothing either way.

My agent ran on Gemini for two days behind a gateway that existed only to translate for it. On this build it talks to Google directly:

```
[runtime] handleMessage: Use your recall tool to search for host mounts, then tell me in one short sentence what you found.
assistant TOOL-CALL recall {"query": "host mounts"}
tool     TOOL-RESULT ok
assistant TEXT I have read-write access to /mnt/tools, /mnt/usenet and /mnt/media, with /mnt/media/Backups mounted read-only.
```

Recall and segments run over that same direct connection: 44 chunks with 44 vectors at 3072 dimensions, 13 segments all summarized.

## Notes

- **The swap applies to a whole endpoint.** For Google's host every `createModel` consumer moves with it, including daily notes and the media, PDF, image and audio paths. Segment summaries and embeddings go through `createOpenAIClient`, which this PR does not touch.
- **Vertex is not covered.** Its OpenAI endpoint (`<region>-aiplatform.googleapis.com`) documents the same `extra_content` representation, but I have no Vertex project to test against and would rather not ship an untested branch. Google behind a transparent proxy is invisible to a host check too.
- **The pinned provider still cannot assemble a tool call split across deltas.** Its assembler falls back to `toolCalls.length` when `index` is absent, so fragmented arguments would be read as a second call. Google sends the whole call in one delta today, which is why this works. Upstream fixed the fragmented case in `@ai-sdk/openai-compatible@3.0.23`.
- **Staying on the 2.x line is deliberate.** The fix for arbitrary provider names is in `3.0.32`, and that line requires Node >=22 while kern declares `>=18`. When kern moves, the `google` name becomes unnecessary and the host check can go.
- One direct dependency, `@ai-sdk/openai-compatible@^2.0.75`, from the same `@ai-sdk` family. The lockfile also picks up its transitive packages.
- `CHANGELOG.md` will conflict trivially with #334 and #335 if they land first, same `## next` slot.

`npm test` passes 109, `npm run build:server` clean.

Is Vertex worth covering in the same host check, or would you rather that wait until someone reports it?
