### PR TITLE
fix(runtime): notify user and persist message when step limit is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Discord interface** ([#337](https://github.com/oguzbilgic/kern-ai/pull/337)) — connect your agent directly to Discord via bot gateway. Add `DISCORD_TOKEN` to `.kern/.env` to enable. Supports pairing-gated Direct Messages, server/guild channels with @mention gating, automatic message chunking for Discord's 2,000-character limit, typing indicators, media attachment ingestion (up to 25 MB), and proactive messaging via `message` tool.
 
 ### Fixes
+- **Surface step-limit notifications instead of silently dropping turns** — turns that reach `maxSteps` (30) now append an explicit `⏳ Reached step limit (30 steps). Reply "continue" to proceed.` notice. If the model emitted 0 text on the step limit, a clear message is delivered and persisted instead of being silently treated as `NO_REPLY` and deleting placeholders on chat interfaces.
 - **Stop background summarization from getting stuck in an infinite loop** ([#338](https://github.com/oguzbilgic/kern-ai/pull/338)) — under certain conditions when rolling up older conversation segments into higher-level summaries, already-summarized segments could fail to link to their parent summary. The background process would continuously re-summarize the exact same conversation window every few seconds, burning API tokens and driving unexpected spend. Rollup now detects existing parent summaries immediately, linking child segments and stopping the loop.
 
 ## 0.34.1 (2026-09-09)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -404,6 +404,22 @@ export class Runtime {
 
       log("runtime", `stream finished, text length: ${fullText.length}`);
 
+      // Check if turn hit the step limit (#310 / step-limit notice)
+      try {
+        const steps = await result.steps;
+        if (steps.length >= this.config.maxSteps) {
+          const stepNotice = fullText.trim()
+            ? `\n\n⏳ Reached step limit (${this.config.maxSteps} steps). Reply \"continue\" to proceed.`
+            : `⏳ Reached step limit (${this.config.maxSteps} steps). Work is partially completed. Reply \"continue\" to proceed.`;
+          fullText += stepNotice;
+          onEvent({ type: "text-delta", text: stepNotice });
+          await this.session.append([{ role: "assistant", content: fullText }]);
+          log("runtime", `step limit (${this.config.maxSteps}) reached — appended continuation notice`);
+        }
+      } catch (err) {
+        log("runtime", `failed to evaluate steps for step limit notice: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
       // If the stream had an error and produced no output, throw to hit error handler
       if (streamError && fullText.length === 0) {
         throw streamError;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -405,23 +405,26 @@ export class Runtime {
       log("runtime", `stream finished, text length: ${fullText.length}`);
 
       // Check if turn hit the step limit (#310 / step-limit notice)
+      let hitStepLimit = false;
       try {
         const steps = await result.steps;
-        if (steps.length >= this.config.maxSteps) {
-          const unit = this.config.maxSteps === 1 ? "step" : "steps";
-          const hasEmittedText = fullText.trim().length > 0;
-          const stepNotice = hasEmittedText
-            ? `\n\n⏳ Reached step limit (${this.config.maxSteps} ${unit}). Reply \"continue\" to proceed.`
-            : `⏳ Reached step limit (${this.config.maxSteps} ${unit}). Work is partially completed. Reply \"continue\" to proceed.`;
-          fullText += stepNotice;
-          onEvent({ type: "text-delta", text: stepNotice });
-          // If the model emitted text, onStepFinish already persisted the assistant message;
-          // append only the notice. If 0 text was emitted, write the notice as an assistant message.
-          await this.session.append([{ role: "assistant", content: stepNotice }]);
-          log("runtime", `step limit (${this.config.maxSteps}) reached — appended continuation notice`);
-        }
+        hitStepLimit = steps.length >= this.config.maxSteps;
       } catch (err) {
         log("runtime", `failed to evaluate steps for step limit notice: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      if (hitStepLimit) {
+        const unit = this.config.maxSteps === 1 ? "step" : "steps";
+        const hasEmittedText = fullText.trim().length > 0;
+        const stepNotice = hasEmittedText
+          ? `\n\n⏳ Reached step limit (${this.config.maxSteps} ${unit}). Reply \"continue\" to proceed.`
+          : `⏳ Reached step limit (${this.config.maxSteps} ${unit}). Work is partially completed. Reply \"continue\" to proceed.`;
+        fullText += stepNotice;
+        onEvent({ type: "text-delta", text: stepNotice });
+        // If the model emitted text, onStepFinish already persisted the assistant message;
+        // append only the notice. If 0 text was emitted, write the notice as an assistant message.
+        await this.session.append([{ role: "assistant", content: stepNotice }]);
+        log("runtime", `step limit (${this.config.maxSteps}) reached — appended continuation notice`);
       }
 
       // If the stream had an error and produced no output, throw to hit error handler

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -408,12 +408,16 @@ export class Runtime {
       try {
         const steps = await result.steps;
         if (steps.length >= this.config.maxSteps) {
-          const stepNotice = fullText.trim()
-            ? `\n\n⏳ Reached step limit (${this.config.maxSteps} steps). Reply \"continue\" to proceed.`
-            : `⏳ Reached step limit (${this.config.maxSteps} steps). Work is partially completed. Reply \"continue\" to proceed.`;
+          const unit = this.config.maxSteps === 1 ? "step" : "steps";
+          const hasEmittedText = fullText.trim().length > 0;
+          const stepNotice = hasEmittedText
+            ? `\n\n⏳ Reached step limit (${this.config.maxSteps} ${unit}). Reply \"continue\" to proceed.`
+            : `⏳ Reached step limit (${this.config.maxSteps} ${unit}). Work is partially completed. Reply \"continue\" to proceed.`;
           fullText += stepNotice;
           onEvent({ type: "text-delta", text: stepNotice });
-          await this.session.append([{ role: "assistant", content: fullText }]);
+          // If the model emitted text, onStepFinish already persisted the assistant message;
+          // append only the notice. If 0 text was emitted, write the notice as an assistant message.
+          await this.session.append([{ role: "assistant", content: stepNotice }]);
           log("runtime", `step limit (${this.config.maxSteps}) reached — appended continuation notice`);
         }
       } catch (err) {

--- a/test/step-limit.test.ts
+++ b/test/step-limit.test.ts
@@ -4,7 +4,7 @@ import { MockLanguageModelV3 } from "ai/test";
 import { streamText, stepCountIs, tool } from "ai";
 import { z } from "zod";
 
-test("step limit notice: appends notice when steps hit maxSteps", async () => {
+test("step limit notice: appends notice when steps hit maxSteps with partial text", async () => {
   let callCount = 0;
   const model = new MockLanguageModelV3({
     doStream: async () => {
@@ -14,7 +14,7 @@ test("step limit notice: appends notice when steps hit maxSteps", async () => {
           stream: new ReadableStream({
             start(controller) {
               controller.enqueue({ type: "response-metadata", id: "1", modelId: "mock", timestamp: new Date() });
-              controller.enqueue({ type: "tool-call", toolCallType: "function", toolCallId: "c1", toolName: "t1", args: "{}" });
+              controller.enqueue({ type: "tool-call", toolCallId: "c1", toolName: "t1", input: "{}" });
               controller.enqueue({ type: "finish", finishReason: "tool-calls", usage: { inputTokens: { total: 10 }, outputTokens: { total: 10 } } });
               controller.close();
             }
@@ -26,7 +26,9 @@ test("step limit notice: appends notice when steps hit maxSteps", async () => {
         stream: new ReadableStream({
           start(controller) {
             controller.enqueue({ type: "response-metadata", id: "2", modelId: "mock", timestamp: new Date() });
+            controller.enqueue({ type: "text-start", id: "d1" });
             controller.enqueue({ type: "text-delta", id: "d1", delta: "Partial summary of work." });
+            controller.enqueue({ type: "text-end", id: "d1" });
             controller.enqueue({ type: "finish", finishReason: "stop", usage: { inputTokens: { total: 10 }, outputTokens: { total: 10 } } });
             controller.close();
           }
@@ -42,7 +44,7 @@ test("step limit notice: appends notice when steps hit maxSteps", async () => {
     tools: {
       t1: tool({
         description: "test",
-        parameters: z.object({}),
+        inputSchema: z.object({}),
         execute: async () => "result 1"
       })
     },
@@ -60,17 +62,17 @@ test("step limit notice: appends notice when steps hit maxSteps", async () => {
   const steps = await res.steps;
   assert.equal(steps.length, maxSteps);
 
-  if (steps.length >= maxSteps) {
-    const stepNotice = fullText.trim()
-      ? `\n\n⏳ Reached step limit (${maxSteps} steps). Reply "continue" to proceed.`
-      : `⏳ Reached step limit (${maxSteps} steps). Work is partially completed. Reply "continue" to proceed.`;
-    fullText += stepNotice;
-  }
+  const unit = maxSteps === 1 ? "step" : "steps";
+  const hasEmittedText = fullText.trim().length > 0;
+  const stepNotice = hasEmittedText
+    ? `\n\n⏳ Reached step limit (${maxSteps} ${unit}). Reply "continue" to proceed.`
+    : `⏳ Reached step limit (${maxSteps} ${unit}). Work is partially completed. Reply "continue" to proceed.`;
+  fullText += stepNotice;
 
   assert.ok(fullText.includes("⏳ Reached step limit (2 steps). Reply \"continue\" to proceed."));
 });
 
-test("step limit notice: handles 0 text emitted when hitting maxSteps", async () => {
+test("step limit notice: pluralizes correctly when maxSteps is 1 and handles empty text", async () => {
   let callCount = 0;
   const model = new MockLanguageModelV3({
     doStream: async () => {
@@ -79,7 +81,6 @@ test("step limit notice: handles 0 text emitted when hitting maxSteps", async ()
         stream: new ReadableStream({
           start(controller) {
             controller.enqueue({ type: "response-metadata", id: String(callCount), modelId: "mock", timestamp: new Date() });
-            controller.enqueue({ type: "text-delta", id: `d${callCount}`, delta: "" });
             controller.enqueue({ type: "finish", finishReason: "stop", usage: { inputTokens: { total: 10 }, outputTokens: { total: 10 } } });
             controller.close();
           }
@@ -106,12 +107,12 @@ test("step limit notice: handles 0 text emitted when hitting maxSteps", async ()
   const steps = await res.steps;
   assert.equal(steps.length, maxSteps);
 
-  if (steps.length >= maxSteps) {
-    const stepNotice = fullText.trim()
-      ? `\n\n⏳ Reached step limit (${maxSteps} steps). Reply "continue" to proceed.`
-      : `⏳ Reached step limit (${maxSteps} steps). Work is partially completed. Reply "continue" to proceed.`;
-    fullText += stepNotice;
-  }
+  const unit = maxSteps === 1 ? "step" : "steps";
+  const hasEmittedText = fullText.trim().length > 0;
+  const stepNotice = hasEmittedText
+    ? `\n\n⏳ Reached step limit (${maxSteps} ${unit}). Reply "continue" to proceed.`
+    : `⏳ Reached step limit (${maxSteps} ${unit}). Work is partially completed. Reply "continue" to proceed.`;
+  fullText += stepNotice;
 
-  assert.equal(fullText, '⏳ Reached step limit (1 steps). Work is partially completed. Reply "continue" to proceed.');
+  assert.equal(fullText, '⏳ Reached step limit (1 step). Work is partially completed. Reply "continue" to proceed.');
 });

--- a/test/step-limit.test.ts
+++ b/test/step-limit.test.ts
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { MockLanguageModelV3 } from "ai/test";
+import { streamText, stepCountIs, tool } from "ai";
+import { z } from "zod";
+
+test("step limit notice: appends notice when steps hit maxSteps", async () => {
+  let callCount = 0;
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          stream: new ReadableStream({
+            start(controller) {
+              controller.enqueue({ type: "response-metadata", id: "1", modelId: "mock", timestamp: new Date() });
+              controller.enqueue({ type: "tool-call", toolCallType: "function", toolCallId: "c1", toolName: "t1", args: "{}" });
+              controller.enqueue({ type: "finish", finishReason: "tool-calls", usage: { inputTokens: { total: 10 }, outputTokens: { total: 10 } } });
+              controller.close();
+            }
+          }),
+          rawCall: { rawPrompt: null, rawSettings: {} }
+        };
+      }
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "response-metadata", id: "2", modelId: "mock", timestamp: new Date() });
+            controller.enqueue({ type: "text-delta", id: "d1", delta: "Partial summary of work." });
+            controller.enqueue({ type: "finish", finishReason: "stop", usage: { inputTokens: { total: 10 }, outputTokens: { total: 10 } } });
+            controller.close();
+          }
+        }),
+        rawCall: { rawPrompt: null, rawSettings: {} }
+      };
+    }
+  });
+
+  const maxSteps = 2;
+  const res = streamText({
+    model,
+    tools: {
+      t1: tool({
+        description: "test",
+        parameters: z.object({}),
+        execute: async () => "result 1"
+      })
+    },
+    stopWhen: stepCountIs(maxSteps),
+    prompt: "do work"
+  });
+
+  let fullText = "";
+  for await (const part of res.fullStream) {
+    if (part.type === "text-delta") {
+      fullText += part.delta || (part as any).text || "";
+    }
+  }
+
+  const steps = await res.steps;
+  assert.equal(steps.length, maxSteps);
+
+  if (steps.length >= maxSteps) {
+    const stepNotice = fullText.trim()
+      ? `\n\n⏳ Reached step limit (${maxSteps} steps). Reply "continue" to proceed.`
+      : `⏳ Reached step limit (${maxSteps} steps). Work is partially completed. Reply "continue" to proceed.`;
+    fullText += stepNotice;
+  }
+
+  assert.ok(fullText.includes("⏳ Reached step limit (2 steps). Reply \"continue\" to proceed."));
+});
+
+test("step limit notice: handles 0 text emitted when hitting maxSteps", async () => {
+  let callCount = 0;
+  const model = new MockLanguageModelV3({
+    doStream: async () => {
+      callCount++;
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "response-metadata", id: String(callCount), modelId: "mock", timestamp: new Date() });
+            controller.enqueue({ type: "text-delta", id: `d${callCount}`, delta: "" });
+            controller.enqueue({ type: "finish", finishReason: "stop", usage: { inputTokens: { total: 10 }, outputTokens: { total: 10 } } });
+            controller.close();
+          }
+        }),
+        rawCall: { rawPrompt: null, rawSettings: {} }
+      };
+    }
+  });
+
+  const maxSteps = 1;
+  const res = streamText({
+    model,
+    stopWhen: stepCountIs(maxSteps),
+    prompt: "do work"
+  });
+
+  let fullText = "";
+  for await (const part of res.fullStream) {
+    if (part.type === "text-delta") {
+      fullText += part.delta || (part as any).text || "";
+    }
+  }
+
+  const steps = await res.steps;
+  assert.equal(steps.length, maxSteps);
+
+  if (steps.length >= maxSteps) {
+    const stepNotice = fullText.trim()
+      ? `\n\n⏳ Reached step limit (${maxSteps} steps). Reply "continue" to proceed.`
+      : `⏳ Reached step limit (${maxSteps} steps). Work is partially completed. Reply "continue" to proceed.`;
+    fullText += stepNotice;
+  }
+
+  assert.equal(fullText, '⏳ Reached step limit (1 steps). Work is partially completed. Reply "continue" to proceed.');
+});


### PR DESCRIPTION
### Problem
When a multi-step turn hits `maxSteps` (default: 30), the agent enters the final step where tools are disabled. If the model emits 0 text tokens (or wraps up without output), `fullText` is empty string `""`.
On chat interfaces like Telegram, `isNoReply("")` evaluates to `true`, silently deleting the placeholder message. The turn ends with complete silence and leaves the user unaware of why the agent stopped.

### Fix
- After the stream finishes, inspect `result.steps`. If `steps.length >= config.maxSteps`:
  - If the model emitted partial text: append `\n\n⏳ Reached step limit (30 steps). Reply "continue" to proceed.`
  - If the model emitted 0 text: set text to `⏳ Reached step limit (30 steps). Work is partially completed. Reply "continue" to proceed.`
  - Persist this assistant message to session JSONL so the session and memory accurately reflect the turn state.
- Emits `text-delta` so streaming interfaces update in real-time.
- Added unit tests in `test/step-limit.test.ts` verifying notice generation for both non-empty and 0-text step cap endings.