### PR TITLE
feat(plugins): extract irc tool to plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## next
 
+### Improvements
+- **Extract IRC tool to plugin (`src/plugins/irc/`)** — moves IRC management and inspection tool (`irc`) out of core runtime tools into a modular plugin, keeping core tool definitions, scopes, and context assembly clean.
+
 ### Features
-- **Slack inspection and interaction tool (`slack`)** — built-in tool that allows the agent to inspect Slack workspaces on-demand without sending unsolicited messages: read channel history (`history`), read thread replies (`thread`), list public and private channels (`channels`), look up user profiles (`user`), list pinned messages (`pins`), view channel bookmarks (`bookmarks`), and add emoji reactions (`react`).
+- **Slack inspection and interaction tool (`slack`)** — built-in plugin that allows the agent to inspect Slack workspaces on-demand without sending unsolicited messages: read channel history (`history`), read thread replies (`thread`), list public and private channels (`channels`), look up user profiles (`user`), list pinned messages (`pins`), view channel bookmarks (`bookmarks`), and add emoji reactions (`react`).
 
 ## 0.35.0 (2026-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## next
 
-### Improvements
-- **Extract IRC tool to plugin (`src/plugins/irc/`)** — moves IRC management and inspection tool (`irc`) out of core runtime tools into a modular plugin, keeping core tool definitions, scopes, and context assembly clean.
-
 ### Features
 - **Slack inspection and interaction tool (`slack`)** — built-in plugin that allows the agent to inspect Slack workspaces on-demand without sending unsolicited messages: read channel history (`history`), read thread replies (`thread`), list public and private channels (`channels`), look up user profiles (`user`), list pinned messages (`pins`), view channel bookmarks (`bookmarks`), and add emoji reactions (`react`).
+
+### Improvements
+- **Extract IRC tool to plugin (`src/plugins/irc/`)** — moves IRC management and inspection tool (`irc`) out of core runtime tools into a modular plugin, keeping core tool definitions, scopes, and context assembly clean.
 
 ## 0.35.0 (2026-09-10)
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ import { registerAgent, writePidFile, removePidFile, assignPort } from "./regist
 import { AgentServer } from "./server.js";
 import { PairingManager } from "./pairing.js";
 import { setMessageSender } from "./tools/message.js";
-import { setIrcInterface, initIrcTool } from "./tools/irc.js";
+import { setIrcInterface } from "./plugins/irc/tools.js";
 import { SegmentIndex } from "./segments.js";
 import { MemoryDB } from "./memory.js";
 import { MessageQueue } from "./queue.js";
@@ -496,7 +496,6 @@ export async function startApp(agentDir: string, forceCli = false): Promise<void
   }
 
   // Start IRC if configured — IRC_URL overrides config.irc
