### PR TITLE
fix(segments): link child segments to existing parent on rollup conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.34.2 (unreleased)
+
+### Fixes
+- **Prevent infinite background segment rollup loop** ([#338](https://github.com/oguzbilgic/kern-ai/pull/338)) — when 10 child segments were rolled up into an L1 or L2 parent segment that already existed in SQLite (`INSERT OR IGNORE` conflict), the transaction exited early without assigning `parent_id` to the child segments. Because they remained orphans (`parent_id IS NULL`), the rollup loop re-selected the exact same group on every iteration and repeatedly called the summary model indefinitely. Rollup now links child segments to the existing parent segment ID on conflict, terminating the orphan state cleanly.
+
 ## 0.34.1 (2026-09-09)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.34.2 (unreleased)
+## next
 
 ### Fixes
 - **Stop background summarization from getting stuck in an infinite loop** ([#338](https://github.com/oguzbilgic/kern-ai/pull/338)) — under certain conditions when rolling up older conversation segments into higher-level summaries, already-summarized segments could fail to link to their parent summary. The background process would continuously re-summarize the exact same conversation window every few seconds, burning API tokens and driving unexpected spend. Rollup now detects existing parent summaries immediately, linking child segments and stopping the loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.34.2 (unreleased)
 
 ### Fixes
-- **Prevent infinite background segment rollup loop** ([#338](https://github.com/oguzbilgic/kern-ai/pull/338)) — when 10 child segments were rolled up into an L1 or L2 parent segment that already existed in SQLite (`INSERT OR IGNORE` conflict), the transaction exited early without assigning `parent_id` to the child segments. Because they remained orphans (`parent_id IS NULL`), the rollup loop re-selected the exact same group on every iteration and repeatedly called the summary model indefinitely. Rollup now links child segments to the existing parent segment ID on conflict, terminating the orphan state cleanly.
+- **Stop background summarization from getting stuck in an infinite loop** ([#338](https://github.com/oguzbilgic/kern-ai/pull/338)) — under certain conditions when rolling up older conversation segments into higher-level summaries, already-summarized segments could fail to link to their parent summary. The background process would continuously re-summarize the exact same conversation window every few seconds, burning API tokens and driving unexpected spend. Rollup now detects existing parent summaries immediately, linking child segments and stopping the loop.
 
 ## 0.34.1 (2026-09-09)
 

--- a/src/segments.ts
+++ b/src/segments.ts
@@ -508,9 +508,17 @@ export class SegmentIndex {
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`
               ).run(sessionId, msgStart, msgEnd, startTime, endTime, parentLevel, summaryText, totalTokens, summaryTokens);
 
-              if (info.changes === 0) return; // already exists
+              let parentId: number | bigint = info.lastInsertRowid;
+              if (info.changes === 0) {
+                // Already exists — find existing parent ID so children don't loop endlessly as orphans
+                const existing = this.db.prepare(
+                  `SELECT id FROM semantic_segments
+                   WHERE session_id = ? AND level = ? AND msg_start = ? AND msg_end = ?`
+                ).get(sessionId, parentLevel, msgStart, msgEnd) as { id: number } | undefined;
+                if (!existing) return;
+                parentId = existing.id;
+              }
 
-              const parentId = info.lastInsertRowid;
               const setParent = this.db.prepare(
                 "UPDATE semantic_segments SET parent_id = ? WHERE id = ?"
               );


### PR DESCRIPTION
### Problem
In `SegmentIndex.rollupSegments()`, when 10 child segments are rolled up into an L1/L2 parent, the insertion uses `INSERT OR IGNORE`:
```sql
INSERT OR IGNORE INTO semantic_segments (...) VALUES (...)
```
If a parent segment with the same `(session_id, level, msg_start, msg_end)` already exists in the database (e.g. from an earlier interrupted run or re-index), `info.changes === 0`.

Previously, the transaction immediately returned:
```ts
if (info.changes === 0) return;
```
This left all 10 child segments with `parent_id IS NULL`. Since the rollup selection queries for `WHERE parent_id IS NULL AND summarized = 1`, the exact same 10 child segments were selected again on the very next rollup loop (~every 2 seconds), continuously calling the LLM summary model in an infinite loop without ever updating `parent_id`.

### Fix
When `info.changes === 0`, query the existing parent record by unique key `(session_id, level, msg_start, msg_end)` and use its `id` to update `parent_id` on the child group, terminating the orphan state and stopping the loop.