### PR TITLE
feat(discord): add discord tool plugin (history, react, pins, user, raw)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## next
+
+### Features
+- **Discord inspection and interaction tool (`discord`)** — built-in plugin that allows the agent to inspect and interact with Discord: read channel or DM history (`history`), add emoji reactions (`react`), inspect pinned messages (`pins`), fetch user profiles (`user`), and execute arbitrary Discord REST API calls (`raw`).
+
 ## 0.36.0 (2026-09-10)
 
 ### Features

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -356,6 +356,7 @@ Direct integration via Discord Bot API gateway.
 - **Message Chunking**: Discord's 2,000-character limit is automatically split across clean message boundaries (newlines/spaces).
 - **Attachments**: Supports images, audio, video, and document uploads up to 25 MB.
 - **Outbound Messaging**: Send to Discord users or channels via the `message` tool with `interface: "discord"`.
+- **Discord Tool**: Agents with Discord active have access to the `discord` tool to read channel or DM history (`history`), add reactions (`react`), inspect pinned messages (`pins`), fetch user info (`user`), or execute arbitrary REST requests (`raw`).
 
 ## IRC
 

--- a/src/interfaces/discord.ts
+++ b/src/interfaces/discord.ts
@@ -10,6 +10,7 @@ import type { Attachment, Interface, StartOptions } from "./types.js";
 import type { PairingManager } from "../pairing.js";
 import { log } from "../log.js";
 import { isNoReply } from "../util.js";
+import { setDiscordClient } from "../plugins/discord/plugin.js";
 
 const MAX_DISCORD_MSG_LENGTH = 2000;
 const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