-  initIrcTool(agentDir);
   const ircUrls = parseIrcUrls(process.env.IRC_URL || config.irc);
   let ircBot: IrcInterface | null = null;
   if (!forceCli && ircUrls.length) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,8 +74,8 @@ export type McpServerConfig =
 const shell = process.platform === "win32" ? "pwsh" : "bash";
 
 const TOOL_SCOPES: Record<ToolScope, string[]> = {
-  full: [shell, "read", "write", "edit", "glob", "grep", "webfetch", "websearch", "pdf", "image", "audio", "kern", "message", "irc"],
-  write: ["read", "write", "edit", "glob", "grep", "webfetch", "websearch", "pdf", "image", "audio", "kern", "message", "irc"],
+  full: [shell, "read", "write", "edit", "glob", "grep", "webfetch", "websearch", "pdf", "image", "audio", "kern", "message"],
+  write: ["read", "write", "edit", "glob", "grep", "webfetch", "websearch", "pdf", "image", "audio", "kern", "message"],
   read: ["read", "glob", "grep", "webfetch", "websearch", "pdf", "image", "audio", "kern"],
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -68,7 +68,6 @@ export async function loadSystemPrompt(agentDir: string, config: KernConfig, plu
     audio: "transcribe or analyze audio files using the AI model",
     kern: "manage your own runtime (status, config, env)",
     message: "send messages proactively",
-    irc: "manage IRC connections, register accounts, and query users/channels",
     ...pluginToolDescriptions,
   };
   // Plugin tools are always available — add them to the list

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -7,6 +7,7 @@ import { skillsPlugin } from "./skills/plugin.js";
 import { mcpPlugin } from "./mcp/plugin.js";
 import { subagentsPlugin } from "./subagents/plugin.js";
 import { slackPlugin } from "./slack/plugin.js";
+import { ircPlugin } from "./irc/plugin.js";
 import { log } from "../log.js";
 
 export type { KernPlugin, PluginContext, RouteHandler, ContextInjection, BeforeContextInfo } from "./types.js";
@@ -24,6 +25,7 @@ const availablePlugins: KernPlugin[] = [
   mcpPlugin,
   subagentsPlugin,
   slackPlugin,
+  ircPlugin,
 ];
 
 /** Active plugin instances after loading */

--- a/src/plugins/irc/plugin.ts
+++ b/src/plugins/irc/plugin.ts
@@ -1,0 +1,24 @@
+import type { KernPlugin, PluginContext } from "../types.js";
+import { ircTool, setIrcInterface, initIrcTool } from "./tools.js";
+
+export { setIrcInterface, initIrcTool } from "./tools.js";
+
+export const ircPlugin: KernPlugin = {
+  name: "irc",
+
+  tools: {
+    irc: ircTool,
+  },
+
+  toolDescriptions: {
+    irc: "manage IRC connections, register accounts, and query users/channels",
+  },
+
+  async onStartup(ctx: PluginContext) {
+    initIrcTool(ctx.agentDir);
+  },
+
+  async onShutdown() {
+    setIrcInterface(null);
+  },
+};

--- a/src/plugins/irc/tools.ts
+++ b/src/plugins/irc/tools.ts
@@ -4,8 +4,8 @@ import { createConnection } from "net";
 import { connect as tlsConnect } from "tls";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { join } from "path";
-import { parseIrcLine } from "../interfaces/irc.js";
-import type { IrcInterface, IrcLine } from "../interfaces/irc.js";
+import { parseIrcLine } from "../../interfaces/irc.js";
+import type { IrcInterface, IrcLine } from "../../interfaces/irc.js";
 
 let _agentDir = "";
 let _ircBot: IrcInterface | null = null;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,7 +12,6 @@ import { imageTool } from "./image.js";
 import { audioTool } from "./audio.js";
 import { kernTool } from "./kern.js";
 import { messageTool } from "./message.js";
-import { ircTool } from "./irc.js";
 
 const isWindows = process.platform === "win32";
 
@@ -31,7 +30,6 @@ export const allTools = {
   audio: audioTool,
   kern: kernTool,
   message: messageTool,
-  irc: ircTool,
 };
 
 export type ToolName = keyof typeof allTools;

--- a/test/irc-tool.test.ts
+++ b/test/irc-tool.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { ircTool, initIrcTool, setIrcInterface } from "../src/tools/irc.js";
+import { ircTool, initIrcTool, setIrcInterface } from "../src/plugins/irc/tools.js";
 import { mkdtemp, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";


### PR DESCRIPTION
## Summary
Extracts the `irc` management and command execution tool from core runtime tools into a modular plugin under `src/plugins/irc/`, following the same pattern as `slack`, `mcp`, `subagents`, `dashboard`, `notes`, etc.

### Changes
- **Plugin definition** (`src/plugins/irc/plugin.ts`): Registers the `irc` tool and its description, and initializes `agentDir` via `onStartup(ctx)`.
- **Tool location** (`src/plugins/irc/tools.ts`): Moved from `src/tools/irc.ts`, keeping all actions (`probe`, `register`, `configure`, `send`) intact.
- **Core cleanup**:
  - Removed `irc` from `src/tools/index.ts` (`allTools`).
  - Removed `irc` from `TOOL_SCOPES` in `src/config.ts`.
  - Removed hardcoded description from `src/context.ts` (now provided dynamically via `pluginToolDescriptions`).
  - Removed manual `initIrcTool(agentDir)` call from `src/app.ts` (handled via plugin `onStartup`).
- **Tests & Changelog**: Updated test imports in `test/irc-tool.test.ts` and updated `CHANGELOG.md`.

### Verification
- Tested via `tsx --test test/irc-tool.test.ts` (all tests passing)
- Full test suite clean (`npm test`)
- Full build clean (`npm run build`)