### PR TITLE
feat(matrix): convert markdown to org.matrix.custom.html formatted_body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - **Telegram inspection and interaction tool (`telegram`)** — built-in plugin that allows the agent to inspect and manage Telegram groups, channels, and chats: fetch chat details (`chat`), inspect chat administrators (`admins`), check member status (`member`), pin and unpin messages (`pin`, `unpin`), set emoji reactions (`react`), and execute arbitrary Telegram Bot API methods (`raw`).
 - **OpenRouter inspection tool (`openrouter`)** — built-in plugin that allows the agent to inspect its own OpenRouter API key limits, daily/weekly/monthly credit usage, and rate limits (`key`), search available models by query and category with pricing per million tokens and context lengths (`models`), and query detailed token generation stats and cost for specific generation IDs (`generation`).
 
+### Improvements
+- **Matrix markdown to HTML formatting (`org.matrix.custom.html`)** — Matrix messages now format markdown text into compliant HTML with `formatted_body`, enabling rich rendering for headers, code blocks with language tags, inline code, bold/italic, blockquotes, unordered lists, links, and strikethroughs across Matrix web and desktop clients like Cinny and Element. Plain text `body` is preserved for terminal/bridge clients.
+
 ## 0.36.0 (2026-09-10)
 
 ### Features