@@ -96,6 +97,7 @@ export class DiscordInterface implements Interface {
       this.botUserId = c.user.id;
       this._status = "connected";
       this._statusDetail = undefined;
+      setDiscordClient(this.client);
       if (this.retryTimeout) {
         clearTimeout(this.retryTimeout);
         this.retryTimeout = undefined;
@@ -254,6 +256,7 @@ export class DiscordInterface implements Interface {
       this.retryTimeout = undefined;
     }
     this._status = "disconnected";
+    setDiscordClient(null);
     try {
       this.client.destroy();
     } catch {}

--- a/src/plugins/discord/plugin.ts
+++ b/src/plugins/discord/plugin.ts
@@ -1,0 +1,27 @@
+import type { KernPlugin, PluginContext } from "../types.js";
+import { discordTool, setDiscordClient } from "./tools.js";
+import { log } from "../../log.js";
+
+export { setDiscordClient, getDiscordClient } from "./tools.js";
+
+export const discordPlugin: KernPlugin = {
+  name: "discord",
+
+  tools: {
+    discord: discordTool,
+  },
+
+  toolDescriptions: {
+    discord:
+      "Inspect and interact with Discord: read channel or DM history, add emoji reactions, view pinned messages, look up user profiles, or execute raw Discord REST API calls.",
+  },
+
+  async onStartup(ctx: PluginContext) {
+    // Client is set dynamically by DiscordInterface when started
+    log("discord", "discord plugin registered");
+  },
+
+  async onShutdown() {
+    setDiscordClient(null);
+  },
+};

--- a/src/plugins/discord/tools.ts
+++ b/src/plugins/discord/tools.ts
@@ -1,0 +1,248 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { Client } from "discord.js";
+
+let _client: Client | null = null;
+
+export function setDiscordClient(client: Client | null) {
+  _client = client;
+}
+
+export function getDiscordClient(): Client | null {
+  return _client;
+}
+
+export const discordTool = tool({
+  description:
+    "Inspect and interact with Discord: read channel or DM history, add emoji reactions, view pinned messages, look up user profiles, or execute raw Discord REST API calls.",
+  inputSchema: z.object({
+    action: z
+      .enum(["history", "react", "pins", "user", "raw"])
+      .describe(
+        "history: read recent messages in a channel or DM. react: add an emoji reaction to a message. pins: list pinned messages in a channel or DM. user: look up user profile by ID. raw: make an arbitrary Discord REST API request.",
+      ),
+    channel: z
+      .string()
+      .optional()
+      .describe("Channel ID or DM channel ID for history, react, or pins"),
+    messageId: z
+      .string()
+      .optional()
+      .describe("Message ID for react"),
+    emoji: z
+      .string()
+      .optional()
+      .describe("Emoji for react (Unicode character e.g. '👍', '👀', or custom emoji name:id 'name:123456789')"),
+    userId: z
+      .string()
+      .optional()
+      .describe("User ID for user lookup"),
+    limit: z
+      .number()
+      .optional()
+      .describe("Maximum items to return (default 20, max 100)"),
+    before: z
+      .string()
+      .optional()
+      .describe("Only get messages before this message ID (for history)"),
+    after: z
+      .string()
+      .optional()
+      .describe("Only get messages after this message ID (for history)"),
+    method: z
+      .enum(["GET", "POST", "PATCH", "PUT", "DELETE"])
+      .optional()
+      .describe("HTTP method for raw REST action (default: GET)"),
+    path: z
+      .string()
+      .optional()
+      .describe("REST API path for raw action (e.g. '/users/@me', '/channels/123/messages')"),
+    body: z
+      .string()
+      .optional()
+      .describe("JSON string payload for raw action (for POST, PATCH, PUT)"),
+  }),
+  execute: async ({
+    action,
+    channel,
+    messageId,
+    emoji,
+    userId,
+    limit = 20,
+    before,
+    after,
+    method = "GET",
+    path,
+    body,
+  }) => {
+    if (!_client) {
+      return "Error: Discord interface is not running or not configured on this agent.";
+    }
+
+    const client = _client;
+    const boundedLimit = Math.min(Math.max(1, limit), 100);
+
+    try {
+      switch (action) {
+        case "history": {
+          if (!channel) return "Error: channel is required for history";
+          let targetChannel: any = await client.channels.fetch(channel).catch(() => null);
+
+          // If not found as a channel, check if channel is a userId and try to open DM
+          if (!targetChannel) {
+            const user = await client.users.fetch(channel).catch(() => null);
+            if (user) {
+              targetChannel = await user.createDM().catch(() => null);
+            }
+          }
+
+          if (!targetChannel || !("messages" in targetChannel)) {
+            return `Error: Channel "${channel}" not found or is not a text channel.`;
+          }
+
+          const fetchOptions: any = { limit: boundedLimit };
+          if (before) fetchOptions.before = before;
+          if (after) fetchOptions.after = after;
+
+          const messages = await targetChannel.messages.fetch(fetchOptions);
+          if (messages.size === 0) {
+            return `No messages found in channel ${channel}.`;
+          }
+
+          const sorted = Array.from(messages.values()).sort(
+            (a: any, b: any) => a.createdTimestamp - b.createdTimestamp,
+          );
+
+          const lines = sorted.map((m: any) => {
+            const author = `${m.author.tag || m.author.username} (${m.author.id})`;
+            const ts = m.createdAt ? m.createdAt.toISOString() : "";
+            const reactions = m.reactions.cache
+              .map((r: any) => `${r.emoji.name} (${r.count})`)
+              .join(" ");
+            const rxStr = reactions ? ` [${reactions}]` : "";
+            const attachments = m.attachments.size > 0
+              ? ` [${m.attachments.map((a: any) => a.name || a.url).join(", ")}]`
+              : "";
+            return `[${ts}] [id: ${m.id}] ${author}: ${m.content || "(no text)"}${attachments}${rxStr}`;
+          });
+
+          return `History for ${channel} (${messages.size} messages):\n\n${lines.join("\n")}`;
+        }
+
+        case "react": {
+          if (!channel) return "Error: channel is required for react";
+          if (!messageId) return "Error: messageId is required for react";
+          if (!emoji) return "Error: emoji is required for react";
+
+          const targetChannel: any = await client.channels.fetch(channel).catch(() => null);
+          if (!targetChannel || !("messages" in targetChannel)) {
+            return `Error: Channel "${channel}" not found or is not a text channel.`;
+          }
+
+          const msg = await targetChannel.messages.fetch(messageId).catch(() => null);
+          if (!msg) {
+            return `Error: Message "${messageId}" not found in channel "${channel}".`;
+          }
+
+          await msg.react(emoji);
+          return `Added reaction ${emoji} to message ${messageId} in channel ${channel}.`;
+        }
+
+        case "pins": {
+          if (!channel) return "Error: channel is required for pins";
+          const targetChannel: any = await client.channels.fetch(channel).catch(() => null);
+          if (!targetChannel || !("messages" in targetChannel)) {
+            return `Error: Channel "${channel}" not found or is not a text channel.`;
+          }
+
+          const pins = await targetChannel.messages.fetchPinned();
+          if (pins.size === 0) {
+            return `No pinned messages found in channel ${channel}.`;
+          }
+
+          const lines = Array.from(pins.values()).map((m: any) => {
+            const author = `${m.author.tag || m.author.username} (${m.author.id})`;
+            const ts = m.createdAt ? m.createdAt.toISOString() : "";
+            return `[${ts}] [id: ${m.id}] ${author}: ${m.content || "(no text)"}`;
+          });
+
+          return `Pinned messages in ${channel} (${pins.size} pins):\n\n${lines.join("\n")}`;
+        }
+
+        case "user": {
+          if (!userId) return "Error: userId is required for user lookup";
+          const user = await client.users.fetch(userId).catch(() => null);
+          if (!user) {
+            return `User "${userId}" not found.`;
+          }
+
+          const info = [
+            `ID: ${user.id}`,
+            `Username: ${user.username}`,
+            `Global Name: ${user.globalName || "(none)"}`,
+            `Tag: ${user.tag}`,
+            `Bot: ${user.bot ? "yes" : "no"}`,
+            `Created At: ${user.createdAt.toISOString()}`,
+            user.avatarURL() ? `Avatar: ${user.avatarURL()}` : undefined,
+          ].filter(Boolean);
+
+          return `User info for ${userId}:\n\n${info.join("\n")}`;
+        }
+
+        case "raw": {
+          if (!path) return "Error: path is required for raw action";
+          const formattedPath = path.startsWith("/") ? path : `/${path}`;
+
+          let parsedBody: any = undefined;
+          if (body) {
+            try {
+              parsedBody = JSON.parse(body);
+            } catch (err: any) {
+              return `Error parsing JSON body: ${err.message}`;
+            }
+          }
+
+          const reqOptions: any = {};
+          if (parsedBody !== undefined) {
+            reqOptions.body = parsedBody;
+          }
+
+          const upperMethod = method.toUpperCase();
+          let res: any;
+
+          switch (upperMethod) {
+            case "GET":
+              res = await (client.rest as any).get(formattedPath, reqOptions);
+              break;
+            case "POST":
+              res = await (client.rest as any).post(formattedPath, reqOptions);
+              break;
+            case "PATCH":
+              res = await (client.rest as any).patch(formattedPath, reqOptions);
+              break;
+            case "PUT":
+              res = await (client.rest as any).put(formattedPath, reqOptions);
+              break;
+            case "DELETE":
+              res = await (client.rest as any).delete(formattedPath, reqOptions);
+              break;
+            default:
+              return `Unsupported method: ${method}`;
+          }
+
+          if (res === null || res === undefined) {
+            return `${upperMethod} ${formattedPath} succeeded with no response content.`;
+          }
+
+          const out = typeof res === "object" ? JSON.stringify(res, null, 2) : String(res);
+          return out.length > 25000 ? `${out.slice(0, 25000)}\n\n[truncated]` : out;
+        }
+
+        default:
+          return `Unknown action: ${action}`;
+      }
+    } catch (err: any) {
+      return `Discord API error: ${err.message || String(err)}`;
+    }
+  },
+});

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -8,6 +8,7 @@ import { mcpPlugin } from "./mcp/plugin.js";
 import { subagentsPlugin } from "./subagents/plugin.js";
 import { slackPlugin } from "./slack/plugin.js";
 import { ircPlugin } from "./irc/plugin.js";
+import { discordPlugin } from "./discord/plugin.js";
 import { log } from "../log.js";
 
 export type { KernPlugin, PluginContext, RouteHandler, ContextInjection, BeforeContextInfo } from "./types.js";
@@ -26,6 +27,7 @@ const availablePlugins: KernPlugin[] = [
   subagentsPlugin,
   slackPlugin,
   ircPlugin,
+  discordPlugin,
 ];
 
 /** Active plugin instances after loading */

--- a/test/discord-tool.test.ts
+++ b/test/discord-tool.test.ts
@@ -1,0 +1,196 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { discordTool, setDiscordClient } from "../src/plugins/discord/tools.js";
+
+test("discordTool: returns error when Discord interface is not configured", async () => {
+  setDiscordClient(null);
+  const res = await (discordTool as any).execute({ action: "history", channel: "123456" });
+  assert.match(res, /Discord interface is not running or not configured/);
+});
+
+test("discordTool: history action returns formatted messages", async () => {
+  const fakeChannel = {
+    messages: {
+      async fetch({ limit }: any) {
+        assert.equal(limit, 20);
+        return new Map([
+          [
+            "m1",
+            {
+              id: "m1",
+              content: "Hello from discord",
+              author: { username: "alice", tag: "alice#0001", id: "u1" },
+              createdAt: new Date("2026-09-10T12:00:00Z"),
+              createdTimestamp: 1000,
+              reactions: { cache: [] },
+              attachments: new Map(),
+            },
+          ],
+          [
+            "m2",
+            {
+              id: "m2",
+              content: "Second message",
+              author: { username: "bob", tag: "bob#0002", id: "u2" },
+              createdAt: new Date("2026-09-10T12:05:00Z"),
+              createdTimestamp: 2000,
+              reactions: { cache: [{ emoji: { name: "👍" }, count: 3 }] },
+              attachments: new Map(),
+            },
+          ],
+        ]);
+      },
+    },
+  };
+
+  const fakeClient: any = {
+    channels: {
+      async fetch(id: string) {
+        if (id === "123456") return fakeChannel;
+        return null;
+      },
+    },
+  };
+
+  setDiscordClient(fakeClient);
+  const res = await (discordTool as any).execute({ action: "history", channel: "123456" });
+  assert.match(res, /History for 123456 \(2 messages\):/);
+  assert.match(res, /\[id: m1\] alice#0001 \(u1\): Hello from discord/);
+  assert.match(res, /\[id: m2\] bob#0002 \(u2\): Second message \[👍 \(3\)\]/);
+});
+
+test("discordTool: react action adds emoji reaction", async () => {
+  let reactedEmoji = "";
+  const fakeChannel = {
+    messages: {
+      async fetch(id: string) {
+        if (id === "m1") {
+          return {
+            id: "m1",
+            react: async (e: string) => {
+              reactedEmoji = e;
+            },
+          };
+        }
+        return null;
+      },
+    },
+  };
+
+  const fakeClient: any = {
+    channels: {
+      async fetch(id: string) {
+        return id === "123456" ? fakeChannel : null;
+      },
+    },
+  };
+
+  setDiscordClient(fakeClient);
+  const res = await (discordTool as any).execute({
+    action: "react",
+    channel: "123456",
+    messageId: "m1",
+    emoji: "🔥",
+  });
+  assert.equal(reactedEmoji, "🔥");
+  assert.match(res, /Added reaction 🔥 to message m1 in channel 123456/);
+});
+
+test("discordTool: pins action lists pinned messages", async () => {
+  const fakeChannel = {
+    messages: {
+      async fetchPinned() {
+        return new Map([
+          [
+            "p1",
+            {
+              id: "p1",
+              content: "Pinned announcement",
+              author: { username: "admin", tag: "admin", id: "u0" },
+              createdAt: new Date("2026-09-01T00:00:00Z"),
+            },
+          ],
+        ]);
+      },
+    },
+  };
+
+  const fakeClient: any = {
+    channels: {
+      async fetch(id: string) {
+        return id === "123456" ? fakeChannel : null;
+      },
+    },
+  };
+
+  setDiscordClient(fakeClient);
+  const res = await (discordTool as any).execute({ action: "pins", channel: "123456" });
+  assert.match(res, /Pinned messages in 123456 \(1 pins\):/);
+  assert.match(res, /Pinned announcement/);
+});
+
+test("discordTool: user action fetches user profile", async () => {
+  const fakeClient: any = {
+    users: {
+      async fetch(id: string) {
+        if (id === "u123") {
+          return {
+            id: "u123",
+            username: "tester",
+            globalName: "Tester Operator",
+            tag: "tester",
+            bot: false,
+            createdAt: new Date("2026-01-01T00:00:00Z"),
+            avatarURL: () => "https://cdn.discordapp.com/avatars/u123/avatar.png",
+          };
+        }
+        return null;
+      },
+    },
+  };
+
+  setDiscordClient(fakeClient);
+  const res = await (discordTool as any).execute({ action: "user", userId: "u123" });
+  assert.match(res, /User info for u123:/);
+  assert.match(res, /Username: tester/);
+  assert.match(res, /Global Name: Tester Operator/);
+  assert.match(res, /Bot: no/);
+});
+
+test("discordTool: raw action executes REST request", async () => {
+  let calledPath = "";
+  let calledOptions: any = null;
+
+  const fakeClient: any = {
+    rest: {
+      async get(path: string, options: any) {
+        calledPath = path;
+        calledOptions = options;
+        return { id: "123", username: "mybot" };
+      },
+      async post(path: string, options: any) {
+        calledPath = path;
+        calledOptions = options;
+        return { ok: true };
+      },
+    },
+  };
+
+  setDiscordClient(fakeClient);
+
+  // Test GET
+  const resGet = await (discordTool as any).execute({ action: "raw", method: "GET", path: "/users/@me" });
+  assert.equal(calledPath, "/users/@me");
+  assert.match(resGet, /"username": "mybot"/);
+
+  // Test POST with body
+  const resPost = await (discordTool as any).execute({
+    action: "raw",
+    method: "POST",
+    path: "/channels/123/messages",
+    body: JSON.stringify({ content: "test" }),
+  });
+  assert.equal(calledPath, "/channels/123/messages");
+  assert.deepEqual(calledOptions.body, { content: "test" });
+  assert.match(resPost, /"ok": true/);
+});


### PR DESCRIPTION
### Summary
Adds a native `discord` inspection and interaction tool plugin for agents running on Discord (pattern matches `slack` and `irc` plugins).

### Capabilities
- **`history`**: Read message history in a channel or DM, formatted with sender ID/tag, timestamp, reactions, and attachments.
- **`react`**: Add an emoji reaction to any message (Unicode or custom `name:id`).
- **`pins`**: List pinned messages in a channel or DM.
- **`user`**: Look up user profile details by ID (username, global name, bot status, created timestamp, avatar).
- **`raw`**: Execute arbitrary Discord REST API calls directly via Discord's REST router (`GET`, `POST`, `PATCH`, `PUT`, `DELETE`) for full API flexibility without hardcoding every endpoint.

### Tests
- 6 dedicated unit tests covering missing client error, `history`, `react`, `pins`, `user`, and `raw` (`GET` and `POST` with body).
- All 62 test suites in kern pass clean.