### PR TITLE
feat: add telegram and openrouter inspection plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 - **Discord inspection and interaction tool (`discord`)** — built-in plugin that allows the agent to inspect and interact with Discord: read channel or DM history (`history`), add emoji reactions (`react`), inspect pinned messages (`pins`), fetch user profiles (`user`), and execute arbitrary Discord REST API calls (`raw`).
+- **Telegram inspection and interaction tool (`telegram`)** — built-in plugin that allows the agent to inspect and manage Telegram groups, channels, and chats: fetch chat details (`chat`), inspect chat administrators (`admins`), check member status (`member`), pin and unpin messages (`pin`, `unpin`), set emoji reactions (`react`), and execute arbitrary Telegram Bot API methods (`raw`).
+- **OpenRouter inspection tool (`openrouter`)** — built-in plugin that allows the agent to inspect its own OpenRouter API key limits, daily/weekly/monthly credit usage, and rate limits (`key`), search available models by query and category with pricing per million tokens and context lengths (`models`), and query detailed token generation stats and cost for specific generation IDs (`generation`).
 
 ## 0.36.0 (2026-09-10)
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -221,6 +221,7 @@ Long polling bot. Works behind NAT, no public URL needed.
 - Markdown converted to Telegram HTML
 - Graceful shutdown: polling stops cleanly on SIGTERM
 - 409 conflicts auto-retry after 5 seconds
+- **Telegram Tool**: Agents with Telegram active have access to the `telegram` tool to view chat details (`chat`), list chat administrators (`admins`), check member status (`member`), pin or unpin messages (`pin`, `unpin`), add emoji reactions (`react`), or execute arbitrary Telegram Bot API methods (`raw`).
 
 ## Slack
 

--- a/src/interfaces/telegram.ts
+++ b/src/interfaces/telegram.ts
@@ -4,6 +4,7 @@ import type { PairingManager } from "../pairing.js";
 import { log } from "../log.js";
 import { isNoReply } from "../util.js";
 import { synthesizeSpeech, stripForSpeech, ttsAvailable } from "../tts.js";
