### PR TITLE
fix(discord): send directly in DMs and only use reply in guild channels

### DIFF
--- a/src/interfaces/discord.ts
+++ b/src/interfaces/discord.ts
@@ -211,7 +211,7 @@ export class DiscordInterface implements Interface {
 
           const chunks = chunkMessage(reply);
           for (let i = 0; i < chunks.length; i++) {
-            if (i === 0) {
+            if (i === 0 && !isDM) {
               await message.reply({ content: chunks[i], allowedMentions: { repliedUser: false } });
             } else {
               await (message.channel as any).send({ content: chunks[i] });
@@ -220,10 +220,12 @@ export class DiscordInterface implements Interface {
         } catch (err: any) {
           clearInterval(typingInterval);
           log.error("discord", `turn failed: ${err.message || err}`);
-          await message.reply({
-            content: "Error processing message.",
-            allowedMentions: { repliedUser: false },
-          }).catch(() => {});
+          const errorMsg = { content: "Error processing message.", allowedMentions: { repliedUser: false } };
+          if (isDM) {
+            await (message.channel as any).send({ content: "Error processing message." }).catch(() => {});
+          } else {
+            await message.reply(errorMsg).catch(() => {});
+          }
         }
       });
 

--- a/test/discord.test.ts
+++ b/test/discord.test.ts
@@ -69,3 +69,76 @@ test("DiscordInterface: start() is non-blocking and stop() halts retry loop clea
   assert.strictEqual(discord.status, "disconnected");
   assert.strictEqual((discord as any).retryTimeout, undefined);
 });
+
+test("DiscordInterface: send in DMs and reply in guild channels", async () => {
+  const { DiscordInterface } = await import("../src/interfaces/discord.js");
+  const discord = new DiscordInterface("fake-token");
+
+  let dmReplied = false;
+  let dmSentMessage = "";
+  const mockDMMessage = {
+    author: { id: "user1", username: "oguz" },
+    channel: {
+      id: "dm-channel-1",
+      type: 1, // ChannelType.DM
+      send: async (payload: any) => {
+        dmSentMessage = payload.content;
+      },
+    },
+    guild: null,
+    mentions: { users: new Map(), roles: new Map() },
+    attachments: new Map(),
+    content: "hello agent in dm",
+    reply: async () => {
+      dmReplied = true;
+    },
+  };
+
+  let guildReplied = false;
+  let guildReplyContent = "";
+  const mockGuildMessage = {
+    author: { id: "user2", username: "someone" },
+    channel: {
+      id: "guild-channel-1",
+      type: 0, // ChannelType.GuildText
+      name: "general",
+      send: async () => {},
+    },
+    guild: {
+      id: "guild-1",
+      members: { me: { roles: { cache: new Map() } } },
+    },
+    mentions: { users: new Map([["fake-bot-id", {}]]), roles: new Map() },
+    attachments: new Map(),
+    content: "hello agent in channel",
+    reply: async (payload: any) => {
+      guildReplied = true;
+      guildReplyContent = payload.content;
+    },
+  };
+
+  // Trigger message handler directly
+  let messageCreateHandler: any;
+  (discord as any).botUserId = "fake-bot-id";
+  (discord as any).client.on = (event: string, handler: any) => {
+    if (event === "messageCreate") messageCreateHandler = handler;
+  };
+  (discord as any).client.login = async () => {};
+
+  await discord.start({
+    onMessage: async (msg) => `Reply to: ${msg.text}`,
+  });
+
+  // 1. DM message should use channel.send, NOT message.reply
+  await messageCreateHandler(mockDMMessage);
+  assert.strictEqual(dmReplied, false, "Should not reply() in DMs");
+  assert.strictEqual(dmSentMessage, "Reply to: hello agent in dm");
+
+  // 2. Guild message should use message.reply for the first chunk
+  await messageCreateHandler(mockGuildMessage);
+  assert.strictEqual(guildReplied, true, "Should reply() in guild channels");
+  assert.strictEqual(guildReplyContent, "Reply to: hello agent in channel");
+
+  await discord.stop();
+});
+


### PR DESCRIPTION
### Summary
- In DMs (`isDM === true`), send responses and error messages directly to `message.channel.send()` without creating quote/reply blocks.
- In guild/server channels (`!isDM`), keep `message.reply()` for the first chunk to indicate who is being answered.
- Added unit test covering both DM (`channel.send`) and guild channel (`message.reply`) message delivery paths.