--- a/src/interfaces/matrix.ts
+++ b/src/interfaces/matrix.ts
@@ -227,10 +227,20 @@ export class MatrixInterface implements Interface {
 
   private async sendMessage(roomId: string, body: string): Promise<void> {
     const txnId = `kern-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const formatted = mdToMatrixHtml(body);
+    const payload: Record<string, unknown> = {
+      msgtype: "m.text",
+      body,
+    };
+    if (formatted) {
+      payload.format = "org.matrix.custom.html";
+      payload.formatted_body = formatted;
+    }
+
     await this.api(
       "PUT",
       `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${txnId}`,
-      { msgtype: "m.text", body },
+      payload,
     );
   }
 
@@ -267,6 +277,104 @@ export class MatrixInterface implements Interface {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Convert markdown to Matrix-compliant HTML (`org.matrix.custom.html`).
+ * Returns undefined if no markdown constructs are detected.
+ */
+export function mdToMatrixHtml(text: string): string | undefined {
+  if (!/[*_`~#\[\]>-]/.test(text)) {
+    return undefined;
+  }
+
+  // 1. Extract and protect code blocks
+  const codeBlocks: string[] = [];
+  let html = text.replace(/```(\w*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+    const escapedCode = escapeHtml(code.replace(/\n$/, ""));
+    const langAttr = lang ? ` class="language-${escapeHtml(lang)}"` : "";
+    const placeholder = `\x00BLOCK_${codeBlocks.length}\x00`;
+    codeBlocks.push(`<pre><code${langAttr}>${escapedCode}</code></pre>`);
+    return placeholder;
+  });
+
+  // 2. Extract and protect inline code
+  const inlineCodes: string[] = [];
+  html = html.replace(/`([^`\n]+)`/g, (_, code) => {
+    const placeholder = `\x00INLINE_${inlineCodes.length}\x00`;
+    inlineCodes.push(`<code>${escapeHtml(code)}</code>`);
+    return placeholder;
+  });
+
+  // 3. Escape raw HTML entities in remaining text
+  html = escapeHtml(html);
+
+  // 4. Headers: # Heading -> <h1>Heading</h1>
+  html = html.replace(/^######\s+(.+)$/gm, "<h6>$1</h6>");
+  html = html.replace(/^#####\s+(.+)$/gm, "<h5>$1</h5>");
+  html = html.replace(/^####\s+(.+)$/gm, "<h4>$1</h4>");
+  html = html.replace(/^###\s+(.+)$/gm, "<h3>$1</h3>");
+  html = html.replace(/^##\s+(.+)$/gm, "<h2>$1</h2>");
+  html = html.replace(/^#\s+(.+)$/gm, "<h1>$1</h1>");
+
+  // 5. Blockquotes: &gt; line (since &gt; was escaped from >)
+  html = html.replace(/^&gt;\s*(.+)$/gm, "<blockquote>$1</blockquote>");
+  html = html.replace(/<\/blockquote>\n<blockquote>/g, "<br />");
+
+  // 6. Links: [text](url)
+  html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2">$1</a>');
+
+  // 7. Bold: **text** or __text__
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/__(.+?)__/g, "<strong>$1</strong>");
+
+  // 8. Italic: *text* or _text_
+  html = html.replace(/(?<![*<])\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>");
+  html = html.replace(/\b_([^_]+)_\b/g, "<em>$1</em>");
+
+  // 9. Strikethrough: ~~text~~
+  html = html.replace(/~~(.+?)~~/g, "<del>$1</del>");
+
+  // 10. Unordered lists: - item or * item
+  html = html.replace(/^[*-]\s+(.+)$/gm, "<li>$1</li>");
+  html = html.replace(/(<li>.*<\/li>(\n|$))+/g, (match) => `<ul>\n${match.trimEnd()}\n</ul>\n`);
+
+  // 11. Restore inline code and code blocks
+  inlineCodes.forEach((code, i) => {
+    html = html.replace(`\x00INLINE_${i}\x00`, code);
+  });
+  codeBlocks.forEach((block, i) => {
+    html = html.replace(`\x00BLOCK_${i}\x00`, block);
+  });
+
+  // 12. Convert newlines to <br /> outside pre/ul/blockquote/h1-6 tags
+  const parts = html.split(
+    /(<pre>[\s\S]*?<\/pre>|<ul>[\s\S]*?<\/ul>|<h[1-6]>[\s\S]*?<\/h[1-6]>|<blockquote>[\s\S]*?<\/blockquote>)/g,
+  );
+  html = parts
+    .map((part) => {
+      if (
+        part.startsWith("<pre>") ||
+        part.startsWith("<ul>") ||
+        part.startsWith("<h") ||
+        part.startsWith("<blockquote>")
+      ) {
+        return part;
+      }
+      return part.replace(/\n/g, "<br />");
+    })
+    .join("");
+
+  return html;
 }
 
 // Minimal typings for the parts of /sync we care about

--- a/test/matrix.test.ts
+++ b/test/matrix.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mdToMatrixHtml } from "../src/interfaces/matrix.ts";
+
+test("mdToMatrixHtml: plain text returns undefined", () => {
+  assert.equal(mdToMatrixHtml("Hello world!"), undefined);
+});
+
+test("mdToMatrixHtml: formatting bold, italic, inline code", () => {
+  const result = mdToMatrixHtml("Hello **bold** and *italic* with `code`");
+  assert.ok(result);
+  assert.ok(result.includes("<strong>bold</strong>"));
+  assert.ok(result.includes("<em>italic</em>"));
+  assert.ok(result.includes("<code>code</code>"));
+});
+
+test("mdToMatrixHtml: code blocks with language and HTML escaping", () => {
+  const input = "Check this:\n```ts\nconst a = 1 < 2 && 3 > 0;\n```";
+  const result = mdToMatrixHtml(input);
+  assert.ok(result);
+  assert.ok(result.includes('<pre><code class="language-ts">const a = 1 &lt; 2 &amp;&amp; 3 &gt; 0;</code></pre>'));
+});
+
+test("mdToMatrixHtml: lists and blockquotes", () => {
+  const input = "> A famous quote\n\n- item 1\n- item 2";
+  const result = mdToMatrixHtml(input);
+  assert.ok(result);
+  assert.ok(result.includes("<blockquote>A famous quote</blockquote>"));
+  assert.ok(result.includes("<ul>\n<li>item 1</li>\n<li>item 2</li>\n</ul>"));
+});
+
+test("mdToMatrixHtml: links and strikethrough", () => {
+  const input = "Visit [Matrix](https://matrix.org) or ~~old link~~";
+  const result = mdToMatrixHtml(input);
+  assert.ok(result);
+  assert.ok(result.includes('<a href="https://matrix.org">Matrix</a>'));
+  assert.ok(result.includes("<del>old link</del>"));
+});


### PR DESCRIPTION
Matrix specification uses HTML (`org.matrix.custom.html`) in `formatted_body` for rich text rendering across clients like Cinny and Element.

### Changes
- Implemented `mdToMatrixHtml` utility in `src/interfaces/matrix.ts` to parse:
  - Code blocks with language tags (`<pre><code class="language-...">`)
  - Inline code (`<code>`)
  - Bold (`<strong>`), Italic (`<em>`), Strikethrough (`<del>`)
  - Headers 1-6 (`<h1>` - `<h6>`)
  - Blockquotes (`<blockquote>`)
  - Unordered lists (`<ul><li>...`)
  - Links (`<a href="...">`)
  - Linebreaks outside pre/block tags (`<br />`)
  - Full HTML escaping of untrusted message text
- Extended `sendMessage` to set `format: "org.matrix.custom.html"` and `formatted_body` when markdown constructs are present.
- Added comprehensive unit tests in `test/matrix.test.ts`.