### PR TITLE
fix(discord): retry login with backoff on failure and make start non-blocking

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -487,13 +487,12 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
       ? process.env.DISCORD_MENTION_ONLY === "true" || process.env.DISCORD_MENTION_ONLY === "1"
       : config.discordMentionOnly ?? true;
     discordBot = new DiscordInterface(discordToken, pairing, mentionOnly);
-    discordBot.start({
+    // start() is non-blocking — retries login with backoff on failure
+    await discordBot.start({
       onMessage: async (msg, onEvent) => {
         return enqueueMessage(msg.text, msg.userId, msg.interface, msg.channel || "", onEvent, msg.attachments);
       },
-    }).catch((err) => {
-      // logged internally
-    });
+    }).catch(() => {});
   }
 
   // Start IRC if configured — IRC_URL overrides config.irc

--- a/src/interfaces/discord.ts
+++ b/src/interfaces/discord.ts
@@ -64,6 +64,8 @@ export class DiscordInterface implements Interface {
   private _status: "connected" | "disconnected" | "error" = "disconnected";
   private _statusDetail?: string;
   private sentCodes = new Set<string>();
+  private running: boolean = false;
+  private retryTimeout?: NodeJS.Timeout;
 
   constructor(token: string, pairing?: PairingManager, mentionOnly: boolean = true) {
     this.token = token;
@@ -88,6 +90,7 @@ export class DiscordInterface implements Interface {
   get statusDetail() { return this._statusDetail; }
 
   async start({ onMessage }: StartOptions): Promise<void> {
+    this.running = true;
     return new Promise<void>((resolve, reject) => {
       let resolved = false;
 
@@ -95,6 +98,10 @@ export class DiscordInterface implements Interface {
         this.botUserId = c.user.id;
         this._status = "connected";
         this._statusDetail = undefined;
+        if (this.retryTimeout) {
+          clearTimeout(this.retryTimeout);
+          this.retryTimeout = undefined;
+        }
         log("discord", `connected as ${c.user.tag} (${c.user.id})`);
         if (!resolved) {
           resolved = true;
@@ -226,19 +233,34 @@ export class DiscordInterface implements Interface {
         }
       });
 
-      this.client.login(this.token).catch((err) => {
-        this._status = "error";
-        this._statusDetail = err.message || String(err);
-        log.error("discord", `login failed: ${err.message || err}`);
-        if (!resolved) {
-          resolved = true;
-          reject(err);
-        }
-      });
+      const tryLogin = (backoff = 2000) => {
+        if (!this.running) return;
+        this.client.login(this.token).catch((err) => {
+          this._status = "error";
+          this._statusDetail = err.message || String(err);
+          log.error("discord", `login failed: ${err.message || err}`);
+          if (!resolved) {
+            resolved = true;
+            resolve(); // Don't block startup — retry in background
+          }
+          if (this.running) {
+            const nextBackoff = Math.min(backoff * 1.5, 60000);
+            log("discord", `retrying login in ${Math.round(backoff / 1000)}s`);
+            this.retryTimeout = setTimeout(() => tryLogin(nextBackoff), backoff);
+          }
+        });
+      };
+
+      tryLogin();
     });
   }
 
   async stop(): Promise<void> {
+    this.running = false;
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = undefined;
+    }
     this._status = "disconnected";
     try {
       this.client.destroy();

--- a/src/interfaces/discord.ts
+++ b/src/interfaces/discord.ts
@@ -91,23 +91,17 @@ export class DiscordInterface implements Interface {
 
   async start({ onMessage }: StartOptions): Promise<void> {
     this.running = true;
-    return new Promise<void>((resolve, reject) => {
-      let resolved = false;
 
-      this.client.once("ready", (c) => {
-        this.botUserId = c.user.id;
-        this._status = "connected";
-        this._statusDetail = undefined;
-        if (this.retryTimeout) {
-          clearTimeout(this.retryTimeout);
-          this.retryTimeout = undefined;
-        }
-        log("discord", `connected as ${c.user.tag} (${c.user.id})`);
-        if (!resolved) {
-          resolved = true;
-          resolve();
-        }
-      });
+    this.client.once("ready", (c) => {
+      this.botUserId = c.user.id;
+      this._status = "connected";
+      this._statusDetail = undefined;
+      if (this.retryTimeout) {
+        clearTimeout(this.retryTimeout);
+        this.retryTimeout = undefined;
+      }
+      log("discord", `connected as ${c.user.tag} (${c.user.id})`);
+    });
 
       this.client.on("error", (err) => {
         log.error("discord", `client error: ${err.message || err}`);
@@ -233,26 +227,20 @@ export class DiscordInterface implements Interface {
         }
       });
 
-      const tryLogin = (backoff = 2000) => {
+    const tryLogin = (backoff = 2000) => {
+      if (!this.running) return;
+      this.client.login(this.token).catch((err) => {
         if (!this.running) return;
-        this.client.login(this.token).catch((err) => {
-          this._status = "error";
-          this._statusDetail = err.message || String(err);
-          log.error("discord", `login failed: ${err.message || err}`);
-          if (!resolved) {
-            resolved = true;
-            resolve(); // Don't block startup — retry in background
-          }
-          if (this.running) {
-            const nextBackoff = Math.min(backoff * 1.5, 60000);
-            log("discord", `retrying login in ${Math.round(backoff / 1000)}s`);
-            this.retryTimeout = setTimeout(() => tryLogin(nextBackoff), backoff);
-          }
-        });
-      };
+        this._status = "error";
+        this._statusDetail = err.message || String(err);
+        log.error("discord", `login failed: ${err.message || err}`);
+        const nextBackoff = Math.min(backoff * 1.5, 60000);
+        log("discord", `retrying login in ${Math.round(backoff / 1000)}s`);
+        this.retryTimeout = setTimeout(() => tryLogin(nextBackoff), backoff);
+      });
+    };
 
-      tryLogin();
-    });
+    tryLogin();
   }
 
   async stop(): Promise<void> {

--- a/test/discord.test.ts
+++ b/test/discord.test.ts
@@ -35,3 +35,37 @@ test("chunkMessage: hard cuts when no whitespace", () => {
   assert.strictEqual(chunks[0].length, 2000);
   assert.strictEqual(chunks[1].length, 500);
 });
+
+test("DiscordInterface: start() is non-blocking and stop() halts retry loop cleanly", async () => {
+  const { DiscordInterface } = await import("../src/interfaces/discord.js");
+  const discord = new DiscordInterface("fake-token");
+
+  // Stub client.login to simulate transient failures
+  let loginAttempts = 0;
+  (discord as any).client.login = async () => {
+    loginAttempts++;
+    throw new Error("getaddrinfo ENOTFOUND discord.com");
+  };
+
+  const startPromise = discord.start({
+    onMessage: async () => {},
+  });
+
+  // Verify start() resolves immediately without waiting for login
+  let resolvedImmediately = false;
+  await Promise.race([
+    startPromise.then(() => { resolvedImmediately = true; }),
+    new Promise((_, reject) => setTimeout(() => reject(new Error("start() timed out")), 200)),
+  ]);
+  assert.strictEqual(resolvedImmediately, true);
+
+  // Status should be set to error with the failure reason
+  assert.strictEqual(discord.status, "error");
+  assert.match(discord.statusDetail || "", /getaddrinfo ENOTFOUND/);
+  assert.strictEqual(loginAttempts, 1);
+
+  // Stop should cancel retries and reset status to disconnected without being overwritten
+  await discord.stop();
+  assert.strictEqual(discord.status, "disconnected");
+  assert.strictEqual((discord as any).retryTimeout, undefined);
+});


### PR DESCRIPTION
### Problem
When the agent starts or restarts, transient network or DNS failures (such as `getaddrinfo EAI_AGAIN discord.com`) cause `client.login()` to reject immediately.
Because `DiscordInterface.start()` previously rejected and had no reconnect loop, Discord gave up permanently on boot, leaving the interface offline until manual intervention.

### Solution
1. Add an exponential backoff retry loop to `client.login()` (starting at 2s, capped at 60s) while the interface is marked `running`.
2. Clear the retry timer once connected or when `stop()` is called.
3. Make `start()` non-blocking like Matrix/Nostr/IRC so initial connection issues never stall startup.
4. Report `error` status with the failure message until reconnection succeeds.