### PR TITLE
fix(runtime): surface turn errors to user and unwrap provider error details (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Improvements
 - **Extract IRC tool to plugin (`src/plugins/irc/`)** — moves IRC management and inspection tool (`irc`) out of core runtime tools into a modular plugin, keeping core tool definitions, scopes, and context assembly clean.
+- **Surface turn and provider errors across interfaces** ([#344](https://github.com/oguzbilgic/kern-ai/issues/344)) — unwraps provider error chains (JSON `responseBody`, `cause`, HTTP status codes) so rate limits (429), billing issues (402), authentication failures (401), and upstream errors surface with their real API messages instead of generic `"Provider returned error"`. Interfaces (Telegram, Discord, Matrix, Nostr) now notify users with formatted error messages (`⚠️ Rate limit hit (429): ...`) instead of silently dropping turns or sending generic placeholders.
 
 ## 0.35.0 (2026-09-10)
 

--- a/src/interfaces/discord.ts
+++ b/src/interfaces/discord.ts
@@ -219,10 +219,12 @@ export class DiscordInterface implements Interface {
           }
         } catch (err: any) {
           clearInterval(typingInterval);
-          log.error("discord", `turn failed: ${err.message || err}`);
-          const errorMsg = { content: "Error processing message.", allowedMentions: { repliedUser: false } };
+          const reason = String(err?.message || err || "Error processing message.");
+          log.error("discord", `turn failed: ${reason}`);
+          const displayErr = `⚠️ ${reason.slice(0, 300)}`;
+          const errorMsg = { content: displayErr, allowedMentions: { repliedUser: false } };
           if (isDM) {
-            await (message.channel as any).send({ content: "Error processing message." }).catch(() => {});
+            await (message.channel as any).send({ content: displayErr }).catch(() => {});
           } else {
             await message.reply(errorMsg).catch(() => {});
           }

--- a/src/interfaces/matrix.ts
+++ b/src/interfaces/matrix.ts
@@ -219,10 +219,9 @@ export class MatrixInterface implements Interface {
     } catch (err: any) {
       clearInterval(typingInterval);
       await this.setTyping(roomId, false).catch(() => {});
-      // Log details server-side; send a generic message to the room to avoid
-      // leaking HTTP response fragments or stack traces to room members.
-      log.error("matrix", `turn failed in ${roomId}: ${err.message || err}`);
-      await this.sendMessage(roomId, "Error processing message.").catch(() => {});
+      const reason = String(err?.message || err || "Error processing message.");
+      log.error("matrix", `turn failed in ${roomId}: ${reason}`);
+      await this.sendMessage(roomId, `⚠️ ${reason.slice(0, 300)}`).catch(() => {});
     }
   }
 

--- a/src/interfaces/nostr.ts
+++ b/src/interfaces/nostr.ts
@@ -338,8 +338,9 @@ export class NostrInterface implements Interface {
       if (isNoReply(reply)) return;
       await this.sendDM(senderPk, reply, mode);
     } catch (err: any) {
-      log.error("nostr", `turn failed for ${sender}: ${err.message || err}`);
-      await this.sendDM(senderPk, "Error processing message.", mode).catch(() => {});
+      const reason = String(err?.message || err || "Error processing message.");
+      log.error("nostr", `turn failed for ${sender}: ${reason}`);
+      await this.sendDM(senderPk, `⚠️ ${reason.slice(0, 300)}`, mode).catch(() => {});
     }
   }
 

--- a/src/interfaces/telegram.ts
+++ b/src/interfaces/telegram.ts
@@ -340,7 +340,23 @@ export class TelegramInterface implements Interface {
         }
       } catch (error: any) {
         clearInterval(typingInterval);
-        await this.editMessage(ctx, reply.message_id, `Error: ${error.message}`);
+        const reason = String(error?.message || error || "Error processing message.");
+        log.error("telegram", `turn failed: ${reason}`);
+        // Edit active placeholder message or reply if it was deleted
+        const errText = `⚠️ ${reason.slice(0, 300)}`;
+        try {
+          await this.editMessage(ctx, activeMessageId, errText);
+        } catch {
+          if (activeMessageId !== reply.message_id) {
+            try {
+              await this.editMessage(ctx, reply.message_id, errText);
+            } catch {
+              await ctx.reply(errText).catch(() => {});
+            }
+          } else {
+            await ctx.reply(errText).catch(() => {});
+          }
+        }
       }
     });
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -482,23 +482,64 @@ export class Runtime {
 }
 
 /** Clean error categorization from provider error chains */