+import { setTelegramBot } from "../plugins/telegram/plugin.js";
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
@@ -83,6 +84,8 @@ export class TelegramInterface implements Interface {
   get statusDetail() { return this._statusDetail; }
 
   async start({ onMessage }: StartOptions): Promise<void> {
+    setTelegramBot(this.bot);
+
     // Register bot commands with Telegram
     this.bot.api.setMyCommands([
       { command: "status", description: "Show agent status" },
@@ -392,6 +395,7 @@ export class TelegramInterface implements Interface {
   }
 
   async stop(): Promise<void> {
+    setTelegramBot(null);
     await this.bot.stop();
   }
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -9,6 +9,8 @@ import { subagentsPlugin } from "./subagents/plugin.js";
 import { slackPlugin } from "./slack/plugin.js";
 import { ircPlugin } from "./irc/plugin.js";
 import { discordPlugin } from "./discord/plugin.js";
+import { telegramPlugin } from "./telegram/plugin.js";
+import { openrouterPlugin } from "./openrouter/plugin.js";
 import { log } from "../log.js";
 
 export type { KernPlugin, PluginContext, RouteHandler, ContextInjection, BeforeContextInfo } from "./types.js";
@@ -28,6 +30,8 @@ const availablePlugins: KernPlugin[] = [
   slackPlugin,
   ircPlugin,
   discordPlugin,
+  telegramPlugin,
+  openrouterPlugin,
 ];
 
 /** Active plugin instances after loading */

--- a/src/plugins/openrouter/plugin.ts
+++ b/src/plugins/openrouter/plugin.ts
@@ -1,0 +1,30 @@
+import type { KernPlugin, PluginContext } from "../types.js";
+import { openrouterTool, setOpenRouterKey } from "./tools.js";
+import { log } from "../../log.js";
+
+export { setOpenRouterKey, getOpenRouterKey } from "./tools.js";
+
+export const openrouterPlugin: KernPlugin = {
+  name: "openrouter",
+
+  tools: {
+    openrouter: openrouterTool,
+  },
+
+  toolDescriptions: {
+    openrouter:
+      "Inspect OpenRouter API key limits, daily/monthly spend, available models, pricing, and generation metadata.",
+  },
+
+  async onStartup(ctx: PluginContext) {
+    const key = process.env.OPENROUTER_API_KEY;
+    if (key) {
+      setOpenRouterKey(key);
+      log("openrouter", "openrouter plugin initialized");
+    }
+  },
+
+  async onShutdown() {
+    setOpenRouterKey(null);
+  },
+};

--- a/src/plugins/openrouter/tools.ts
+++ b/src/plugins/openrouter/tools.ts
@@ -1,0 +1,159 @@
+import { tool } from "ai";
+import { z } from "zod";
+
+const OPENROUTER_API_BASE = "https://openrouter.ai/api/v1";
+
+let _apiKey: string | null = null;
+
+export function setOpenRouterKey(key: string | null) {
+  _apiKey = key;
+}
+
+export function getOpenRouterKey(): string | null {
+  return _apiKey || process.env.OPENROUTER_API_KEY || null;
+}
+
+export const openrouterTool = tool({
+  description:
+    "Inspect OpenRouter API key limits, credit usage, available models, pricing, and generation metadata.",
+  inputSchema: z.object({
+    action: z
+      .enum(["key", "models", "generation"])
+      .describe(
+        "key: get current API key information, rate limits, credit balance, and daily/monthly usage. models: search or list available models with pricing, context length, and architecture. generation: get metadata, token usage, and cost for a specific generation ID.",
+      ),
+    query: z
+      .string()
+      .optional()
+      .describe("Search query for 'models' action (e.g. 'claude', 'gemini', 'qwen', 'deepseek')"),
+    category: z
+      .string()
+      .optional()
+      .describe("Filter models by category (e.g. 'programming', 'technology', 'science')"),
+    limit: z
+      .number()
+      .optional()
+      .describe("Maximum number of models to return (default 20, max 100)"),
+    generationId: z
+      .string()
+      .optional()
+      .describe("Generation ID for 'generation' action (e.g. 'gen-xxxxxx')"),
+  }),
+  execute: async ({ action, query, category, limit = 20, generationId }) => {
+    const key = getOpenRouterKey();
+    if (!key) {
+      return {
+        error: "OpenRouter API key is not available. Ensure OPENROUTER_API_KEY is configured in your environment.",
+      };
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      "X-OpenRouter-Title": "kern",
+    };
+
+    try {
+      switch (action) {
+        case "key": {
+          const res = await fetch(`${OPENROUTER_API_BASE}/key`, {
+            method: "GET",
+            headers,
+          });
+          if (!res.ok) {
+            const errText = await res.text();
+            return { error: `OpenRouter API error (${res.status}): ${errText}` };
+          }
+          const body = (await res.json()) as any;
+          const data = body.data || {};
+          return {
+            label: data.label,
+            usage: data.usage,
+            usageDaily: data.usage_daily,
+            usageWeekly: data.usage_weekly,
+            usageMonthly: data.usage_monthly,
+            byokUsage: data.byok_usage,
+            limit: data.limit,
+            limitRemaining: data.limit_remaining,
+            limitReset: data.limit_reset,
+            isFreeTier: data.is_free_tier,
+            rateLimit: data.rate_limit,
+          };
+        }
+
+        case "models": {
+          const url = new URL(`${OPENROUTER_API_BASE}/models`);
+          if (query) url.searchParams.set("q", query);
+          if (category) url.searchParams.set("category", category);
+
+          const res = await fetch(url.toString(), {
+            method: "GET",
+            headers,
+          });
+          if (!res.ok) {
+            const errText = await res.text();
+            return { error: `OpenRouter API error (${res.status}): ${errText}` };
+          }
+          const body = (await res.json()) as any;
+          const allModels: any[] = body.data || [];
+          const clampedLimit = Math.min(Math.max(1, limit), 100);
+          const sliced = allModels.slice(0, clampedLimit);
+
+          return {
+            total: allModels.length,
+            count: sliced.length,
+            models: sliced.map((m) => ({
+              id: m.id,
+              name: m.name,
+              contextLength: m.context_length,
+              pricing: {
+                promptPerMillion: m.pricing?.prompt ? Number(m.pricing.prompt) * 1_000_000 : 0,
+                completionPerMillion: m.pricing?.completion ? Number(m.pricing.completion) * 1_000_000 : 0,
+              },
+              modalities: m.architecture?.input_modalities,
+              topProvider: m.top_provider?.is_moderated ? "moderated" : "unmoderated",
+            })),
+          };
+        }
+
+        case "generation": {
+          if (!generationId) {
+            return { error: "generationId is required for 'generation' action" };
+          }
+          const url = new URL(`${OPENROUTER_API_BASE}/generation`);
+          url.searchParams.set("id", generationId);
+
+          const res = await fetch(url.toString(), {
+            method: "GET",
+            headers,
+          });
+          if (!res.ok) {
+            const errText = await res.text();
+            return { error: `OpenRouter API error (${res.status}): ${errText}` };
+          }
+          const body = (await res.json()) as any;
+          const data = body.data || {};
+          return {
+            id: data.id,
+            model: data.model,
+            providerName: data.provider_name,
+            totalCost: data.total_cost,
+            tokensPrompt: data.tokens_prompt,
+            tokensCompletion: data.tokens_completion,
+            nativeTokensCached: data.native_tokens_cached,
+            nativeTokensReasoning: data.native_tokens_reasoning,
+            generationTime: data.generation_time,
+            latency: data.latency,
+            finishReason: data.finish_reason,
+            createdAt: data.created_at,
+          };
+        }
+
+        default:
+          return { error: `Unknown action '${action}'` };
+      }
+    } catch (err: any) {
+      return { error: `OpenRouter API request failed: ${err.message}` };
+    }
+  },
+});

--- a/src/plugins/telegram/plugin.ts
+++ b/src/plugins/telegram/plugin.ts
@@ -1,0 +1,27 @@
+import type { KernPlugin, PluginContext } from "../types.js";
+import { telegramTool, setTelegramBot } from "./tools.js";
+import { log } from "../../log.js";
+
+export { setTelegramBot, getTelegramBot } from "./tools.js";
+
+export const telegramPlugin: KernPlugin = {
+  name: "telegram",
+
+  tools: {
+    telegram: telegramTool,
+  },
+
+  toolDescriptions: {
+    telegram:
+      "Inspect and interact with Telegram: view chat info, inspect administrators, check member status, pin or unpin messages, add reactions, or execute raw Telegram Bot API methods.",
+  },
+
+  async onStartup(ctx: PluginContext) {
+    // Bot is set dynamically by TelegramInterface when started
+    log("telegram", "telegram plugin registered");
+  },
+
+  async onShutdown() {
+    setTelegramBot(null);
+  },
+};

--- a/src/plugins/telegram/tools.ts
+++ b/src/plugins/telegram/tools.ts
@@ -1,0 +1,158 @@
+import { tool } from "ai";
+import { z } from "zod";
+import type { Bot } from "grammy";
+
+let _bot: Bot | null = null;
+
+export function setTelegramBot(bot: Bot | null) {
+  _bot = bot;
+}
+
+export function getTelegramBot(): Bot | null {
+  return _bot;
+}
+
+export const telegramTool = tool({
+  description:
+    "Inspect and interact with Telegram: view chat details, inspect administrators, check member status, pin or unpin messages, add emoji reactions, or execute raw Telegram Bot API methods.",
+  inputSchema: z.object({
+    action: z
+      .enum(["chat", "admins", "member", "pin", "unpin", "react", "raw"])
+      .describe(
+        "chat: get information about a chat or channel. admins: list administrators in a chat. member: get details of a specific member in a chat. pin: pin a message in a chat. unpin: unpin a message (or all) in a chat. react: add or set emoji reaction on a message. raw: call any Telegram Bot API method directly.",
+      ),
+    chatId: z
+      .string()
+      .optional()
+      .describe("Chat ID or channel username (e.g. '@channelusername' or '-1001234567890')"),
+    userId: z
+      .number()
+      .optional()
+      .describe("User ID for 'member' action"),
+    messageId: z
+      .number()
+      .optional()
+      .describe("Message ID for 'pin', 'unpin', or 'react'"),
+    emoji: z
+      .string()
+      .optional()
+      .describe("Emoji for 'react' (e.g. '👍', '🔥', '🎉')"),
+    method: z
+      .string()
+      .optional()
+      .describe("API method name for 'raw' action (e.g. 'getMe', 'exportChatInviteLink', 'setChatTitle')"),
+    params: z
+      .record(z.any())
+      .optional()
+      .describe("Parameters object for 'raw' action"),
+  }),
+  execute: async ({ action, chatId, userId, messageId, emoji, method, params }) => {
+    if (!_bot) {
+      return {
+        error: "Telegram client is not available. Ensure TELEGRAM_BOT_TOKEN is configured and Telegram is enabled.",
+      };
+    }
+
+    try {
+      switch (action) {
+        case "chat": {
+          if (!chatId) return { error: "chatId is required for 'chat' action" };
+          const chat = await _bot.api.getChat(chatId);
+          return {
+            id: chat.id,
+            type: chat.type,
+            title: "title" in chat ? chat.title : undefined,
+            username: "username" in chat ? chat.username : undefined,
+            description: "description" in chat ? chat.description : undefined,
+            inviteLink: "invite_link" in chat ? chat.invite_link : undefined,
+            pinnedMessage: "pinned_message" in chat && chat.pinned_message ? {
+              messageId: chat.pinned_message.message_id,
+              date: chat.pinned_message.date,
+              text: chat.pinned_message.text,
+            } : undefined,
+          };
+        }
+
+        case "admins": {
+          if (!chatId) return { error: "chatId is required for 'admins' action" };
+          const admins = await _bot.api.getChatAdministrators(chatId);
+          return {
+            count: admins.length,
+            administrators: admins.map((a) => ({
+              status: a.status,
+              user: {
+                id: a.user.id,
+                isBot: a.user.is_bot,
+                firstName: a.user.first_name,
+                lastName: a.user.last_name,
+                username: a.user.username,
+              },
+              customTitle: "custom_title" in a ? a.custom_title : undefined,
+              isAnonymous: "is_anonymous" in a ? a.is_anonymous : false,
+            })),
+          };
+        }
+
+        case "member": {
+          if (!chatId) return { error: "chatId is required for 'member' action" };
+          if (!userId) return { error: "userId is required for 'member' action" };
+          const member = await _bot.api.getChatMember(chatId, userId);
+          return {
+            status: member.status,
+            user: {
+              id: member.user.id,
+              isBot: member.user.is_bot,
+              firstName: member.user.first_name,
+              lastName: member.user.last_name,
+              username: member.user.username,
+            },
+            untilDate: "until_date" in member ? member.until_date : undefined,
+            customTitle: "custom_title" in member ? member.custom_title : undefined,
+          };
+        }
+
+        case "pin": {
+          if (!chatId) return { error: "chatId is required for 'pin' action" };
+          if (!messageId) return { error: "messageId is required for 'pin' action" };
+          await _bot.api.pinChatMessage(chatId, messageId);
+          return { success: true, message: `Pinned message ${messageId} in chat ${chatId}` };
+        }
+
+        case "unpin": {
+          if (!chatId) return { error: "chatId is required for 'unpin' action" };
+          if (messageId) {
+            await _bot.api.unpinChatMessage(chatId, messageId);
+            return { success: true, message: `Unpinned message ${messageId} in chat ${chatId}` };
+          }
+          await _bot.api.unpinAllChatMessages(chatId);
+          return { success: true, message: `Unpinned all messages in chat ${chatId}` };
+        }
+
+        case "react": {
+          if (!chatId) return { error: "chatId is required for 'react' action" };
+          if (!messageId) return { error: "messageId is required for 'react' action" };
+          if (!emoji) return { error: "emoji is required for 'react' action" };
+          await _bot.api.setMessageReaction(chatId, messageId, [
+            { type: "emoji", emoji: emoji as any },
+          ]);
+          return { success: true, emoji, messageId, chatId };
+        }
+
+        case "raw": {
+          if (!method) return { error: "method is required for 'raw' action (e.g. 'getMe', 'exportChatInviteLink')" };
+          const rawFn = (_bot.api.raw as any)[method];
+          if (typeof rawFn !== "function") {
+            return { error: `Unknown Telegram Bot API method '${method}'` };
+          }
+          const result = await rawFn.call(_bot.api.raw, params || {});
+          return { result };
+        }
+
+        default:
+          return { error: `Unknown action '${action}'` };
+      }
+    } catch (err: any) {
+      return { error: `Telegram API error: ${err.message}` };
+    }
+  },
+});

--- a/test/openrouter-tool.test.ts
+++ b/test/openrouter-tool.test.ts
@@ -1,0 +1,156 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { openrouterTool, setOpenRouterKey } from "../src/plugins/openrouter/tools.js";
+
+const origFetch = globalThis.fetch;
+
+test("openrouterTool: returns error when api key is not set", async () => {
+  setOpenRouterKey(null);
+  delete process.env.OPENROUTER_API_KEY;
+  const result = await (openrouterTool as any).execute({ action: "key" });
+  assert.ok(result.error);
+  assert.match(result.error, /OpenRouter API key is not available/);
+});
+
+test("openrouterTool: handles 'key' action", async () => {
+  setOpenRouterKey("sk-or-test-key");
+  const mockData = {
+    label: "sk-or-test...123",
+    usage: 12.5,
+    usage_daily: 2.1,
+    usage_weekly: 5.4,
+    usage_monthly: 12.5,
+    byok_usage: 0,
+    limit: 100,
+    limit_remaining: 87.5,
+    limit_reset: "monthly",
+    is_free_tier: false,
+    rate_limit: { requests: 1000, interval: "1h" },
+  };
+
+  let fetchedUrl = "";
+  let fetchedOptions: any = null;
+  globalThis.fetch = (async (url: any, opts: any) => {
+    fetchedUrl = url.toString();
+    fetchedOptions = opts;
+    return {
+      ok: true,
+      async json() {
+        return { data: mockData };
+      },
+    } as any;
+  }) as any;
+
+  try {
+    const result = await (openrouterTool as any).execute({ action: "key" });
+    assert.equal(fetchedUrl, "https://openrouter.ai/api/v1/key");
+    assert.equal(fetchedOptions.headers.Authorization, "Bearer sk-or-test-key");
+    assert.deepEqual(result, {
+      label: "sk-or-test...123",
+      usage: 12.5,
+      usageDaily: 2.1,
+      usageWeekly: 5.4,
+      usageMonthly: 12.5,
+      byokUsage: 0,
+      limit: 100,
+      limitRemaining: 87.5,
+      limitReset: "monthly",
+      isFreeTier: false,
+      rateLimit: { requests: 1000, interval: "1h" },
+    });
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("openrouterTool: handles 'models' action", async () => {
+  setOpenRouterKey("sk-or-test-key");
+  const mockModels = [
+    {
+      id: "anthropic/claude-3.5-sonnet",
+      name: "Claude 3.5 Sonnet",
+      context_length: 200000,
+      pricing: { prompt: "0.000003", completion: "0.000015" },
+      architecture: { input_modalities: ["text", "image"] },
+      top_provider: { is_moderated: true },
+    },
+    {
+      id: "deepseek/deepseek-chat",
+      name: "DeepSeek V3",
+      context_length: 64000,
+      pricing: { prompt: "0.00000014", completion: "0.00000028" },
+      architecture: { input_modalities: ["text"] },
+      top_provider: { is_moderated: false },
+    },
+  ];
+
+  let fetchedUrl = "";
+  globalThis.fetch = (async (url: any) => {
+    fetchedUrl = url.toString();
+    return {
+      ok: true,
+      async json() {
+        return { data: mockModels };
+      },
+    } as any;
+  }) as any;
+
+  try {
+    const result = await (openrouterTool as any).execute({
+      action: "models",
+      query: "claude",
+      limit: 10,
+    });
+
+    assert.equal(fetchedUrl, "https://openrouter.ai/api/v1/models?q=claude");
+    assert.equal(result.total, 2);
+    assert.equal(result.count, 2);
+    assert.equal(result.models[0].pricing.promptPerMillion, 3);
+    assert.equal(result.models[0].pricing.completionPerMillion, 15);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});
+
+test("openrouterTool: handles 'generation' action", async () => {
+  setOpenRouterKey("sk-or-test-key");
+  const mockGen = {
+    id: "gen-12345",
+    model: "anthropic/claude-3.5-sonnet",
+    provider_name: "Anthropic",
+    total_cost: 0.0025,
+    tokens_prompt: 500,
+    tokens_completion: 120,
+    native_tokens_cached: 400,
+    native_tokens_reasoning: 0,
+    generation_time: 1400,
+    latency: 1450,
+    finish_reason: "stop",
+    created_at: "2026-09-10T20:00:00Z",
+  };
+
+  let fetchedUrl = "";
+  globalThis.fetch = (async (url: any) => {
+    fetchedUrl = url.toString();
+    return {
+      ok: true,
+      async json() {
+        return { data: mockGen };
+      },
+    } as any;
+  }) as any;
+
+  try {
+    const result = await (openrouterTool as any).execute({
+      action: "generation",
+      generationId: "gen-12345",
+    });
+
+    assert.equal(fetchedUrl, "https://openrouter.ai/api/v1/generation?id=gen-12345");
+    assert.equal(result.id, "gen-12345");
+    assert.equal(result.totalCost, 0.0025);
+    assert.equal(result.tokensPrompt, 500);
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+});

--- a/test/telegram-tool.test.ts
+++ b/test/telegram-tool.test.ts
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { telegramTool, setTelegramBot } from "../src/plugins/telegram/tools.js";
+
+test("telegramTool: returns error when telegram bot is not set", async () => {
+  setTelegramBot(null);
+  const result = await (telegramTool as any).execute({ action: "chat", chatId: "12345" });
+  assert.ok(result.error);
+  assert.match(result.error, /Telegram client is not available/);
+});
+
+test("telegramTool: handles 'chat' action", async () => {
+  let calledWith: string | null = null;
+  const mockBot = {
+    api: {
+      async getChat(chatId: string) {
+        calledWith = chatId;
+        return {
+          id: 12345,
+          type: "supergroup",
+          title: "Homelab Chat",
+          username: "homelab",
+          description: "Homelab group chat",
+        };
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({ action: "chat", chatId: "12345" });
+  assert.equal(calledWith, "12345");
+  assert.deepEqual(result, {
+    id: 12345,
+    type: "supergroup",
+    title: "Homelab Chat",
+    username: "homelab",
+    description: "Homelab group chat",
+    inviteLink: undefined,
+    pinnedMessage: undefined,
+  });
+});
+
+test("telegramTool: handles 'admins' action", async () => {
+  let calledWith: string | null = null;
+  const mockBot = {
+    api: {
+      async getChatAdministrators(chatId: string) {
+        calledWith = chatId;
+        return [
+          {
+            status: "creator",
+            user: { id: 111, is_bot: false, first_name: "Oguz", username: "oguz" },
+            is_anonymous: false,
+          },
+          {
+            status: "administrator",
+            user: { id: 222, is_bot: true, first_name: "Atlas", username: "atlas_bot" },
+            custom_title: "Agent",
+            is_anonymous: false,
+          },
+        ];
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({ action: "admins", chatId: "-100123" });
+  assert.equal(calledWith, "-100123");
+  assert.equal(result.count, 2);
+  assert.equal(result.administrators[0].user.username, "oguz");
+  assert.equal(result.administrators[1].customTitle, "Agent");
+});
+
+test("telegramTool: handles 'member' action", async () => {
+  let calledChat: string | null = null;
+  let calledUser: number | null = null;
+  const mockBot = {
+    api: {
+      async getChatMember(chatId: string, userId: number) {
+        calledChat = chatId;
+        calledUser = userId;
+        return {
+          status: "member",
+          user: { id: 111, is_bot: false, first_name: "Oguz", username: "oguz" },
+        };
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({ action: "member", chatId: "-100123", userId: 111 });
+  assert.equal(calledChat, "-100123");
+  assert.equal(calledUser, 111);
+  assert.equal(result.status, "member");
+  assert.equal(result.user.username, "oguz");
+});
+
+test("telegramTool: handles 'pin' action", async () => {
+  let calledPin: [string, number] | null = null;
+  const mockBot = {
+    api: {
+      async pinChatMessage(chatId: string, messageId: number) {
+        calledPin = [chatId, messageId];
+        return true;
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({ action: "pin", chatId: "-100123", messageId: 99 });
+  assert.deepEqual(calledPin, ["-100123", 99]);
+  assert.equal(result.success, true);
+});
+
+test("telegramTool: handles 'unpin' action with specific messageId", async () => {
+  let calledUnpin: [string, number] | null = null;
+  const mockBot = {
+    api: {
+      async unpinChatMessage(chatId: string, messageId: number) {
+        calledUnpin = [chatId, messageId];
+        return true;
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({ action: "unpin", chatId: "-100123", messageId: 99 });
+  assert.deepEqual(calledUnpin, ["-100123", 99]);
+  assert.equal(result.success, true);
+});
+
+test("telegramTool: handles 'react' action", async () => {
+  let calledReact: any = null;
+  const mockBot = {
+    api: {
+      async setMessageReaction(chatId: string, messageId: number, reaction: any[]) {
+        calledReact = { chatId, messageId, reaction };
+        return true;
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({
+    action: "react",
+    chatId: "-100123",
+    messageId: 99,
+    emoji: "👍",
+  });
+  assert.deepEqual(calledReact, {
+    chatId: "-100123",
+    messageId: 99,
+    reaction: [{ type: "emoji", emoji: "👍" }],
+  });
+  assert.equal(result.success, true);
+  assert.equal(result.emoji, "👍");
+});
+
+test("telegramTool: handles 'raw' action", async () => {
+  let calledRawWith: any = null;
+  const mockBot = {
+    api: {
+      raw: {
+        async getMe(params: any) {
+          calledRawWith = params;
+          return { id: 123, is_bot: true, first_name: "Atlas" };
+        },
+      },
+    },
+  } as any;
+
+  setTelegramBot(mockBot);
+  const result = await (telegramTool as any).execute({
+    action: "raw",
+    method: "getMe",
+  });
+  assert.deepEqual(calledRawWith, {});
+  assert.deepEqual(result, { result: { id: 123, is_bot: true, first_name: "Atlas" } });
+});


### PR DESCRIPTION
### Summary

Adds two modular plugins for on-demand platform inspection and self-awareness:

1. **Telegram Plugin (`telegram`)**:
   - `chat`: Fetch chat metadata, description, title, pinned message, invite link
   - `admins`: Fetch chat administrators and creator info
   - `member`: Check specific member status and role
   - `pin` / `unpin`: Pin or unpin chat messages
   - `react`: Add emoji reactions to messages
   - `raw`: Escape hatch to call any Telegram Bot API method dynamically via grammY

2. **OpenRouter Plugin (`openrouter`)**:
   - `key`: Inspect current API key usage, daily/weekly/monthly spend, limits, and rate limits
   - `models`: Query and search available models with pricing per million tokens, context lengths, and modalities
   - `generation`: Fetch generation metadata, exact token counts, and cost by generation ID

### Tests & Build
- Added `test/telegram-tool.test.ts` and `test/openrouter-tool.test.ts`
- All 25 interface & plugin unit tests pass
- Full production build compiles clean