### PR TITLE
feat(matrix): support inbound media attachments (images, audio, video, files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 ## next
 
 ### Features
+- **Matrix inbound media attachment support** — support for inbound images (`m.image`), files/documents (`m.file`), audio (`m.audio`), and video (`m.video`) uploaded by users in Matrix rooms and direct chats. Attachments are downloaded from the homeserver via Matrix media download endpoints and fed directly into the runtime's media pipeline for vision analysis, pre-digest summaries, and tool access.
 - **Discord inspection and interaction tool (`discord`)** — built-in plugin that allows the agent to inspect and interact with Discord: read channel or DM history (`history`), add emoji reactions (`react`), inspect pinned messages (`pins`), fetch user profiles (`user`), and execute arbitrary Discord REST API calls (`raw`).
 - **Telegram inspection and interaction tool (`telegram`)** — built-in plugin that allows the agent to inspect and manage Telegram groups, channels, and chats: fetch chat details (`chat`), inspect chat administrators (`admins`), check member status (`member`), pin and unpin messages (`pin`, `unpin`), set emoji reactions (`react`), and execute arbitrary Telegram Bot API methods (`raw`).
 - **OpenRouter inspection tool (`openrouter`)** — built-in plugin that allows the agent to inspect its own OpenRouter API key limits, daily/weekly/monthly credit usage, and rate limits (`key`), search available models by query and category with pricing per million tokens and context lengths (`models`), and query detailed token generation stats and cost for specific generation IDs (`generation`).
 
 ### Improvements
-- **Matrix typing indicator refresh interval** — reduced Matrix typing notification refresh interval from 20s to 6s. Matrix clients (such as Cinny and Element) auto-clear typing indicators if not refreshed within ~10 seconds; the shorter refresh interval keeps the typing indicator continuously visible during multi-tool execution and longer model responses.
+- **Matrix typing indicator refresh interval** ([#352](https://github.com/oguzbilgic/kern-ai/pull/352)) — reduced Matrix typing notification refresh interval to 3s (down from 20s). Matrix clients like Cinny hardcode a 5-second client-side typing indicator timeout; refreshing every 3s prevents the typing bubble from flickering or disappearing during multi-step tool calls and longer responses.
 - **Matrix markdown to HTML formatting (`org.matrix.custom.html`)** ([#351](https://github.com/oguzbilgic/kern-ai/pull/351)) — Matrix messages now format markdown text into compliant HTML with `formatted_body`, enabling rich rendering for headers, code blocks with language tags, inline code, bold/italic, blockquotes, unordered lists, links, and strikethroughs across Matrix web and desktop clients like Cinny and Element. Plain text `body` is preserved for terminal/bridge clients.
 
 ## 0.36.0 (2026-09-10)

--- a/src/interfaces/matrix.ts
+++ b/src/interfaces/matrix.ts
@@ -1,17 +1,27 @@
-import type { Interface, StartOptions } from "./types.js";
+import type { Interface, StartOptions, Attachment } from "./types.js";
 import type { PairingManager } from "../pairing.js";
 import { log } from "../log.js";
 import { isNoReply } from "../util.js";
 
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+export function mimeToType(mime: string): Attachment["type"] {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  return "document";
+}
+
 /**
  * Matrix interface — long-polls /sync, accepts invites, replies via /send.
  *
- * MVP scope:
+ * Scope:
  * - Text messages in/out
  * - Typing indicators while the agent is thinking
+ * - Inbound media attachments (images, audio, video, files)
  * - Auto-accept invites (any inviter; pairing still gates message handling)
  * - Pairing enforced in every room (DM and group) before messages are processed
- * - No E2E encryption, no media, no reactions
+ * - No E2E encryption, no reactions
  *
  * Config via env:
  *   MATRIX_HOMESERVER     e.g. http://matrix:8008
@@ -132,11 +142,14 @@ export class MatrixInterface implements Interface {
           for (const ev of events) {
             if (ev.type !== "m.room.message") continue;
             if (ev.sender === this.userId) continue; // our own sends
-            if (ev.content?.msgtype !== "m.text") continue; // skip media for MVP
-            const body = ev.content.body || "";
-            if (!body) continue;
+            const content = ev.content || {};
+            const msgtype = typeof content.msgtype === "string" ? content.msgtype : "";
+            const supportedMsgTypes = ["m.text", "m.image", "m.file", "m.audio", "m.video"];
+            if (!supportedMsgTypes.includes(msgtype)) continue;
+
+            const body = content.body || "";
             // Fire and forget — don't block the sync loop on a long turn
-            this.handleIncoming(roomId, ev.sender, body, onMessage).catch((err) => {
+            this.handleIncoming(roomId, ev.sender, body, content, onMessage).catch((err) => {
               log.error("matrix", `handle incoming failed: ${err.message || err}`);
             });
           }
@@ -168,9 +181,24 @@ export class MatrixInterface implements Interface {
     roomId: string,
     sender: string,
     text: string,
+    content: Record<string, any>,
     onMessage: StartOptions["onMessage"],
   ): Promise<void> {
-    log("matrix", `message from ${sender} in ${roomId}: ${text.slice(0, 80)}`);
+    const attachments: Attachment[] = [];
+
+    // If message is a media event with an MXC URL, download the attachment
+    if (content.url && typeof content.url === "string") {
+      const att = await this.downloadMediaAttachment(content);
+      if (att) attachments.push(att);
+    }
+
+    const hasText = Boolean(text.trim());
+    if (!hasText && attachments.length === 0) return;
+
+    log(
+      "matrix",
+      `message from ${sender} in ${roomId}: ${(text || "[media]").slice(0, 80)}${attachments.length ? ` +${attachments.length} file(s)` : ""}`,
+    );
 
     // Pairing: auto-pair first user, gate others
     if (this.pairing && !this.pairing.isPaired(sender)) {
@@ -192,10 +220,10 @@ export class MatrixInterface implements Interface {
     }
 
     // Keep typing indicator alive while the turn runs. Matrix clients like Cinny
-    // clear the typing indicator if not refreshed within ~10 seconds.
+    // expire typing state after 5 seconds, so refresh every 3 seconds.
     const typingInterval = setInterval(() => {
       this.setTyping(roomId, true).catch(() => {});
-    }, 6000);
+    }, 3000);
     await this.setTyping(roomId, true).catch(() => {});
 
     try {
@@ -206,6 +234,7 @@ export class MatrixInterface implements Interface {
           chatId: roomId,
           interface: "matrix",
           channel: `matrix:${roomId}`,
+          attachments: attachments.length > 0 ? attachments : undefined,
         },
         // Ignore stream events for MVP — reply with final text only
         () => {},
@@ -223,6 +252,59 @@ export class MatrixInterface implements Interface {
       const reason = String(err?.message || err || "Error processing message.");
       log.error("matrix", `turn failed in ${roomId}: ${reason}`);
       await this.sendMessage(roomId, `⚠️ ${reason.slice(0, 300)}`).catch(() => {});
+    }
+  }
+
+  private async downloadMediaAttachment(content: Record<string, any>): Promise<Attachment | null> {
+    const mxc = content.url;
+    const match = typeof mxc === "string" ? mxc.match(/^mxc:\/\/([^/]+)\/(.+)$/) : null;
+    if (!match) return null;
+
+    const [, serverName, mediaId] = match;
+    const info = content.info || {};
+    const size = typeof info.size === "number" ? info.size : 0;
+    if (size > MAX_FILE_SIZE) {
+      log.warn("matrix", `attachment ${content.body || mediaId} exceeds max file size (${size} bytes)`);
+      return null;
+    }
+
+    const mimeType = info.mimetype || "application/octet-stream";
+    const filename = content.body || mediaId;
+
+    try {
+      // Try modern media endpoint first, falling back to legacy endpoint if needed
+      const paths = [
+        `/_matrix/media/v3/download/${encodeURIComponent(serverName)}/${encodeURIComponent(mediaId)}`,
+        `/_matrix/client/v3/media/download/${encodeURIComponent(serverName)}/${encodeURIComponent(mediaId)}`,
+      ];
+
+      for (const path of paths) {
+        try {
+          const res = await fetch(`${this.homeserver}${path}`, {
+            headers: {
+              Authorization: `Bearer ${this.token}`,
+            },
+          });
+          if (res.ok) {
+            const buf = Buffer.from(await res.arrayBuffer());
+            if (buf.length > MAX_FILE_SIZE) return null;
+            return {
+              type: mimeToType(mimeType),
+              data: buf,
+              mimeType,
+              filename,
+              size: buf.length,
+            };
+          }
+        } catch {
+          // try next path
+        }
+      }
+      log.warn("matrix", `failed to download media from ${mxc}`);
+      return null;
+    } catch (err: any) {
+      log.warn("matrix", `download error for ${mxc}: ${err.message || err}`);
+      return null;
     }
   }
 

--- a/test/matrix.test.ts
+++ b/test/matrix.test.ts
@@ -1,6 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mdToMatrixHtml } from "../src/interfaces/matrix.ts";
+import { mdToMatrixHtml, mimeToType } from "../src/interfaces/matrix.ts";
+
+test("mimeToType: categorizes mime types correctly", () => {
+  assert.equal(mimeToType("image/png"), "image");
+  assert.equal(mimeToType("image/jpeg"), "image");
+  assert.equal(mimeToType("audio/ogg"), "audio");
+  assert.equal(mimeToType("audio/mp3"), "audio");
+  assert.equal(mimeToType("video/mp4"), "video");
+  assert.equal(mimeToType("application/pdf"), "document");
+  assert.equal(mimeToType("text/plain"), "document");
+  assert.equal(mimeToType("application/octet-stream"), "document");
+});
 
 test("mdToMatrixHtml: plain text returns undefined", () => {
   assert.equal(mdToMatrixHtml("Hello world!"), undefined);


### PR DESCRIPTION
### Summary
Enables inbound media attachments on the Matrix interface (`src/interfaces/matrix.ts`), bringing it to parity with Discord, Slack, and Telegram:

- **Supported event types**: Listens for `m.room.message` with `msgtype` in `["m.text", "m.image", "m.file", "m.audio", "m.video"]`.
- **Media download**: Parses the `mxc://` URI from `content.url` and fetches the file payload from homeserver media endpoints (`/_matrix/media/v3/download/...` with fallback to legacy `/_matrix/client/v3/media/download/...`).
- **Pipeline integration**: Packages downloaded media into `Attachment` objects (`data: Buffer`, `mimeType`, `filename`, `size`, `type`) and passes them via `onMessage`. Kern's media plugin automatically persists the files to `.kern/media/`, generates pre-digest descriptions/transcripts, and makes them accessible to tools.
- **Safety**: Rejects files exceeding `MAX_FILE_SIZE` (50MB). Empty text messages with valid attachments are allowed through.
- **Typing indicator timing**: Retains 3-second typing indicator refresh interval ([#352](https://github.com/oguzbilgic/kern-ai/pull/352)).
- **Tests**: Added tests for `mimeToType` in `test/matrix.test.ts`.