-function parseProviderError(
+export function parseProviderError(
   streamError: unknown,
   caughtError: any
 ): { message: string; category: string } {
   const realError: any = streamError || caughtError;
   const lastErr = realError?.lastError || realError;
   const cause: any = lastErr?.cause || realError?.cause;
-  const status = lastErr?.statusCode || lastErr?.data?.error?.code;
-  const rawApiMsg = lastErr?.data?.error?.message || lastErr?.responseBody;
 
-  // Detect HTML error pages
+  // Extract HTTP status code across common error shapes
+  const status =
+    lastErr?.statusCode ??
+    realError?.statusCode ??
+    cause?.statusCode ??
+    lastErr?.status ??
+    realError?.status ??
+    lastErr?.data?.error?.code;
+
+  // Helper to test for HTML strings
   const isHtml = (s: unknown): boolean =>
     typeof s === "string" && s.includes("<html");
 
-  const apiMsg = isHtml(rawApiMsg)
-    ? null // discard HTML, fall through to status-based matching
-    : rawApiMsg;
+  // Attempt to parse JSON response body if string
+  let parsedBody: any = null;
+  const rawBody = lastErr?.responseBody ?? realError?.responseBody ?? cause?.responseBody;
+  if (typeof rawBody === "string" && !isHtml(rawBody)) {
+    try {
+      parsedBody = JSON.parse(rawBody);
+    } catch {
+      // not JSON
+    }
+  } else if (typeof rawBody === "object" && rawBody !== null) {
+    parsedBody = rawBody;
+  }
+
+  // Extract raw API error message if available
+  const rawApiMsg =
+    lastErr?.data?.error?.message ||
+    parsedBody?.error?.message ||
+    parsedBody?.message ||
+    parsedBody?.detail ||
+    (typeof rawBody === "string" && !isHtml(rawBody) ? rawBody : null);
+
+  const apiMsg = isHtml(rawApiMsg) ? null : rawApiMsg;
+
+  // Detect generic "Provider returned error" string without details
+  const isGenericProviderError = (msg: unknown): boolean =>
+    typeof msg === "string" && (msg === "Provider returned error" || msg.startsWith("APICallError: Provider returned error"));
+
+  // Clean, non-generic message from lastErr or realError
+  const lastMsg = !isGenericProviderError(lastErr?.message) && !isHtml(lastErr?.message) && !lastErr?.message?.includes("No output generated")
+    ? lastErr?.message
+    : null;
+  const causeMsg = !isGenericProviderError(cause?.message) && !isHtml(cause?.message)
+    ? cause?.message
+    : null;
+
+  // Detailed error explanation extracted from provider
+  const detailMsg = apiMsg || lastMsg || causeMsg;
 
   // Priority-ordered matchers: first match wins
   const matchers: Array<{
@@ -514,45 +555,54 @@ function parseProviderError(
     {
       test: () => status === 401 || status === 403,
       category: "auth",
-      message: "API authentication failed — check your API key in .kern/.env",
+      message: detailMsg && detailMsg !== "Provider returned error"
+        ? `API authentication failed (${status}): ${detailMsg}`
+        : "API authentication failed — check your API key in .kern/.env",
     },
     {
-      test: () => status === 429 || apiMsg?.includes?.("rate limit"),
+      test: () => status === 429 || detailMsg?.toLowerCase?.().includes("rate limit"),
       category: "rate_limit",
-      message: "Rate limit hit — wait a moment and try again",
+      message: detailMsg && !isGenericProviderError(detailMsg)
+        ? `Rate limit hit (429): ${detailMsg}`
+        : "Rate limit hit (429) — wait a moment and try again",
     },
     {
       test: () =>
         status === 402 ||
-        apiMsg?.includes?.("credit") ||
-        apiMsg?.includes?.("insufficient"),
+        detailMsg?.toLowerCase?.().includes("credit") ||
+        detailMsg?.toLowerCase?.().includes("insufficient"),
       category: "billing",
-      message:
-        "API credits exhausted — check your OpenRouter/provider balance",
+      message: detailMsg && !isGenericProviderError(detailMsg)
+        ? `API credits exhausted (402): ${detailMsg}`
+        : "API credits exhausted (402) — check your OpenRouter/provider balance",
     },
     {
-      test: () => status === 502 || isHtml(rawApiMsg),
+      test: () => status === 502 || isHtml(rawBody) || isHtml(lastErr?.message),
       category: "provider",
       message:
         "Provider returned 502 Bad Gateway — the upstream model may be temporarily unavailable",
     },
     {
-      test: () => !!apiMsg,
+      test: () => status === 503 || status === 504,
       category: "provider",
-      message: apiMsg,
+      message: detailMsg && !isGenericProviderError(detailMsg)
+        ? `Provider unavailable (${status}): ${detailMsg}`
+        : `Provider unavailable (${status}) — upstream service is overloaded or timed out`,
     },
     {
-      test: () =>
-        !!lastErr?.message &&
-        !lastErr.message.includes("No output generated") &&
-        !isHtml(lastErr.message),
+      test: () => !!detailMsg && !isGenericProviderError(detailMsg),
       category: "provider",
-      message: lastErr?.message,
+      message: status ? `Provider error (${status}): ${detailMsg}` : detailMsg,
     },
     {
       test: () => caughtError?.message?.includes?.("No output generated"),
       category: "no_output",
       message: `No response from model (${cause?.message || cause || lastErr?.message || "unknown cause"})`,
+    },
+    {
+      test: () => status !== undefined && status !== null,
+      category: "provider",
+      message: `Provider returned HTTP status ${status}`,
     },
   ];
 

--- a/test/provider-error.test.ts
+++ b/test/provider-error.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseProviderError } from "../src/runtime.js";
+
+test("parseProviderError: unwraps JSON responseBody on 429 rate limit error", () => {
+  const error = {
+    message: "Provider returned error",
+    statusCode: 429,
+    responseBody: JSON.stringify({
+      error: {
+        message: "Rate limit exceeded for model google/gemini-3.8-flash: 15 RPM",
+        code: 429,
+      },
+    }),
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "rate_limit");
+  assert.equal(
+    res.message,
+    "Rate limit hit (429): Rate limit exceeded for model google/gemini-3.8-flash: 15 RPM"
+  );
+});
+
+test("parseProviderError: handles rate limit when status code is 429 without response body", () => {
+  const error = {
+    message: "Provider returned error",
+    statusCode: 429,
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "rate_limit");
+  assert.equal(res.message, "Rate limit hit (429) — wait a moment and try again");
+});
+
+test("parseProviderError: unwraps 402 billing/credits exhaustion", () => {
+  const error = {
+    message: "Provider returned error",
+    statusCode: 402,
+    responseBody: JSON.stringify({
+      error: {
+        message: "Insufficient credits on account",
+      },
+    }),
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "billing");
+  assert.equal(
+    res.message,
+    "API credits exhausted (402): Insufficient credits on account"
+  );
+});
+
+test("parseProviderError: unwraps 401 auth failure with detail message", () => {
+  const error = {
+    message: "Provider returned error",
+    statusCode: 401,
+    responseBody: JSON.stringify({
+      error: {
+        message: "Invalid API Key provided",
+      },
+    }),
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "auth");
+  assert.equal(
+    res.message,
+    "API authentication failed (401): Invalid API Key provided"
+  );
+});
+
+test("parseProviderError: handles 502 HTML error page", () => {
+  const error = {
+    message: "Provider returned error",
+    statusCode: 502,
+    responseBody:
+      "<html><head><title>502 Bad Gateway</title></head><body>Cloudflare 502</body></html>",
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "provider");
+  assert.equal(
+    res.message,
+    "Provider returned 502 Bad Gateway — the upstream model may be temporarily unavailable"
+  );
+});
+
+test("parseProviderError: handles 503 / 504 provider overloaded", () => {
+  const error = {
+    statusCode: 503,
+    responseBody: JSON.stringify({
+      message: "Model engine is currently overloaded",
+    }),
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "provider");
+  assert.equal(
+    res.message,
+    "Provider unavailable (503): Model engine is currently overloaded"
+  );
+});
+
+test("parseProviderError: unwraps nested APICallError structure with cause", () => {
+  const error = {
+    name: "APICallError",
+    message: "APICallError: Provider returned error",
+    cause: {
+      statusCode: 400,
+      responseBody: JSON.stringify({
+        error: {
+          message: "Context length exceeded (requested 128000, max 64000)",
+        },
+      }),
+    },
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "provider");
+  assert.equal(
+    res.message,
+    "Provider error (400): Context length exceeded (requested 128000, max 64000)"
+  );
+});
+
+test("parseProviderError: unwraps network DNS resolution failure", () => {
+  const error = {
+    message: "fetch failed",
+    cause: {
+      code: "EAI_AGAIN",
+    },
+  };
+
+  const res = parseProviderError(null, error);
+  assert.equal(res.category, "network");
+  assert.equal(res.message, "DNS resolution failed — check network connection");
+});


### PR DESCRIPTION
Fixes #344.

### What & Why
When an upstream model provider returns an error (429 rate limit, 402 billing exhaustion, 401 auth, 400 context overflow), the AI SDK wraps it in an `APICallError` with `message: "Provider returned error"` and buries the actual error message inside a JSON string in `responseBody` or `cause`. Previously:
- `parseProviderError()` failed to parse `responseBody` JSON, falling back to the generic message.
- Chat interfaces (Discord, Matrix, Nostr, Telegram) either sent a generic placeholder (`"Error processing message."`) or silently deleted the placeholder on error.

### Changes
1. **`src/runtime.ts`**:
   - Parses `responseBody` JSON string or object to extract `error.message` / `message` / `detail`.
   - Inspects status codes across `statusCode` / `status` / `cause` and ignores generic `"Provider returned error"` strings when extracting the detailed error message.
   - Formats user-friendly category errors with real detail: `Rate limit hit (429): <upstream detail>`, `API credits exhausted (402): <detail>`, `Provider error (<status>): <detail>`.
2. **Interfaces (`discord.ts`, `matrix.ts`, `nostr.ts`, `telegram.ts`)**:
   - Deliver the actual parsed error string (`⚠️ Rate limit hit (429): ...`) to the chat instead of generic placeholders or silent drops.
3. **Tests (`test/provider-error.test.ts`)**:
   - Unit tests covering 429 rate limit JSON unwrapping, 402 billing, 401 auth, 502 HTML, 503/504, 400 context overflow, and DNS network failures.